### PR TITLE
Use "check_timeout" duration in case of error on imap connection

### DIFF
--- a/parsedmarc/mail/imap.py
+++ b/parsedmarc/mail/imap.py
@@ -69,8 +69,8 @@ class IMAPConnection(MailboxConnection):
                            idle_timeout=check_timeout)
             except (timeout, IMAPClientError):
                 logger.warning("IMAP connection timeout. Reconnecting...")
-                sleep(5)
+                sleep(check_timeout)
             except Exception as e:
                 logger.warning("IMAP connection error. {0}. "
                                "Reconnecting...".format(e))
-                sleep(5)
+                sleep(check_timeout)


### PR DESCRIPTION
In case of timeout or exception, wait "check_timeout" before to try a new connection (documentation : "or the number of seconds until the next mail check").
Else in case of a mail server issue, we try to connect again each 5 seconds.