### PR TITLE
Making dkim_aligned and spf_aligned case insensitive.

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -115,8 +115,8 @@ def _parse_report_record(record, offline=False, nameservers=None,
     if "spf" in policy_evaluated:
         new_policy_evaluated["spf"] = policy_evaluated["spf"]
     reasons = []
-    spf_aligned = policy_evaluated["spf"] == "pass"
-    dkim_aligned = policy_evaluated["dkim"] == "pass"
+    spf_aligned = policy_evaluated["spf"] is not None and policy_evaluated["spf"].lower() == "pass"
+    dkim_aligned = policy_evaluated["dkim"] is not None and policy_evaluated["dkim"].lower() == "pass"
     dmarc_aligned = spf_aligned or dkim_aligned
     new_record["alignment"] = dict()
     new_record["alignment"]["spf"] = spf_aligned

--- a/parsedmarc/elastic.py
+++ b/parsedmarc/elastic.py
@@ -354,8 +354,10 @@ def save_aggregate_report_to_elasticsearch(aggregate_report,
             source_base_domain=record["source"]["base_domain"],
             message_count=record["count"],
             disposition=record["policy_evaluated"]["disposition"],
-            dkim_aligned=record["policy_evaluated"]["dkim"] == "pass",
-            spf_aligned=record["policy_evaluated"]["spf"] == "pass",
+            dkim_aligned=record["policy_evaluated"]["dkim"] is not None and
+                         record["policy_evaluated"]["dkim"].lower() == "pass",
+            spf_aligned=record["policy_evaluated"]["spf"] is not None and
+                        record["policy_evaluated"]["spf"].lower() == "pass",
             header_from=record["identifiers"]["header_from"],
             envelope_from=record["identifiers"]["envelope_from"],
             envelope_to=record["identifiers"]["envelope_to"]

--- a/samples/aggregate/report_with_upper_cased_pass.xml
+++ b/samples/aggregate/report_with_upper_cased_pass.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<feedback>
+ <report_metadata>
+  <org_name>example.com </org_name>
+  <email>postmaster@example.com</email>
+  <report_id>aggr_report_example.com_20191202_1638</report_id>
+  <date_range>
+   <begin>1574955300</begin>
+   <end>1575304683</end>
+  </date_range>
+ </report_metadata>
+ <policy_published>
+  <domain>example.com</domain>
+  <adkim>r</adkim>
+  <aspf>r</aspf>
+  <p>reject</p>
+  <pct>100</pct>
+ </policy_published>
+ <record>
+  <row>
+   <source_ip>23.104.41.189</source_ip>
+   <count>1</count>
+   <policy_evaluated>
+    <disposition>none</disposition>
+    <dkim>Pass</dkim>
+    <spf>Pass</spf>
+   </policy_evaluated>
+  </row>
+  <identifiers>
+   <header_from>example.com</header_from>
+  </identifiers>
+  <auth_results>
+   <dkim>
+    <domain>example.com</domain>
+    <result>Pass</result>
+    <human_result>verify result: all signatures verified</human_result>
+   </dkim>
+   <spf>
+    <domain>example.com</domain>
+    <result>Pass</result>
+   </spf>
+  </auth_results>
+ </record>
+</feedback>


### PR DESCRIPTION
Hi 
First of all I would like to thank you for making parsedmarc an open source project. 
I ran parsedmarc on our company dmarc reports. When I was sorting through the results I notice all the report from one particular email provider has their “dkim_aligned”, “spf_aligned” and “passed_dmarc” set to false. But when I look at the reports I could see that both spf and dkim are aligned. After a bit of debugging it turned out that in the report instead of “pass” it is written “Pass” and the code checks pass in a case sensitive way.
