### PR TITLE
Ignore errors when parsing text-based forensic reports

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -852,16 +852,23 @@ def parse_report_email(input_, offline=False, ip_db_path=None,
             sample = payload
         elif content_type == "text/plain":
             if "A message claiming to be from you has failed" in payload:
-                parts = payload.split("detected.")
-                field_matches = text_report_regex.findall(parts[0])
-                fields = dict()
-                for match in field_matches:
-                    field_name = match[0].lower().replace(" ", "-")
-                    fields[field_name] = match[1].strip()
-                feedback_report = "Arrival-Date: {}\n" \
-                                  "Source-IP: {}" \
-                                  "".format(fields["received-date"],
-                                            fields["sender-ip-address"])
+                try:
+                    parts = payload.split("detected.", 1)
+                    field_matches = text_report_regex.findall(parts[0])
+                    fields = dict()
+                    for match in field_matches:
+                        field_name = match[0].lower().replace(" ", "-")
+                        fields[field_name] = match[1].strip()
+
+                    feedback_report = "Arrival-Date: {}\n" \
+                                    "Source-IP: {}" \
+                                    "".format(fields["received-date"],
+                                                fields["sender-ip-address"])
+                except Exception as e:
+                    error = 'Unable to parse message with ' \
+                            'subject "{0}": {1}'.format(subject, e)
+                    raise InvalidDMARCReport(error)
+
                 sample = parts[1].lstrip()
                 sample = sample.replace("=\r\n", "")
                 logger.debug(sample)


### PR DESCRIPTION
Starting 8.2.0, parsedmarc crashes instead of ignoring some invalid reports.

In my case, this was due to dmarc reports being forwarded to a mailing list and the content being wrapped (thus received-date header was mangled/missing).

I first tried to unwrap the payload, but that's too finicky.

The original change was introduced in abf969522809626bc1aeb886cf69ae0e2bb62895.

An example of failure I got recently:

```
Traceback (most recent call last):
  File "/home/demarteaub/.local/bin/parsedmarc", line 8, in <module>
    sys.exit(_main())
             ^^^^^^^
  File "/home/demarteaub/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/cli.py", line 933, in _main
    reports = get_dmarc_reports_from_mbox(mbox_path,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/demarteaub/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 1032, in get_dmarc_reports_from_mbox
    parsed_email = parse_report_email(msg_content,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/demarteaub/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 869, in parse_report_email
    raise e
  File "/home/demarteaub/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 865, in parse_report_email
    "".format(fields["received-date"],
              ~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'received-date'
```

content of `fields` variable:
```
{'sender-domain': 'liege.be Sender IP Address: 40.107.6.95 Receiv=', 'ed-date': 'Wed, 16 Aug 2023 09:11:18 +0200 SPF Alignment: no DKIM Alignment: =', 'no-dmarc-results': 'Quarantine ------ This is a copy of the headers that were='}
```