### PR TITLE
Resolve issue #238 - Limit number of imap reports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,7 @@ The full set of configuration options are:
     - ``watch`` - bool: Use the IMAP ``IDLE`` command to process messages as they arrive
     - ``delete`` - bool: Delete messages after processing them, instead of archiving them
     - ``test`` - bool: Do not move or delete messages
+    - ``limit_messages`` - int: Process a maximum of this many messages per run
 - ``elasticsearch``
     - ``hosts`` - str: A comma separated list of hostnames and ports or URLs (e.g. ``127.0.0.1:9200`` or ``https://user:secret@localhost``)
 

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1004,7 +1004,8 @@ def get_dmarc_reports_from_inbox(connection=None,
                                  nameservers=None,
                                  dns_timeout=6.0,
                                  strip_attachment_payloads=False,
-                                 results=None):
+                                 results=None,
+                                 limit_messages=None):
     """
     Fetches and parses DMARC reports from an inbox
 
@@ -1066,6 +1067,8 @@ def get_dmarc_reports_from_inbox(connection=None,
     server.create_folder(invalid_reports_folder)
 
     messages = server.search()
+    if limit_messages is not None:
+        messages = messages[:limit_messages]
     total_messages = len(messages)
     logger.debug("Found {0} messages in {1}".format(len(messages),
                                                     reports_folder))
@@ -1165,7 +1168,7 @@ def get_dmarc_reports_from_inbox(connection=None,
 
     total_messages = len(server.search())
 
-    if not test and total_messages > 0:
+    if not test and (len(messages) < limit_messages) and total_messages > 0:
         # Process emails that came in during the last run
         results = get_dmarc_reports_from_inbox(
             connection=server,
@@ -1177,7 +1180,8 @@ def get_dmarc_reports_from_inbox(connection=None,
             dns_timeout=dns_timeout,
             strip_attachment_payloads=strip_attachment_payloads,
             results=results,
-            offline=offline
+            offline=offline,
+            limit_messages=limit_messages-len(messages)
         )
 
     return results

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -210,6 +210,7 @@ def _main():
                      imap_watch=False,
                      imap_delete=False,
                      imap_test=False,
+                     imap_limit_messages=None,
                      hec=None,
                      hec_token=None,
                      hec_index=None,
@@ -327,6 +328,8 @@ def _main():
                 opts.imap_delete = imap_config.getboolean("delete")
             if "test" in imap_config:
                 opts.imap_test = imap_config.getboolean("test")
+            if "limit_messages" in imap_config:
+                opts.imap_limit_messages = imap_config.getint("limit_messages")
         if "elasticsearch" in config:
             elasticsearch_config = config["elasticsearch"]
             if "hosts" in elasticsearch_config:
@@ -613,9 +616,9 @@ def _main():
                 offline=opts.offline,
                 nameservers=ns,
                 test=opts.imap_test,
-                strip_attachment_payloads=sa
+                strip_attachment_payloads=sa,
+                limit_messages=opts.imap_limit_messages
                                                    )
-
             aggregate_reports += reports["aggregate_reports"]
             forensic_reports += reports["forensic_reports"]
 


### PR DESCRIPTION
* adds `limit_messages` configuration parameter to imap
* updates `README.rst` to reflect new parameter

It would be IMHO better if the code was restructured in such a way as to make this a global option and/or for the saving/exporting and the reading/processing parts to be run concurrently instead of serially.  That said, this does allow limiting the size of batch jobs to enable more predictable runtime and memory usage as when run as a periodic job over a report volume that may be highly variable.