### PR TITLE
Correct bug in 6.5.1

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -447,7 +447,7 @@ def parsed_aggregate_reports_to_csv_rows(reports):
                            adkim=adkim, aspf=aspf, p=p, sp=sp, pct=pct, fo=fo)
 
         for record in report["records"]:
-            row = report_dict
+            row = report_dict.copy()
             row["source_ip_address"] = record["source"]["ip_address"]
             row["source_country"] = record["source"]["country"]
             row["source_reverse_dns"] = record["source"]["reverse_dns"]


### PR DESCRIPTION
This change corrects a bug introduced in 6.5.1 that caused only the last record's data to be used for each row in an aggregate report's CSV version.