### PR TITLE
Fixed Bug in graph.py

### DIFF
--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -156,7 +156,7 @@ class MSGraphConnection(MailboxConnection):
         params = {
             '$select': 'id'
         }
-        if batch_size:
+        if batch_size and batch_size > 0:
             params['$top'] = batch_size
         else:
             params['$top'] = 100

--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -223,11 +223,12 @@ class MSGraphConnection(MailboxConnection):
         if parent_folder_id is not None:
             sub_url = f'/{parent_folder_id}/childFolders'
         url = f'/users/{self.mailbox_name}/mailFolders{sub_url}'
-        folders_resp = self._client.get(url)
+        filter = f"?$filter=displayName eq '{folder_name}'"
+        folders_resp = self._client.get(url + filter)
         if folders_resp.status_code != 200:
             raise RuntimeWarning(f"Failed to list folders."
                                  f"{folders_resp.json()}")
-        folders = folders_resp.json()['value']
+        folders:list = folders_resp.json()['value']
         matched_folders = [folder for folder in folders
                            if folder['displayName'] == folder_name]
         if len(matched_folders) == 0:


### PR DESCRIPTION
Fixed Bug regarding the finding of a specific folder. This Bug caused parsedmarc to crash if it could not find the folder in one Ms Graph request. This is only an issue if your MailBox contains 10+ folders. It was solved by adding the `$filter=displayName eq '{folder_name}'` param so it would immediatly find the folder.