### PR TITLE
fix: [imap] fixes #163 crash on imap timeout

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -28,6 +28,7 @@ import xmltodict
 from lxml import etree
 from mailsuite.imap import IMAPClient
 from mailsuite.smtp import send_email
+from imapclient.exceptions import IMAPClientError
 
 from parsedmarc.utils import get_base_domain, get_ip_address_info
 from parsedmarc.utils import is_outlook_msg, convert_outlook_msg
@@ -1230,7 +1231,7 @@ def watch_inbox(host, username, password, callback, port=None, ssl=True,
                        initial_folder=reports_folder,
                        idle_callback=idle_callback,
                        idle_timeout=idle_timeout)
-        except timeout:
+        except (timeout, IMAPClientError):
             logger.warning("IMAP connection timeout. Reconnecting...")
 
 


### PR DESCRIPTION
Fixes one more situation when issue #163 crash when imap timeout appears.

```
Aug 26 08:47:20 parsedmarc[822]:     return self.read(nbytes, buffer)
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/lib/python3.8/ssl.py", line 1099, in read
Aug 26 08:47:20 parsedmarc[822]:     return self._sslobj.read(len, buffer)
Aug 26 08:47:20 parsedmarc[822]: socket.timeout: The read operation timed out
Aug 26 08:47:20 parsedmarc[822]: During handling of the above exception, another exception occurred:
Aug 26 08:47:20 parsedmarc[822]: Traceback (most recent call last):
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/bin/parsedmarc", line 8, in <module>
Aug 26 08:47:20 parsedmarc[822]:     sys.exit(_main())
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/parsedmarc/cli.py", line 641, in _main
Aug 26 08:47:20 parsedmarc[822]:     watch_inbox(
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/parsedmarc/__init__.py", line 1228, in watch_inbox
Aug 26 08:47:20 parsedmarc[822]:     IMAPClient(host=host, username=username, password=password,
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/mailsuite/imap.py", line 192, in __init__
Aug 26 08:47:20 parsedmarc[822]:     self._start_idle(idle_callback, idle_timeout=idle_timeout)
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/mailsuite/imap.py", line 90, in _start_idle
Aug 26 08:47:20 parsedmarc[822]:     self.reset_connection()
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/mailsuite/imap.py", line 202, in reset_connection
Aug 26 08:47:20 parsedmarc[822]:     self.__init__(self._init_args["host"],
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/mailsuite/imap.py", line 192, in __init__
Aug 26 08:47:20 parsedmarc[822]:     self._start_idle(idle_callback, idle_timeout=idle_timeout)
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/mailsuite/imap.py", line 90, in _start_idle
Aug 26 08:47:20 parsedmarc[822]:     self.reset_connection()
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/mailsuite/imap.py", line 202, in reset_connection
Aug 26 08:47:20 parsedmarc[822]:     self.__init__(self._init_args["host"],
Aug 26 08:47:20 parsedmarc[822]:   File "/usr/local/lib/python3.8/dist-packages/mailsuite/imap.py", line 177, in __init__
Aug 26 08:47:20 parsedmarc[822]:     raise imapclient.exceptions.IMAPClientError(error)
Aug 26 08:47:20 parsedmarc[822]: imaplib.error: The read operation timed out
Aug 26 08:47:20 systemd[1]: parsedmarc.service: Main process exited, code=exited, status=1/FAILURE
Aug 26 08:47:20 systemd[1]: parsedmarc.service: Failed with result 'exit-code'.
```