### PR TITLE
Handling other IMAP connection errors. 

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1237,7 +1237,8 @@ def watch_inbox(host, username, password, callback, port=None, ssl=True,
             logger.warning("IMAP connection timeout. Reconnecting...")
             sleep(5)
         except Exception as e:
-            logger.warning("IMAP connection error. {0}. Reconnecting...".format(e))
+            logger.warning("IMAP connection error. {0}. "
+                           "Reconnecting...".format(e))
             sleep(5)
 
 

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -8,6 +8,7 @@ import shutil
 import xml.parsers.expat as expat
 import json
 from datetime import datetime
+from time import sleep
 from collections import OrderedDict
 from io import BytesIO, StringIO
 from gzip import GzipFile
@@ -1234,6 +1235,10 @@ def watch_inbox(host, username, password, callback, port=None, ssl=True,
                        idle_timeout=idle_timeout)
         except (timeout, IMAPClientError):
             logger.warning("IMAP connection timeout. Reconnecting...")
+            sleep(5)
+        except Exception as e:
+            logger.warning("IMAP connection error. {0}. Reconnecting...".format(e))
+            sleep(5)
 
 
 def save_output(results, output_directory="output"):


### PR DESCRIPTION
Also adding a short sleep() to avoid hammering the IMAP-server on error.

Could probably be improved by someone with more imap-experience to handle different exceptions in different ways...