### PR TITLE
Add Graph credentials cache and fix issue with batch size

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,6 +228,7 @@ The full set of configuration options are:
     - ``client_secret`` - str: The app registration's secret
     - ``tenant_id`` - str: The Azure AD tenant ID. This is required for all auth methods except UsernamePassword.
     - ``mailbox`` - str: The mailbox name. This defaults to the current user if using the UsernamePassword auth method, but could be a shared mailbox if the user has access to the mailbox
+    - ``token_file`` - str: Path to save the token file (Default: .token)
 
     .. note::
         You must create an app registration in Azure AD and have an admin grant the Microsoft Graph ``Mail.ReadWrite`` (delegated) permission to the app.
@@ -290,10 +291,10 @@ The full set of configuration options are:
     - ``server`` - str: The Syslog server name or IP address
     - ``port`` - int: The UDP port to use (Default: 514)
 - ``gmail_api``
-    - ``gmail_api_credentials_file`` - str: Path to file containing the credentials, None to disable (Default: None)
-    - ``gmail_api_token_file`` - str: Path to save the token file (Default: .token)
-    - ``gmail_api_include_spam_trash`` - bool: Include messages in Spam and Trash when searching reports (Default: False)
-    - ``gmail_api_scopes`` - str: Comma separated list of scopes to use when acquiring credentials (Default: https://www.googleapis.com/auth/gmail.modify)
+    - ``credentials_file`` - str: Path to file containing the credentials, None to disable (Default: None)
+    - ``token_file`` - str: Path to save the token file (Default: .token)
+    - ``include_spam_trash`` - bool: Include messages in Spam and Trash when searching reports (Default: False)
+    - ``scopes`` - str: Comma separated list of scopes to use when acquiring credentials (Default: https://www.googleapis.com/auth/gmail.modify)
 
 .. warning::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -223,6 +223,7 @@ The full set of configuration options are:
     - ``client_secret`` - str: The app registration's secret
     - ``tenant_id`` - str: The Azure AD tenant ID. This is required for all auth methods except UsernamePassword.
     - ``mailbox`` - str: The mailbox name. This defaults to the current user if using the UsernamePassword auth method, but could be a shared mailbox if the user has access to the mailbox
+    - ``token_file`` - str: Path to save the token file (Default: .token)
 
     .. note::
         You must create an app registration in Azure AD and have an admin grant the Microsoft Graph ``Mail.ReadWrite`` (delegated) permission to the app.
@@ -289,10 +290,10 @@ The full set of configuration options are:
     - ``server`` - str: The Syslog server name or IP address
     - ``port`` - int: The UDP port to use (Default: 514)
 - ``gmail_api``
-    - ``gmail_api_credentials_file`` - str: Path to file containing the credentials, None to disable (Default: None)
-    - ``gmail_api_token_file`` - str: Path to save the token file (Default: .token)
-    - ``gmail_api_include_spam_trash`` - bool: Include messages in Spam and Trash when searching reports (Default: False)
-    - ``gmail_api_scopes`` - str: Comma separated list of scopes to use when acquiring credentials (Default: https://www.googleapis.com/auth/gmail.modify)
+    - ``credentials_file`` - str: Path to file containing the credentials, None to disable (Default: None)
+    - ``token_file`` - str: Path to save the token file (Default: .token)
+    - ``include_spam_trash`` - bool: Include messages in Spam and Trash when searching reports (Default: False)
+    - ``scopes`` - str: Comma separated list of scopes to use when acquiring credentials (Default: https://www.googleapis.com/auth/gmail.modify)
 
 .. warning::
 

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1087,7 +1087,7 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
         connection.create_folder(forensic_reports_folder)
         connection.create_folder(invalid_reports_folder)
 
-    messages = connection.fetch_messages(reports_folder)
+    messages = connection.fetch_messages(reports_folder, batch_size=batch_size)
     total_messages = len(messages)
     logger.debug("Found {0} messages in {1}".format(len(messages),
                                                     reports_folder))

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -480,6 +480,8 @@ def _main():
 
         if "msgraph" in config.sections():
             graph_config = config["msgraph"]
+            opts.graph_token_file = graph_config.get("token_file", ".token")
+
             if "auth_method" not in graph_config:
                 logger.info("auth_method setting missing from the "
                             "msgraph config section "
@@ -894,7 +896,8 @@ def _main():
                 client_id=opts.graph_client_id,
                 client_secret=opts.graph_client_secret,
                 username=opts.graph_user,
-                password=opts.graph_password
+                password=opts.graph_password,
+                token_file=opts.graph_token_file
             )
 
         except Exception as error:

--- a/parsedmarc/mail/gmail.py
+++ b/parsedmarc/mail/gmail.py
@@ -65,7 +65,7 @@ class GmailConnection(MailboxConnection):
             else:
                 raise e
 
-    def fetch_messages(self, reports_folder: str) -> List[str]:
+    def fetch_messages(self, reports_folder: str, **kwargs) -> List[str]:
         reports_label_id = self._find_label_id_for_label(reports_folder)
         results = self.service.users().messages()\
             .list(userId='me',

--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -96,7 +96,7 @@ class MSGraphConnection(MailboxConnection):
                                           token_path=token_path)
         scopes = ['Mail.ReadWrite']
         # Detect if mailbox is shared
-        if username and mailbox and username != mailbox:
+        if mailbox and username != mailbox:
             scopes = ['Mail.ReadWrite.Shared']
         if not isinstance(credential, ClientSecretCredential):
             auth_record = credential.authenticate(scopes=scopes)

--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -129,11 +129,12 @@ class MSGraphConnection(MailboxConnection):
             logger.warning(f'Unknown response '
                            f'{resp.status_code} {resp.json()}')
 
-    def fetch_messages(self, folder_name: str) -> List[str]:
+    def fetch_messages(self, folder_name: str, **kwargs) -> List[str]:
         """ Returns a list of message UIDs in the specified folder """
         folder_id = self._find_folder_id_from_folder_path(folder_name)
+        batch_size = kwargs.get('batch_size', 10)
         url = f'/users/{self.mailbox_name}/mailFolders/' \
-              f'{folder_id}/messages?$select=id'
+              f'{folder_id}/messages?$select=id&$top={batch_size}'
         result = self._client.get(url)
         emails = result.json()['value']
         return [email['id'] for email in emails]

--- a/parsedmarc/mail/imap.py
+++ b/parsedmarc/mail/imap.py
@@ -32,7 +32,7 @@ class IMAPConnection(MailboxConnection):
     def create_folder(self, folder_name: str):
         self._client.create_folder(folder_name)
 
-    def fetch_messages(self, reports_folder: str):
+    def fetch_messages(self, reports_folder: str, **kwargs):
         self._client.select_folder(reports_folder)
         return self._client.search()
 

--- a/parsedmarc/mail/mailbox_connection.py
+++ b/parsedmarc/mail/mailbox_connection.py
@@ -9,7 +9,9 @@ class MailboxConnection(ABC):
     def create_folder(self, folder_name: str):
         raise NotImplementedError
 
-    def fetch_messages(self, reports_folder: str) -> List[str]:
+    def fetch_messages(self,
+                       reports_folder: str,
+                       **kwargs) -> List[str]:
         raise NotImplementedError
 
     def fetch_message(self, message_id) -> str:

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
                       'lxml>=4.4.0',
                       'boto3>=1.16.63',
                       'msgraph-core>=0.2.2',
-                      'azure-identity>=1.8.0'
+                      'azure-identity>=1.8.0',
                       'google-api-core>=2.4.0',
                       'google-api-python-client>=2.35.0',
                       'google-auth>=2.3.3',


### PR DESCRIPTION
Should resolve #333 and #330

- Add the ability to cache credentials from Graph (useful for the `DeviceCode` flow where you don't want to log in each time). This could probably deprecate the `UsernamePassword` flow since the other two are more ideal and work with MFA
- Add the `batch_size` arg into `fetch_messages` method since Graph defaults to only returning 10 messages
- Fix access denied error if using `DeviceCode` flow and connecting to a shared mailbox with a different account.
- Fix gmail configuration properties on readme and package requirement