### PR TITLE
Using freegeoip instead of geoip

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -277,6 +277,8 @@ def _main():
                 opts.n_procs = general_config.getint("n_procs")
             if "chunk_size" in general_config:
                 opts.chunk_size = general_config.getint("chunk_size")
+            if "use_freegeoip" in general_config:
+                opts.use_freegeoip = general_config.getboolean("use_freegeoip")
         if "imap" in config.sections():
             imap_config = config["imap"]
             if "host" in imap_config:

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -20,7 +20,7 @@ from parsedmarc import get_dmarc_reports_from_inbox, watch_inbox, \
     parse_report_file, get_dmarc_reports_from_mbox, elastic, kafkaclient, \
     splunk, save_output, email_results, ParserError, __version__, \
     InvalidDMARCReport
-from parsedmarc.utils import is_mbox
+from parsedmarc.utils import is_mbox, set_use_freegeoip
 
 logger = logging.getLogger("parsedmarc")
 
@@ -194,6 +194,7 @@ def _main():
                      debug=args.debug,
                      save_aggregate=False,
                      save_forensic=False,
+                     use_freegeoip=False,
                      imap_host=None,
                      imap_skip_certificate_verification=False,
                      imap_ssl=True,
@@ -279,6 +280,7 @@ def _main():
                 opts.chunk_size = general_config.getint("chunk_size")
             if "use_freegeoip" in general_config:
                 opts.use_freegeoip = general_config.getboolean("use_freegeoip")
+                set_use_freegeoip(opts.use_freegeoip)
         if "imap" in config.sections():
             imap_config = config["imap"]
             if "host" in imap_config:

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import sys
 from datetime import datetime
 from datetime import timedelta
 from collections import OrderedDict
@@ -40,7 +41,18 @@ mailparser_logger.setLevel(logging.CRITICAL)
 
 tempdir = tempfile.mkdtemp()
 
-use_freegeoip = False
+this = sys.modules[__name__]
+this.use_freegeoip = False
+
+
+def set_use_freegeoip(data):
+    """
+    Set whether to use freegeoip.live or not
+
+    Args:
+        data: True or False
+    """
+    this.use_freegeoip = data
 
 
 def _cleanup():
@@ -58,8 +70,6 @@ class EmailParserError(RuntimeError):
 class DownloadError(RuntimeError):
     """Rasied when an error occurs when downloading a file"""
 
-def set_use_freegeoip(data :bool):
-    use_freegeoip = data
 
 def decode_base64(data):
     """
@@ -277,11 +287,10 @@ def get_ip_address_country(ip_address):
         str: And ISO country code associated with the given IP address
     """
 
-    if use_freegeoip:
+    if this.use_freegeoip:
         r = requests.get('https://freegeoip.live/json/%s' % ip_address)
 
         if r.status_code == 200:
-
             return r.json()["country_code"]
         else:
             return None

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -40,6 +40,8 @@ mailparser_logger.setLevel(logging.CRITICAL)
 
 tempdir = tempfile.mkdtemp()
 
+use_freegeoip = False
+
 
 def _cleanup():
     """Remove temporary files"""
@@ -56,6 +58,8 @@ class EmailParserError(RuntimeError):
 class DownloadError(RuntimeError):
     """Rasied when an error occurs when downloading a file"""
 
+def set_use_freegeoip(data :bool):
+    use_freegeoip = data
 
 def decode_base64(data):
     """
@@ -272,6 +276,16 @@ def get_ip_address_country(ip_address):
     Returns:
         str: And ISO country code associated with the given IP address
     """
+
+    if use_freegeoip:
+        r = requests.get('https://freegeoip.live/json/%s' % ip_address)
+
+        if r.status_code == 200:
+
+            return r.json()["country_code"]
+        else:
+            return None
+
     system_paths = [
         "GeoLite2-Country.mmdb",
         "/usr/local/share/GeoIP/GeoLite2-Country.mmdb",


### PR DESCRIPTION
Hi. I got parsedmarc working with [https://freegeoip.live](https://freegeoip.live/) - it allows up to 50,000 queries per hour per IP, which was sufficient for me. In case anyone else is interested. To use it add the general configuration option `use_freegeoip = True`.
Thanks