### PR TITLE
Fixed log messages written to root logger

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1420,7 +1420,7 @@ def email_results(results, host, mail_from, mail_to,
         attachment_filename (str): Override the default attachment filename
         message (str: Override the default plain text body
     """
-    logging.debug("Emailing report to: {0}".format(",".join(mail_to)))
+    logger.debug("Emailing report to: {0}".format(",".join(mail_to)))
     date_string = datetime.now().strftime("%Y-%m-%d")
     if attachment_filename:
         if not attachment_filename.lower().endswith(".zip"):

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -293,10 +293,10 @@ def get_ip_address_country(ip_address):
     if db_path is None:
         db_path = os.path.join(tempdir, "GeoLite2-Country.mmdb")
         if not os.path.exists(db_path):
-            logging.warning("GeoLite2-Country.mmdb is missing. "
-                            "Please follow the instructions at "
-                            "https://dev.maxmind.com/geoip/geoipupdate/ "
-                            "to get the latest version.")
+            logger.warning("GeoLite2-Country.mmdb is missing. "
+                           "Please follow the instructions at "
+                           "https://dev.maxmind.com/geoip/geoipupdate/ "
+                           "to get the latest version.")
             return None
         else:
             db_age = datetime.now() - datetime.fromtimestamp(


### PR DESCRIPTION
Two lines of code logged logs to the root logger instead to the `parsedmarc` logger.