### PR TITLE
Limit filename length to 100 characters

### DIFF
--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -395,6 +395,8 @@ def get_filename_safe_string(string):
         string = string.replace(char, "")
     string = string.rstrip(".")
 
+    string = (string[:255]) if len(string) > 255 else string
+
     return string
 
 

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -395,7 +395,7 @@ def get_filename_safe_string(string):
         string = string.replace(char, "")
     string = string.rstrip(".")
 
-    string = (string[:255]) if len(string) > 255 else string
+    string = (string[:100]) if len(string) > 100 else string
 
     return string
 


### PR DESCRIPTION
https://github.com/domainaware/parsedmarc/issues/197

Since there is a limit for filename length in some OS, filename length should be limited. I propose limit it to 255 characters.