### PR TITLE
Resolve issue #233 - don't create imap folders when in test mode

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1060,10 +1060,11 @@ def get_dmarc_reports_from_inbox(connection=None,
                             max_retries=max_retries,
                             initial_folder=reports_folder)
 
-    server.create_folder(archive_folder)
-    server.create_folder(aggregate_reports_folder)
-    server.create_folder(forensic_reports_folder)
-    server.create_folder(invalid_reports_folder)
+    if not test:
+        server.create_folder(archive_folder)
+        server.create_folder(aggregate_reports_folder)
+        server.create_folder(forensic_reports_folder)
+        server.create_folder(invalid_reports_folder)
 
     messages = server.search()
     total_messages = len(messages)


### PR DESCRIPTION
This simply wraps the imap folder creation so that it doesn't run in test mode. This should be the only change required to resolve issue #233 