### PR TITLE
Print tqdm progress bar only when running from interactive TTY

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -13,6 +13,7 @@ import json
 from ssl import CERT_NONE, create_default_context
 from multiprocessing import Pool, Value
 from itertools import repeat
+import sys
 import time
 from tqdm import tqdm
 
@@ -626,11 +627,15 @@ def _main():
                                      repeat(opts.offline),
                                      repeat(opts.n_procs >= 1)),
                                  opts.chunk_size)
-    pbar = tqdm(total=len(file_paths))
-    while not results.ready():
-        pbar.update(counter.value - pbar.n)
-        time.sleep(0.1)
-    pbar.close()
+    if sys.stdout.isatty():
+        pbar = tqdm(total=len(file_paths))
+        while not results.ready():
+            pbar.update(counter.value - pbar.n)
+            time.sleep(0.1)
+        pbar.close()
+    else:
+        while not results.ready():
+            time.sleep(0.1)
     results = results.get()
     pool.close()
     pool.join()

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -201,15 +201,15 @@ def get_reverse_dns(ip_address, cache=None, nameservers=None, timeout=2.0):
 
 def timestamp_to_datetime(timestamp):
     """
-    Converts a UNIX/DMARC timestamp to a Python ``DateTime`` object
+    Converts a UNIX/DMARC timestamp to a Python ``DateTime`` object (UTC)
 
     Args:
         timestamp (int): The timestamp
 
     Returns:
-        DateTime: The converted timestamp as a Python ``DateTime`` object
+        DateTime: The converted timestamp as a Python ``DateTime`` object (UTC)
     """
-    return datetime.fromtimestamp(int(timestamp))
+    return datetime.utcfromtimestamp(int(timestamp))
 
 
 def timestamp_to_human(timestamp):
@@ -220,7 +220,7 @@ def timestamp_to_human(timestamp):
         timestamp: The timestamp
 
     Returns:
-        str: The converted timestamp in ``YYYY-MM-DD HH:MM:SS`` format
+        str: The converted timestamp in ``YYYY-MM-DD HH:MM:SS`` format (UTC)
     """
     return timestamp_to_datetime(timestamp).strftime("%Y-%m-%d %H:%M:%S")
 

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -201,15 +201,15 @@ def get_reverse_dns(ip_address, cache=None, nameservers=None, timeout=2.0):
 
 def timestamp_to_datetime(timestamp):
     """
-    Converts a UNIX/DMARC timestamp to a Python ``DateTime`` object (UTC)
+    Converts a UNIX/DMARC timestamp to a Python ``DateTime`` object
 
     Args:
         timestamp (int): The timestamp
 
     Returns:
-        DateTime: The converted timestamp as a Python ``DateTime`` object (UTC)
+        DateTime: The converted timestamp as a Python ``DateTime`` object
     """
-    return datetime.utcfromtimestamp(int(timestamp))
+    return datetime.fromtimestamp(int(timestamp))
 
 
 def timestamp_to_human(timestamp):
@@ -220,7 +220,7 @@ def timestamp_to_human(timestamp):
         timestamp: The timestamp
 
     Returns:
-        str: The converted timestamp in ``YYYY-MM-DD HH:MM:SS`` format (UTC)
+        str: The converted timestamp in ``YYYY-MM-DD HH:MM:SS`` format
     """
     return timestamp_to_datetime(timestamp).strftime("%Y-%m-%d %H:%M:%S")
 


### PR DESCRIPTION
With this change, parsemdarc cli.py won't print a progress bar when running in a cronjob.