### PR TITLE
Set replication to 0 so that single node setups have "healthy" green …

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -253,7 +253,7 @@ def _main():
                      elasticsearch_hosts=None,
                      elasticsearch_timeout=60,
                      elasticsearch_number_of_shards=1,
-                     elasticsearch_number_of_replicas=1,
+                     elasticsearch_number_of_replicas=0,
                      elasticsearch_index_suffix=None,
                      elasticsearch_ssl=True,
                      elasticsearch_ssl_cert_path=None,

--- a/parsedmarc/elastic.py
+++ b/parsedmarc/elastic.py
@@ -411,7 +411,7 @@ def save_forensic_report_to_elasticsearch(forensic_report,
                                           index_suffix=None,
                                           monthly_indexes=False,
                                           number_of_shards=1,
-                                          number_of_replicas=1):
+                                          number_of_replicas=0):
     """
         Saves a parsed DMARC forensic report to ElasticSearch
 

--- a/parsedmarc/elastic.py
+++ b/parsedmarc/elastic.py
@@ -218,7 +218,7 @@ def create_indexes(names, settings=None):
                 logger.debug("Creating Elasticsearch index: {0}".format(name))
                 if settings is None:
                     index.settings(number_of_shards=1,
-                                   number_of_replicas=1)
+                                   number_of_replicas=0)
                 else:
                     index.settings(**settings)
                 index.create()
@@ -281,7 +281,7 @@ def save_aggregate_report_to_elasticsearch(aggregate_report,
                                            index_suffix=None,
                                            monthly_indexes=False,
                                            number_of_shards=1,
-                                           number_of_replicas=1):
+                                           number_of_replicas=0):
     """
     Saves a parsed DMARC aggregate report to ElasticSearch
 


### PR DESCRIPTION
I have changed replicated shards from 1 to 0.

The reason is that single node clusters will never replicate, because by design replication only happens on a different node (which doesn't exist in a single node cluster of one).

This means that the index health is always yellow because it cannot perform the replication.

Given that the instructions are for a single node deployment, it would be better to leave replication off and anyone who has a multi-node cluster can tune replication to their needs anyway.

By doing this we can have nice green index health in single node clusters :)