### PR TITLE
Handle unexpected xml parsing errors more gracefully

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -222,11 +222,14 @@ def parse_aggregate_report_xml(xml, ip_db_path=None, offline=False,
         xmltodict.parse(xml)["feedback"]
     except Exception as e:
         errors.append("Invalid XML: {0}".format(e.__str__()))
-        tree = etree.parse(
-            BytesIO(xml.encode('utf-8')),
-            etree.XMLParser(recover=True, resolve_entities=False))
-        s = etree.tostring(tree)
-        xml = '' if s is None else s.decode('utf-8')
+        try:
+            tree = etree.parse(
+                BytesIO(xml.encode('utf-8')),
+                etree.XMLParser(recover=True, resolve_entities=False))
+            s = etree.tostring(tree)
+            xml = '' if s is None else s.decode('utf-8')
+        except Exception:
+            xml = u'<a/>'
 
     try:
         # Replace XML header (sometimes they are invalid)

--- a/tests.py
+++ b/tests.py
@@ -38,6 +38,11 @@ class Test(unittest.TestCase):
             print("\n")
             print(parsedmarc.parsed_aggregate_reports_to_csv(parsed_report))
 
+    def testEmptySample(self):
+        """Test empty/unparasable report"""
+        with self.assertRaises(parsedmarc.InvalidDMARCReport):
+            parsedmarc.parse_report_file('samples/empty.xml')
+
     def testForensicSamples(self):
         """Test sample forensic/ruf/failure DMARC reports"""
         sample_paths = glob("samples/forensic/*.eml")


### PR DESCRIPTION
* updates `parse_aggregate_report_xml` to not raise an unhandled exception on parsing errors
* Resolves #348