### PR TITLE
Fix ModuleNotFoundError: add parsedmarc.mail to setup packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Features
 
 * Parses draft and 1.0 standard aggregate/rua reports
 * Parses forensic/failure/ruf reports
-* Can parse reports from an inbox over IMAP or Microsoft Graph
+* Can parse reports from an inbox over IMAP, Microsoft Graph, or Gmail API
 * Transparently handles gzip or zip compressed reports
 * Consistent data structures
 * Simple JSON and/or CSV output

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=["parsedmarc", "parsedmarc.resources"],
+    packages=["parsedmarc", "parsedmarc.resources", "parsedmarc.mail"],
     package_data={
             "parsedmarc.resources": ["*.mmdb"]
     },


### PR DESCRIPTION
Upon starting it says:
`ModuleNotFoundError: No module named 'parsedmarc.mail'`