### PR TITLE
fix callback on IMAPConnection

### DIFF
--- a/parsedmarc/mail/imap.py
+++ b/parsedmarc/mail/imap.py
@@ -53,6 +53,13 @@ class IMAPConnection(MailboxConnection):
          Use an IDLE IMAP connection to parse incoming emails,
          and pass the results to a callback function
         """
+
+        # IDLE callback sends IMAPClient object,
+        # send back the imap connection object instead
+        def idle_callback_wrapper(client: IMAPClient):
+            self._client = client
+            check_callback(self)
+
         while True:
             try:
                 IMAPClient(host=self._client.host,
@@ -61,7 +68,7 @@ class IMAPConnection(MailboxConnection):
                            port=self._client.port,
                            ssl=self._client.ssl,
                            verify=self._verify,
-                           idle_callback=check_callback,
+                           idle_callback=idle_callback_wrapper,
                            idle_timeout=check_timeout)
             except (timeout, IMAPClientError):
                 logger.warning("IMAP connection timeout. Reconnecting...")


### PR DESCRIPTION
Fix the returned object in the callback on `IMAPConnection`.

@seanthegeek I've tested this on my end using Gmail, but curious to see what you get on a "real" IMAP server

Related to #311