### PR TITLE
Use SMTP port from config when sending the report

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -619,7 +619,7 @@ def _main():
             if opts.smtp_skip_certificate_verification:
                 verify = False
             email_results(results, opts.smtp_host, opts.smtp_from,
-                          opts.smtp_to, verify=verify,
+                          opts.smtp_to, port=opts.smtp_port, verify=verify,
                           username=opts.smtp_user,
                           password=opts.smtp_password,
                           subject=opts.smtp_subject)


### PR DESCRIPTION
The SMTP port from config isn't being used when sending the report.
Instead, `send_email` function from `mailsuite.smtp` is called with `port=0` which causes that the default port 465 is always used regardless of the config.

Had an error in previous PR so I made a new one. This time I made sure to test things out before pushing.