### PR TITLE
Fix docstring indentations and grammar

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -208,7 +208,7 @@ def parse_aggregate_report_xml(xml, ip_db_path=None, offline=False,
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
         offline (bool): Do not query online for geolocation or DNS
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         timeout (float): Sets the DNS timeout in seconds
         parallel (bool): Parallel processing
         keep_alive (callable): Keep alive function
@@ -409,7 +409,7 @@ def parse_aggregate_report_file(_input, offline=False, ip_db_path=None,
         offline (bool): Do not query online for geolocation or DNS
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         dns_timeout (float): Sets the DNS timeout in seconds
         parallel (bool): Parallel processing
         keep_alive (callable): Keep alive function
@@ -582,10 +582,10 @@ def parse_forensic_report(feedback_report, sample, msg_date,
         sample (str): The RFC 822 headers or RFC 822 message sample
         msg_date (str): The message's date header
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         dns_timeout (float): Sets the DNS timeout in seconds
         strip_attachment_payloads (bool): Remove attachment payloads from
-        forensic report results
+            forensic report results
         parallel (bool): Parallel processing
 
     Returns:
@@ -772,7 +772,7 @@ def parse_report_email(input_, offline=False, ip_db_path=None,
         nameservers (list): A list of one or more nameservers to use
         dns_timeout (float): Sets the DNS timeout in seconds
         strip_attachment_payloads (bool): Remove attachment payloads from
-        forensic report results
+            forensic report results
         parallel (bool): Parallel processing
         keep_alive (callable): keep alive function
 
@@ -914,10 +914,10 @@ def parse_report_file(input_, nameservers=None, dns_timeout=2.0,
     Args:
         input_: A path to a file, a file like object, or bytes
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         dns_timeout (float): Sets the DNS timeout in seconds
         strip_attachment_payloads (bool): Remove attachment payloads from
-        forensic report results
+            forensic report results
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
         offline (bool): Do not make online queries for geolocation or DNS
         parallel (bool): Parallel processing
@@ -974,16 +974,16 @@ def get_dmarc_reports_from_mbox(input_, nameservers=None, dns_timeout=2.0,
     Args:
         input_: A path to a mbox file
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         dns_timeout (float): Sets the DNS timeout in seconds
         strip_attachment_payloads (bool): Remove attachment payloads from
-        forensic report results
+            forensic report results
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
         offline (bool): Do not make online queries for geolocation or DNS
         parallel (bool): Parallel processing
 
     Returns:
-        OrderedDict: Lists of  ``aggregate_reports`` and ``forensic_reports``
+        OrderedDict: Lists of ``aggregate_reports`` and ``forensic_reports``
 
     """
     aggregate_reports = []
@@ -1048,12 +1048,12 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
         nameservers (list): A list of DNS nameservers to query
         dns_timeout (float): Set the DNS query timeout
         strip_attachment_payloads (bool): Remove attachment payloads from
-          forensic report results
+            forensic report results
         results (dict): Results from the previous run
         batch_size (int): Number of messages to read and process before saving
             (use 0 for no limit)
         create_folders (bool): Whether to create the destination folders
-          (not used in watch)
+            (not used in watch)
 
     Returns:
         OrderedDict: Lists of ``aggregate_reports`` and ``forensic_reports``
@@ -1230,14 +1230,14 @@ def watch_inbox(mailbox_connection: MailboxConnection,
         delete (bool): Delete  messages after processing them
         test (bool): Do not move or delete messages after processing them
         check_timeout (int): Number of seconds to wait for a IMAP IDLE response
-          or the number of seconds until the next mail check
+            or the number of seconds until the next mail check
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
         offline (bool): Do not query online for geolocation or DNS
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         dns_timeout (float): Set the DNS query timeout
         strip_attachment_payloads (bool): Replace attachment payloads in
-        forensic report samples with None
+            forensic report samples with None
         batch_size (int): Number of messages to read and process before saving
     """
 
@@ -1425,7 +1425,7 @@ def email_results(results, host, mail_from, mail_to,
         password (str): An optional password
         subject (str): Overrides the default message subject
         attachment_filename (str): Override the default attachment filename
-        message (str: Override the default plain text body
+        message (str): Override the default plain text body
     """
     logger.debug("Emailing report to: {0}".format(",".join(mail_to)))
     date_string = datetime.now().strftime("%Y-%m-%d")

--- a/parsedmarc/splunk.py
+++ b/parsedmarc/splunk.py
@@ -26,6 +26,7 @@ class HECClient(object):
                  source="parsedmarc", verify=True, timeout=60):
         """
         Initializes the HECClient
+        
         Args:
             url (str): The URL of the HEC
             access_token (str): The HEC access token
@@ -33,7 +34,7 @@ class HECClient(object):
             source (str): The source name
             verify (bool): Verify SSL certificates
             timeout (float): Number of seconds to wait for the server to send
-            data before giving up
+                data before giving up
         """
         url = urlparse(url)
         self.url = "{0}://{1}/services/collector/event/1.0".format(url.scheme,
@@ -59,7 +60,7 @@ class HECClient(object):
 
         Args:
             aggregate_reports: A list of aggregate report dictionaries
-            to save in Splunk
+                to save in Splunk
 
         """
         logger.debug("Saving aggregate reports to Splunk")
@@ -125,8 +126,8 @@ class HECClient(object):
         Saves forensic DMARC reports to Splunk
 
         Args:
-            forensic_reports (list):  A list of forensic report dictionaries
-            to save in Splunk
+            forensic_reports (list): A list of forensic report dictionaries
+                to save in Splunk
         """
         logger.debug("Saving forensic reports to Splunk")
         if type(forensic_reports) == dict:

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -139,7 +139,7 @@ def query_dns(domain, record_type, cache=None, nameservers=None, timeout=2.0):
         record_type (str): The record type to query for
         cache (ExpiringDict): Cache storage
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         timeout (float): Sets the DNS timeout in seconds
 
     Returns:
@@ -188,7 +188,7 @@ def get_reverse_dns(ip_address, cache=None, nameservers=None, timeout=2.0):
         ip_address (str): The IP address to resolve
         cache (ExpiringDict): Cache storage
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         timeout (float): Sets the DNS query timeout in seconds
 
     Returns:
@@ -209,13 +209,13 @@ def get_reverse_dns(ip_address, cache=None, nameservers=None, timeout=2.0):
 
 def timestamp_to_datetime(timestamp):
     """
-    Converts a UNIX/DMARC timestamp to a Python ``DateTime`` object
+    Converts a UNIX/DMARC timestamp to a Python ``datetime`` object
 
     Args:
         timestamp (int): The timestamp
 
     Returns:
-        DateTime: The converted timestamp as a Python ``DateTime`` object
+        datetime: The converted timestamp as a Python ``datetime`` object
     """
     return datetime.fromtimestamp(int(timestamp))
 
@@ -235,14 +235,14 @@ def timestamp_to_human(timestamp):
 
 def human_timestamp_to_datetime(human_timestamp, to_utc=False):
     """
-    Converts a human-readable timestamp into a Python ``DateTime`` object
+    Converts a human-readable timestamp into a Python ``datetime`` object
 
     Args:
         human_timestamp (str): A timestamp string
         to_utc (bool): Convert the timestamp to UTC
 
     Returns:
-        DateTime: The converted timestamp
+        datetime: The converted timestamp
     """
 
     human_timestamp = human_timestamp.replace("-0000", "")
@@ -338,7 +338,7 @@ def get_ip_address_info(ip_address, ip_db_path=None, cache=None, offline=False,
         cache (ExpiringDict): Cache storage
         offline (bool): Do not make online queries for geolocation or DNS
         nameservers (list): A list of one or more nameservers to use
-        (Cloudflare's public DNS resolvers by default)
+            (Cloudflare's public DNS resolvers by default)
         timeout (float): Sets the DNS timeout in seconds
         parallel (bool): parallel processing
 
@@ -392,6 +392,7 @@ def parse_email_address(original_address):
 def get_filename_safe_string(string):
     """
     Converts a string to a string that is safe for a filename
+    
     Args:
         string (str): A string to make safe for a filename
 
@@ -413,13 +414,13 @@ def get_filename_safe_string(string):
 
 def is_mbox(path):
     """
-    Checks if the given content is a MBOX mailbox file
+    Checks if the given content is an MBOX mailbox file
 
     Args:
         path: Content to check
 
     Returns:
-        bool: A flag the indicates if a file is a MBOX mailbox file
+        bool: A flag that indicates if the file is an MBOX mailbox file
     """
     _is_mbox = False
     try:
@@ -434,13 +435,13 @@ def is_mbox(path):
 
 def is_outlook_msg(content):
     """
-    Checks if the given content is a Outlook msg OLE file
+    Checks if the given content is an Outlook msg OLE/MSG file
 
     Args:
         content: Content to check
 
     Returns:
-        bool: A flag the indicates if a file is a Outlook MSG file
+        bool: A flag that indicates if the file is an Outlook MSG file
     """
     return type(content) == bytes and content.startswith(
         b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1")
@@ -488,7 +489,8 @@ def parse_email(data, strip_attachment_payloads=False):
         data: The RFC 822 message string, or MSG binary
         strip_attachment_payloads (bool): Remove attachment payloads
 
-    Returns (dict): Parsed email data
+    Returns:
+        dict: Parsed email data
     """
 
     if type(data) == bytes:


### PR DESCRIPTION
In several docstrings incorrect indentation caused errors in the rendered documentation.
I also changed a few words to correct the grammar.

I did notice after committing that the indentation style varies across functions or methods. In some places, there is:

```rst
Args:
    some_arg (type): very long description
                     that continues on the next line
```

... whereas I just added four spaces before the continuations.