### PR TITLE
Add Dockerfile & build/push task

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+dist/
+build/
+test/
+parsedmarc.egg-info/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,10 @@
 name: Build docker image
 
 on:
+  release:
+    types:
+      - published
   push:
-    tags:
-      - 'v*'
     branches:
       - master
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - master
+      - add_dockerfile
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Publish a Docker image on release tag
+name: Build docker image
 
 on:
   push:
@@ -6,7 +6,6 @@ on:
       - 'v*'
     branches:
       - master
-      - add_dockerfile
 
 env:
   REGISTRY: ghcr.io
@@ -47,6 +46,6 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'release' }}
           tags:  ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Publish a Docker image on release tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags:  ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM python:3.9-slim
 
 WORKDIR /app
 COPY parsedmarc/ parsedmarc/
-COPY README.rst requirements.txt setup.py ./
+COPY README.rst setup.py ./
 
-RUN pip install -r requirements.txt
 RUN python setup.py install
 
 ENTRYPOINT ["parsedmarc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+COPY parsedmarc/ parsedmarc/
+COPY README.rst requirements.txt setup.py ./
+
+RUN pip install -r requirements.txt
+RUN python setup.py install
+
+ENTRYPOINT ["parsedmarc"]

--- a/README.rst
+++ b/README.rst
@@ -318,7 +318,7 @@ Docker usage
 
 .. code-block:: bash
 
-   docker run ghcr.io/domainaware/parsedmarc:<version> -c config.ini
+   docker run -v "${PWD}/config.ini:/config.ini" ghcr.io/domainaware/parsedmarc:<version> -c /config.ini
 
 
 Sample aggregate report output

--- a/README.rst
+++ b/README.rst
@@ -313,6 +313,14 @@ The full set of configuration options are:
    after you have manually moved known samples you want to save to that
    folder (e.g. malicious samples and non-sensitive legitimate samples).
 
+Docker usage
+============
+
+.. code-block:: bash
+
+   docker run ghcr.io/domainaware/parsedmarc:<version> -c config.ini
+
+
 Sample aggregate report output
 ==============================
 


### PR DESCRIPTION
- Add Dockerfile and action to build and publish a docker image to GitHub Container Registry.
- Add documentation on how to run the docker image.

Note that it only pushes the docker image on a release, so using the releases option in GitHub is required.

It would be nice to have an official docker image for running on container platforms. 

@seanthegeek  I'm curious if you prefer to use ghcr or DockerHub. If you want to use DockerHub then I will remove the push action. Also let me know your thoughts on the release process.

If this is merged, please use the Squash and merge option so that the test commits are squashed.
