### PR TITLE
Remove nameserver warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,17 +192,6 @@ The full set of configuration options are:
     - ``attachment`` - str: The ZIP attachment filenames
     - ``message`` - str: The email message (Default: Please see the attached parsedmarc report.)
 
-
-.. warning::
-
-    It is **strongly recommended** to **not** use the ``nameservers`` setting.
-    By default, ``parsedmarc`` uses `Cloudflare's public resolvers`_,
-    which are much faster and more reliable than Google, Cisco OpenDNS, or
-    even most local resolvers.
-
-    The ``nameservers`` option should only be used if your network blocks DNS
-    requests to outside resolvers.
-
 .. warning::
 
    ``save_aggregate`` and ``save_forensic`` are separate options because


### PR DESCRIPTION
This warning seems a bit.. unneeded. I would say this is up to the people that implement the software and not to the developer.

We have been monitoring both Google DNS and Cloudflare DNS, and concluded that from our AS - Google DNS is way more reliable with a lower and more consistent latency. We have had survival cases where Cloudflare DNS did not work properly and showed weird latency spikes, while Google was constantly performant.

Due backwards compatibility I was unfortunately not able to remove the defaulted nameservers to Cloudflare, but I'd suggest considering this in a BC-breaking change and default to the system's NS.