### PR TITLE
Smtp auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,8 @@ CLI help
               [--save-forensic] [-O OUTGOING_HOST] [-U OUTGOING_USER]
               [-P OUTGOING_PASSWORD] [-F OUTGOING_FROM]
               [-T OUTGOING_TO [OUTGOING_TO ...]] [-S OUTGOING_SUBJECT]
-              [-A OUTGOING_ATTACHMENT] [-M OUTGOING_MESSAGE] [-w] [--test]
+              [-A OUTGOING_ATTACHMENT] [-M OUTGOING_MESSAGE] [--outgoing-ssl]
+              [--outgoing-tls] [--outgoing-port] [-w] [--test]
               [-s] [--debug] [-v]
               [file_path [file_path ...]]
 
@@ -102,6 +103,10 @@ CLI help
                             Email the results using this filename
       -M OUTGOING_MESSAGE, --outgoing-message OUTGOING_MESSAGE
                             Email the results using this message
+      -outgoing-ssl         SMTP use SSL
+      -outgoing-tls         SMTP use STARTTLS
+      -outgoing-port PORT_NUMBER
+                            Set port used for SMTP connection. Defaults to 25
       -w, --watch           Use an IMAP IDLE connection to process reports as they
                             arrive in the inbox
       --test                Do not move or delete IMAP messages

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1434,21 +1434,17 @@ def email_results(results, host, mail_from, mail_to, port=None, starttls=False,
     msg.attach(part)
 
     try:
-        print("Connect to "+host+" at port "+str(port))
         if ssl_context is None:
             ssl_context = ssl.create_default_context()
         if use_ssl:
-            print("DEBUG:SSL connect")
             server = smtplib.SMTP_SSL(host, port=port, context=ssl_context)
             server.connect(host, port)
             server.ehlo()
         else:
-            print("DEBUG: PLAIN connect")
             server = smtplib.SMTP(host, port=port)
             server.connect(host, port)
             server.ehlo()
             if starttls:
-                print("DEBUG: Upgrade to TLS")
                 server.starttls()
                 server.ehlo()
         if user and password:

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -115,6 +115,12 @@ def _main():
                             help="Email the results using this user")
     arg_parser.add_argument("-P", "--outgoing-password",
                             help="Email the results using this password")
+    arg_parser.add_argument("--outgoing-port",
+                            help="Server port to use")
+    arg_parser.add_argument("--outgoing-tls", action="store_true",
+                            help="Use STARTTLS")
+    arg_parser.add_argument("--outgoing-ssl", action="store_true",
+                            help="Use SSL")
     arg_parser.add_argument("-F", "--outgoing-from",
                             help="Email the results using this from address")
     arg_parser.add_argument("-T", "--outgoing-to", nargs="+",
@@ -230,10 +236,38 @@ def _main():
             exit(1)
 
         try:
-            email_results(results, args.outgoing_host, args.outgoing_from,
-                          args.outgoing_to, user=args.outgoing_user,
-                          password=args.outgoing_password,
-                          subject=args.outgoing_subject)
+            if args.outgoing_port is None:
+                port = 25
+            elif args.outgoing_port != 25:
+                port = args.outgoing_port
+            else:
+                port = 25
+            if args.outgoing_ssl:
+                email_results(results, args.outgoing_host, args.outgoing_from,
+                    args.outgoing_to, user=args.outgoing_user,
+                    password=args.outgoing_password,
+                    subject=args.outgoing_subject,
+                    port=port,
+                    use_ssl=True,
+                    starttls=False)
+
+            elif args.outgoing_tls:
+                email_results(results, args.outgoing_host, args.outgoing_from,
+                    args.outgoing_to, user=args.outgoing_user,
+                    password=args.outgoing_password,
+                    subject=args.outgoing_subject,
+                    port=port,
+                    use_ssl=False,
+                    starttls=True)
+            else:
+                email_results(results, args.outgoing_host, args.outgoing_from,
+                    args.outgoing_to, user=args.outgoing_user,
+                    password=args.outgoing_password,
+                    subject=args.outgoing_subject,
+                    port=port,
+                    use_ssl=False,
+                    starttls=False)
+
         except SMTPError as error:
             logger.error("SMTP Error: {0}".format(error.__str__()))
             exit(1)


### PR DESCRIPTION
 - Added parameters to specify if SMTP will use SSL-TLS or not and its port
- Changed the way the function email_results is invoked to reflect this cases
- Changed the function email_results to support SSL, TLS or plain connections
- Changed the way email_results connects to SMTP servers to comply with Gmail methodology