### PR TITLE
MSGraph: add option to allow unencrypted fallback for token cache

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -246,6 +246,9 @@ The full set of configuration options are:
       could be a shared mailbox if the user has access to the mailbox
   - `token_file` - str: Path to save the token file
       (Default: `.token`)
+  - `allow_unencrypted_storage` - bool: Allows the Azure Identity
+      module to fall back to unencrypted token cache (Default: False).
+      Even if enabled, the cache will always try encrypted storage first.
 
     :::{note}
     You must create an app registration in Azure AD and have an

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -298,6 +298,7 @@ def _main():
                      graph_client_secret=None,
                      graph_tenant_id=None,
                      graph_mailbox=None,
+                     graph_allow_unencrypted_storage=False,
                      hec=None,
                      hec_token=None,
                      hec_index=None,
@@ -549,6 +550,10 @@ def _main():
                 logger.critical("mailbox setting missing from the "
                                 "msgraph config section")
                 exit(-1)
+
+            if "allow_unencrypted_storage" in graph_config:
+                opts.graph_allow_unencrypted_storage = graph_config.getboolean(
+                    "allow_unencrypted_storage")
 
         if "elasticsearch" in config:
             elasticsearch_config = config["elasticsearch"]
@@ -917,7 +922,8 @@ def _main():
                 client_secret=opts.graph_client_secret,
                 username=opts.graph_user,
                 password=opts.graph_password,
-                token_file=opts.graph_token_file
+                token_file=opts.graph_token_file,
+                allow_unencrypted_storage=opts.graph_allow_unencrypted_storage
             )
 
         except Exception:

--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -19,10 +19,12 @@ class AuthMethod(Enum):
     ClientSecret = 3
 
 
-def _get_cache_args(token_path: Path):
+def _get_cache_args(token_path: Path, allow_unencrypted_storage):
     cache_args = {
         'cache_persistence_options':
-            TokenCachePersistenceOptions(name='parsedmarc')
+            TokenCachePersistenceOptions(
+                name='parsedmarc',
+                allow_unencrypted_storage=allow_unencrypted_storage)
     }
     auth_record = _load_token(token_path)
     if auth_record:
@@ -51,7 +53,9 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
             client_secret=kwargs['client_secret'],
             disable_automatic_authentication=True,
             tenant_id=kwargs['tenant_id'],
-            **_get_cache_args(token_path)
+            **_get_cache_args(
+                token_path,
+                allow_unencrypted_storage=kwargs['allow_unencrypted_storage'])
         )
     elif auth_method == AuthMethod.UsernamePassword.name:
         credential = UsernamePasswordCredential(
@@ -60,7 +64,9 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
             disable_automatic_authentication=True,
             username=kwargs['username'],
             password=kwargs['password'],
-            **_get_cache_args(token_path)
+            **_get_cache_args(
+                token_path,
+                allow_unencrypted_storage=kwargs['allow_unencrypted_storage'])
         )
     elif auth_method == AuthMethod.ClientSecret.name:
         credential = ClientSecretCredential(
@@ -82,15 +88,18 @@ class MSGraphConnection(MailboxConnection):
                  username: str,
                  password: str,
                  tenant_id: str,
-                 token_file: str):
+                 token_file: str,
+                 allow_unencrypted_storage: bool):
         token_path = Path(token_file)
-        credential = _generate_credential(auth_method,
-                                          client_id=client_id,
-                                          client_secret=client_secret,
-                                          username=username,
-                                          password=password,
-                                          tenant_id=tenant_id,
-                                          token_path=token_path)
+        credential = _generate_credential(
+            auth_method,
+            client_id=client_id,
+            client_secret=client_secret,
+            username=username,
+            password=password,
+            tenant_id=tenant_id,
+            token_path=token_path,
+            allow_unencrypted_storage=allow_unencrypted_storage)
         client_params = {
             'credential': credential
         }


### PR DESCRIPTION
## Add option in configuration file to set the allow_unencrypted_storage flag, referring to the azure identity token cache

### What happens if this new option is omitted?
If this flag is not specified in the configuration file, the default will remain unchanged (meaning unencrypted storage is disallowed).

### What will this do if manually set to True?
The cache will still try to encrypt the token data, but in case this fails, it will fall back to unencrypted storage. For detailed information, see: https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.tokencachepersistenceoptions

### Why is this needed?
Some environments do not supply the required modules (libsecret, etc) to store with encryption.
