### PR TITLE
Fix: Less error-prone code to minimize the risk of program crash

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -101,6 +101,9 @@ def _main():
                 except elastic.ElasticsearchError as error_:
                     logger.error("Elasticsearch Error: {0}".format(
                         error_.__str__()))
+                except Exception as error_:
+                    logger.error("Elasticsearch exception error: {}".format(
+                        error_.__str__()))
                 try:
                     if opts.kafka_hosts:
                         kafka_client.save_aggregate_reports_to_kafka(

--- a/parsedmarc/elastic.py
+++ b/parsedmarc/elastic.py
@@ -327,7 +327,12 @@ def save_aggregate_report_to_elasticsearch(aggregate_report,
     query = query & begin_date_query & end_date_query
     search.query = query
 
-    existing = search.execute()
+    try:
+        existing = search.execute()
+    except Exception as error_:
+        raise ElasticsearchError("Elasticsearch's search for existing report \
+            error: {}".format(error_.__str__()))
+
     if len(existing) > 0:
         raise AlreadySaved("An aggregate report ID {0} from {1} about {2} "
                            "with a date range of {3} UTC to {4} UTC already "


### PR DESCRIPTION
- Double check if org_name exist. Empty name will crash Elastissearch's 'exist' search
- Move try-statement to include open() to catch if files do not exist
- Enclose Elasticsearch's execute in a try-statement to catch any invalid searches when variables are empty/missing