### PR TITLE
Doc - Update install documentation to Elasticsearch/Kibana 8

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1073,17 +1073,19 @@ sudo nano /etc/nginx/sites-available/kibana
 ```nginx
 server {
     listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    
     ssl_certificate /etc/nginx/ssl/kibana.crt;
     ssl_certificate_key /etc/nginx/ssl/kibana.key;
+    
     ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:50m;
+    ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
     ssl_session_tickets off;
 
 
-    # modern configuration. tweak to your needs.
-    ssl_protocols TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-    ssl_prefer_server_ciphers on;
+    # modern configuration.
+    ssl_protocols TLSv1.3;
+    ssl_prefer_server_ciphers off;
 
     # Uncomment this next line if you are using a signed, trusted cert
     #add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
@@ -1102,9 +1104,16 @@ server {
 
 server {
     listen 80;
+    listen [::]:80;
     return 301 https://$host$request_uri;
 }
 ```
+
+:::{note}
+If TLSv1.2 compatibility is required, please adapt the ssl_* part 
+using the Mozilla conf generator <https://ssl-config.mozilla.org/#server=nginx>
+:::
+
 
 Enable the nginx configuration for Kibana:
 
@@ -1130,7 +1139,7 @@ sudo chmod u=rw,g=r,o= /etc/nginx/htpasswd
 Restart nginx:
 
 ```bash
-sudo service nginx restart
+sudo systemctl restart nginx
 ```
 
 Now that Elasticsearch is up and running, use `parsedmarc` to send data to

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1031,7 +1031,7 @@ Move the keys into place and secure them:
 
 ```bash
 sudo mv kibana.* /etc/kibana
-sudo chmod 660 /etc/kibanakibana.key
+sudo chmod 660 /etc/kibana/kibana.key
 ```
 
 Activate the HTTPS server in Kibana

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1082,6 +1082,9 @@ it.
 
 Download (right click the link and click save as) [export.ndjson].
 
+Connect to kibana using the elastic user and the password you previously provide
+on the console ("End Kibana configuration" part).
+
 Import `export.ndjson` the Saved Objects tab of the Stack management
 page of Kibana.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -966,20 +966,20 @@ On Debian/Ubuntu based systems, run:
 
 ```bash
 sudo apt-get install -y apt-transport-https
-wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-7.x.list
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-8.x.list
 sudo apt-get update
-sudo apt-get install -y default-jre-headless elasticsearch kibana
+sudo apt-get install -y elasticsearch kibana
 ```
 
 For CentOS, RHEL, and other RPM systems, follow the Elastic RPM guides for
 [Elasticsearch] and [Kibana].
 
-:::{warning}
-The default JVM heap size for Elasticsearch is very small (1g), which will
-cause it to crash under a heavy load. To fix this, increase the minimum and
-maximum JVM heap sizes in `/etc/elasticsearch/jvm.options` to more
-reasonable levels, depending on your server's resources.
+:::{note}
+Previously, the default JVM heap size for Elasticsearch was very small (1g),
+which will cause it to crash under a heavy load. To fix this, increase the
+minimum and maximum JVM heap sizes in `/etc/elasticsearch/jvm.options` to
+more reasonable levels, depending on your server's resources.
 
 Make sure the system has at least 2 GB more RAM then the assigned JVM
 heap size.
@@ -994,7 +994,7 @@ For example, to set a 4 GB heap size, set
 -Xmx4g
 ```
 
-See <https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html>
+See <https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#heap-size-settings>
 for more information.
 :::
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1075,6 +1075,7 @@ xpack.security.encryptionKey: xxxx...xxxx
 ```
 ```bash
 sudo systemctl restart kibana
+sudo systemctl restart elasticsearch
 ```
 
 Now that Elasticsearch is up and running, use `parsedmarc` to send data to
@@ -1082,11 +1083,12 @@ it.
 
 Download (right click the link and click save as) [export.ndjson].
 
-Connect to kibana using the elastic user and the password you previously provide
+Connect to kibana using the "elastic" user and the password you previously provide
 on the console ("End Kibana configuration" part).
 
 Import `export.ndjson` the Saved Objects tab of the Stack management
-page of Kibana.
+page of Kibana. (Hamburger menu -> "Management" -> "Stack Management" -> 
+"Kibana" -> "Saved Objects")
 
 It will give you the option to overwrite existing saved dashboards or
 visualizations, which could be used to restore them if you or someone else
@@ -1218,7 +1220,7 @@ service parsedmarc status
 :::{note}
 In the event of a crash, systemd will restart the service after 10
 minutes, but the `service parsedmarc status` command will only show
-the logs for the current process. To vew the logs for previous runs
+the logs for the current process. To view the logs for previous runs
 as well as the current process (newest to oldest), run:
 
 ```bash


### PR DESCRIPTION
Hi,

I updated the installation documentation in order to manager Elasticsearch / Kibana 8.x release.
This release remove nginx reverse proxy requirements as HTTPS can now be used natively on the free version.

Bests regards,
Anael