### PR TITLE
Update documentation default value for ES replica setting

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -290,7 +290,7 @@ The full set of configuration options are:
   - `number_of_shards` - int: The number of shards to use when
     creating the index (Default: `1`)
   - `number_of_replicas` - int: The number of replicas to use when
-    creating the index (Default: `1`)
+    creating the index (Default: `0`)
 - `splunk_hec`
   - `url` - str: The URL of the Splunk HTTP Events Collector (HEC)
   - `token` - str: The HEC token


### PR DESCRIPTION
Change made in 7.1.0 "Set Elasticsearch shard replication to 0 (PR #274)" Documentation was not updated