### PR TITLE
Handle invalid aggregate reports

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -24,6 +24,7 @@ import mailbox
 import mailparser
 from expiringdict import ExpiringDict
 import xmltodict
+from lxml import etree
 from mailsuite.imap import IMAPClient
 from mailsuite.smtp import send_email
 
@@ -355,11 +356,11 @@ def extract_xml(input_):
         file_object.seek(0)
         if header.startswith(MAGIC_ZIP):
             _zip = zipfile.ZipFile(file_object)
-            xml = _zip.open(_zip.namelist()[0]).read().decode()
+            xml = _zip.open(_zip.namelist()[0]).read().decode(errors='ignore')
         elif header.startswith(MAGIC_GZIP):
-            xml = GzipFile(fileobj=file_object).read().decode()
+            xml = GzipFile(fileobj=file_object).read().decode(errors='ignore')
         elif header.startswith(MAGIC_XML):
-            xml = file_object.read().decode()
+            xml = file_object.read().decode(errors='ignore')
         else:
             file_object.close()
             raise InvalidAggregateReport("Not a valid zip, gzip, or xml file")
@@ -419,7 +420,7 @@ def parsed_aggregate_reports_to_csv_rows(reports):
         return str(obj).lower()
 
     if type(reports) == OrderedDict:
-        reports = [reports]
+        reports = [reports['report']]
 
     rows = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ sphinx>=1.0.5
 sphinx_rtd_theme>=0.4.3
 wheel>=0.33.6
 codecov>=2.0.15
+lxml>=4.4.1

--- a/samples/aggregate/invalid_utf_8.xml
+++ b/samples/aggregate/invalid_utf_8.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<feedback>
+ <report_metadata>
+  <org_name></org_name>
+  <email>administrator@accurateplastics.com</email>
+  <report_id>example.com:1538463741</report_id>
+  <date_range>
+   <begin>1538413632</begin>
+   <end>1538413632</end>
+  </date_range>
+ </report_metadata>
+ <policy_published>
+  <domain>example.com</domain>
+  <adkim>r</adkim>
+  <aspf>r</aspf>
+  <p>none</p>
+  <sp>reject</sp>
+  <pct>100</pct>
+ </policy_published>
+ <record>
+  <row>
+   <source_ip>12.20.127.122</source_ip>
+   <count>1</count>
+   <policy_evaluated>
+    <disposition>none</disposition>
+    <dkim>fail</dkim>
+    <spf>fail</spf>
+   </policy_evaluated>
+  </row>
+  <identifiers>
+   <header_from>bad_byte‘</header_from>
+  </identifiers>
+  <auth_results>
+   <spf>
+    <domain></domain>
+    <result>none</result>
+   </spf>
+  </auth_results>
+ </record>
+</feedback>

--- a/samples/aggregate/invalid_xml.xml
+++ b/samples/aggregate/invalid_xml.xml
@@ -28,7 +28,7 @@
    </policy_evaluated>
   </row>
   <identifiers>
-   <header_from>example.com</header_from>
+   <header_from>bad<xml.net</header_from>
   </identifiers>
   <auth_results>
    <spf>

--- a/samples/aggregate/invalid_xml.xml
+++ b/samples/aggregate/invalid_xml.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<feedback>
+ <report_metadata>
+  <org_name>veeam.com</org_name>
+  <email><bad-xml@bad-xml.net></email>
+  <report_id>sonexushealth.com:1530233361</report_id>
+  <date_range>
+   <begin>1530133200</begin>
+   <end>1530219600</end>
+  </date_range>
+ </report_metadata>
+ <policy_published>
+  <domain>example.com</domain>
+  <adkim>r</adkim>
+  <aspf>r</aspf>
+  <p>none</p>
+  <sp>none</sp>
+  <pct>100</pct>
+ </policy_published>
+ <record>
+  <row>
+   <source_ip>199.230.200.36</source_ip>
+   <count>1</count>
+   <policy_evaluated>
+    <disposition>none</disposition>
+    <dkim>fail</dkim>
+    <spf>fail</spf>
+   </policy_evaluated>
+  </row>
+  <identifiers>
+   <header_from>example.com</header_from>
+  </identifiers>
+  <auth_results>
+   <spf>
+    <domain></domain>
+    <result>none</result>
+   </spf>
+  </auth_results>
+ </record>
+</feedback>

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
                       'elasticsearch>=6.3.1,<7.0.0',
                       'elasticsearch-dsl>=6.3.1,<7.0.0',
                       'kafka-python>=1.4.4',
-                      'tqdm>=4.31.1'
+                      'tqdm>=4.31.1', 'lxml>=4.4.1'
                       ],
 
     entry_points={


### PR DESCRIPTION
In my testing over the past few months I've encountered some invalid aggregate report files, and I'd like to upstream my workarounds so that the errors can be handled gracefully rather than discarding an entire report due to a single bad character.

Specifically, I've observed the following two errors:

* Invalid bytes (such as 0x91), typically in URL fields.
* Invalid XML, typically due to the use of `<` or `>` characters in user-defined fields (e.g. org email) or in a URL.

I've added sample report files that exhibit these characteristics, and have made the modifications needed to handle them, including:

* Dropping invalid bytes when decoding
* Parsing invalid XML with `lxml` (a new dependency) and attempting to recover from errors
* Stripping out any artifacts introduced by `lxml` as part of its recovery efforts

I also made one modification at line 422/429 of `__init__.py` to correct what may have been a bug.

I'm not sure if this is a perfect solution, so please test it out and let me know what you think.