### PR TITLE
More error-prune code to handle Elasticsearch's requirements

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -254,6 +254,13 @@ def parse_aggregate_report_xml(xml, ip_db_path=None, offline=False,
             new_org_name = get_base_domain(org_name)
             if new_org_name is not None:
                 org_name = new_org_name
+        if not org_name:
+            logger.debug("Could not parse org_name from XML.\r\n{0}".format(
+                report.__str__()
+            ))
+            raise KeyError("Organization name is missing. \
+                           This field is a requirement for \
+                           saving the report")
         new_report_metadata["org_name"] = org_name
         new_report_metadata["org_email"] = report_metadata["email"]
         extra = None

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -101,6 +101,9 @@ def _main():
                 except elastic.ElasticsearchError as error_:
                     logger.error("Elasticsearch Error: {0}".format(
                         error_.__str__()))
+                except Exception as error_:
+                    logger.error("Elasticsearch exception error: {}".format(
+                        error_.__str__()))
                 try:
                     if opts.kafka_hosts:
                         kafka_client.save_aggregate_reports_to_kafka(


### PR DESCRIPTION
For some rare occasions, the XML could not parse metadata["org_name"] which broke the search for already existing reports. Instead of crashing, this code now moves on and raises an error which is handled and logged.