### PR TITLE
Use UTC datetimes for Elastic output

### DIFF
--- a/parsedmarc/elastic.py
+++ b/parsedmarc/elastic.py
@@ -317,8 +317,8 @@ def save_aggregate_report_to_elasticsearch(aggregate_report,
     org_name_query = Q(dict(match_phrase=dict(org_name=org_name)))
     report_id_query = Q(dict(match_phrase=dict(report_id=report_id)))
     domain_query = Q(dict(match_phrase={"published_policy.domain": domain}))
-    begin_date_query = Q(dict(match=dict(date_range=begin_date)))
-    end_date_query = Q(dict(match=dict(date_range=end_date)))
+    begin_date_query = Q(dict(match=dict(date_begin=begin_date)))
+    end_date_query = Q(dict(match=dict(date_end=end_date)))
 
     if index_suffix is not None:
         search = Search(index="dmarc_aggregate_{0}*".format(index_suffix))

--- a/parsedmarc/elastic.py
+++ b/parsedmarc/elastic.py
@@ -301,10 +301,10 @@ def save_aggregate_report_to_elasticsearch(aggregate_report,
     org_name = metadata["org_name"]
     report_id = metadata["report_id"]
     domain = aggregate_report["policy_published"]["domain"]
-    begin_date = human_timestamp_to_datetime(metadata["begin_date"])
-    end_date = human_timestamp_to_datetime(metadata["end_date"])
-    begin_date_human = begin_date.strftime("%Y-%m-%d %H:%M:%S")
-    end_date_human = end_date.strftime("%Y-%m-%d %H:%M:%S")
+    begin_date = human_timestamp_to_datetime(metadata["begin_date"], to_utc=True)
+    end_date = human_timestamp_to_datetime(metadata["end_date"], to_utc=True)
+    begin_date_human = begin_date.strftime("%Y-%m-%d %H:%M:%SZ")
+    end_date_human = end_date.strftime("%Y-%m-%d %H:%M:%SZ")
     if monthly_indexes:
         index_date = begin_date.strftime("%Y-%m")
     else:


### PR DESCRIPTION
Elastic expects UTC datetimes. However, parsedmarc outputs local time. As consequence, Elastic will shift the date range erroneously by the local timezone offset.

The following example ...
  <date_range>
    <begin>1622851200</begin>
    <end>1622937599</end>
  </date_range>

... will be imported into Elastic as ...
    "date_range": [
      "2021-06-05T02:00:00.000Z",
      "2021-06-06T01:59:59.000Z"
    ],

... while it should be:
    "date_range": [
      "2021-06-05T00:00:00.000Z",
      "2021-06-05T23:59:59.000Z"
    ],

Note the "Z" at the end, which indicates that Elastic is using UTC timezone.

This pull request converts the dates in Elastic output to UTC. We add "Z" explicitly, though it is not necessary with Elastic's default, but it increases robustness in case when the default changes or is reconfigured.