### PR TITLE
Add message about scoping shared mailboxes when using MSGraph ClientSecret auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,7 @@ The full set of configuration options are:
         If you are using the `ClientSecret` auth method, you need to grant the ``Mail.ReadWrite`` (application) permission to the app.
         You must also restrict the application's access to a specific mailbox since it allows all mailboxes by default.
         Use the ``New-ApplicationAccessPolicy`` command in the Exchange PowerShell module.
+        If you need to scope the policy to shared mailboxes, you can add them to a mail enabled security group and use that as the group id.
 
         ``New-ApplicationAccessPolicy -AccessRight RestrictAccess -AppId "<CLIENT_ID>" -PolicyScopeGroupId "<MAILBOX>" -Description "Restrict access to dmarc reports mailbox."``
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -232,6 +232,7 @@ The full set of configuration options are:
         If you are using the `ClientSecret` auth method, you need to grant the ``Mail.ReadWrite`` (application) permission to the app.
         You must also restrict the application's access to a specific mailbox since it allows all mailboxes by default.
         Use the ``New-ApplicationAccessPolicy`` command in the Exchange PowerShell module.
+        If you need to scope the policy to shared mailboxes, you can add them to a mail enabled security group and use that as the group id.
 
         ``New-ApplicationAccessPolicy -AccessRight RestrictAccess -AppId "<CLIENT_ID>" -PolicyScopeGroupId "<MAILBOX>" -Description "Restrict access to dmarc reports mailbox."``
 

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -230,8 +230,9 @@ def parse_aggregate_report_xml(xml, ip_db_path=None, offline=False,
         xmltodict.parse(xml)["feedback"]
     except Exception as e:
         errors.append("Invalid XML: {0}".format(e.__str__()))
-        tree = etree.parse(BytesIO(xml.encode('utf-8')),
-                           etree.XMLParser(recover=True))
+        tree = etree.parse(
+            BytesIO(xml.encode('utf-8')),
+            etree.XMLParser(recover=True, resolve_entities=False))
         s = etree.tostring(tree)
         xml = '' if s is None else s.decode('utf-8')
 


### PR DESCRIPTION
There is a small issue when you need to scope to shared mailboxes as they are not a security principal.

You'll get the error `The identity of the policy scope is not a security principal.`

To fix this you must first create a mail enabled security group, add the shared mailbox to that group, and restrict using the group.

Also add `resolve_entities=False` on the XmlParser just to be safe. I don't think lxml is vulnerable but since we don't need it, good to turn off. Sonarqube was flagging it https://rules.sonarsource.com/python/RSPEC-2755.