### PR TITLE
Removed usage of logging.basicConfig

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -38,12 +38,14 @@ from parsedmarc.utils import parse_email
 
 __version__ = "7.1.1"
 
-logging.basicConfig(
-    format='%(levelname)8s:%(filename)s:%(lineno)d:'
-           '%(message)s',
+formatter = logging.Formatter(
+    fmt='%(levelname)8s:%(filename)s:%(lineno)d:%(message)s',
     datefmt='%Y-%m-%d:%H:%M:%S')
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
 
 logger = logging.getLogger("parsedmarc")
+logger.addHandler(handler)
 logger.debug("parsedmarc v{0}".format(__version__))
 
 feedback_report_regex = re.compile(r"^([\w\-]+): (.+)$", re.MULTILINE)

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -578,14 +578,11 @@ def _main():
             else:
                 opts.syslog_port = 514
 
-    logging.basicConfig(level=logging.WARNING)
     logger.setLevel(logging.WARNING)
 
     if opts.verbose:
-        logging.basicConfig(level=logging.INFO)
         logger.setLevel(logging.INFO)
     if opts.debug:
-        logging.basicConfig(level=logging.DEBUG)
         logger.setLevel(logging.DEBUG)
     if opts.log_file:
         fh = logging.FileHandler(opts.log_file)


### PR DESCRIPTION
logging.basicConfig will change the configuration of the root logger and not the configuration of your own library logger. Since parsedmarc is a library, it should keep its logging configuration to its own logger, such that the logging configuration of applications using this library are not affected.