### PR TITLE
Updated to pass nameserver arguments to all occurances of parse_repor…

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -492,7 +492,8 @@ def parse_aggregate_report_xml(xml, nameservers=None, timeout=6.0):
                                                     timeout=timeout))
 
         else:
-            records.append(_parse_report_record(report["record"]))
+            records.append(_parse_report_record(report["record"]),
+                           nameservers=nameservers)
 
         new_report["records"] = records
 

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -163,12 +163,14 @@ def _main():
 
             rf = args.reports_folder
             af = args.archive_folder
+            ns = args.nameservers
             reports = get_dmarc_reports_from_inbox(args.host,
                                                    args.user,
                                                    args.password,
                                                    reports_folder=rf,
                                                    archive_folder=af,
                                                    delete=args.delete,
+                                                   nameservers=ns,
                                                    test=args.test)
 
             aggregate_reports += reports["aggregate_reports"]


### PR DESCRIPTION
So I noticed that nameservers was not being passed to _parse_report_record() in some cases. As a result it was trying to do lookups against Cloudflare and taking a very long time on large reports.

This significantly speeds up processing long reports from an inbox in my testing by using local DNS. 