### PR TITLE
Actually add DBIP database static copy to packaged files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,9 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=["parsedmarc", "parsedmarc.resources"],
+    package_data={
+            "parsedmarc.resources": ["*.mmdb"]
+    },
 
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment


### PR DESCRIPTION
The package published on pypi for [v7.1.0](https://files.pythonhosted.org/packages/64/ab/4c390d38855a9c8efe58b75496a15dca8d4037539c5acaf73ffc67e57d9c/parsedmarc-7.1.0.tar.gz) is missing the file `parsedmarc/resources/dbip-country-lite.mmdb`. 

This, in turn, leads to failures during parsing for perfectly fine reports with  a quite misleading error message ("Not a valid aggregate or forensic report") if no IP database is found on the system.

This PR fixes the packaging by explicitly adding any `.mmdb` file in the package `parsedmarc.resources`.