### PR TITLE
Fix for copy-paste error

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -290,7 +290,7 @@ def _main():
             if "timeout" in imap_config:
                 opts.imap_timeout = imap_config.getfloat("timeout")
             if "max_retries" in imap_config:
-                opts.imap_port = imap_config.getint("max_retries")
+                opts.imap_max_retries = imap_config.getint("max_retries")
             if "ssl" in imap_config:
                 opts.imap_ssl = imap_config.getboolean("ssl")
             if "skip_certificate_verification" in imap_config:


### PR DESCRIPTION
If max_retries is defined in config it will override the port configuration.

Signed-off-by: Sander Lepik <sander.lepik@cooppank.ee>