### PR TITLE
fix: handle none value

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -507,7 +507,7 @@ def parsed_aggregate_reports_to_csv_rows(reports):
             row["dmarc_aligned"] = record["alignment"]["dmarc"]
             row["disposition"] = record["policy_evaluated"]["disposition"]
             policy_override_reasons = list(map(
-                lambda r_: r_["type"],
+                lambda r_: r_["type"] or "none",
                 record["policy_evaluated"]
                 ["policy_override_reasons"]))
             policy_override_comments = list(map(

--- a/samples/aggregate/empty_reason.xml
+++ b/samples/aggregate/empty_reason.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feedback>
+  <version>1.0</version>
+  <report_metadata>
+    <org_name>example.org</org_name>
+    <email>noreply-dmarc-support@example.org</email>
+    <extra_contact_info>https://support.example.org/dmarc</extra_contact_info>
+    <report_id>20240125141224705995</report_id>
+    <date_range>
+      <begin>1706159544</begin>
+      <end>1706185733</end>
+    </date_range>
+  </report_metadata>
+  <policy_published>
+    <domain>example.com</domain>
+    <adkim>r</adkim>
+    <aspf>r</aspf>
+    <p>quarantine</p>
+    <sp>quarantine</sp>
+    <pct>100</pct>
+    <fo>1</fo>
+  </policy_published>
+  <record>
+    <row>
+      <source_ip>198.51.100.123</source_ip>
+      <count>2</count>
+      <policy_evaluated>
+        <disposition>none</disposition>
+        <dkim>pass</dkim>
+        <spf>fail</spf>
+        <reason>
+          <type></type>
+          <comment></comment>
+        </reason>
+      </policy_evaluated>
+    </row>
+    <identifiers>
+      <envelope_to>example.net</envelope_to>
+      <envelope_from>example.edu</envelope_from>
+      <header_from>example.com</header_from>
+    </identifiers>
+    <auth_results>
+      <dkim>
+        <domain>example.com</domain>
+        <selector>example</selector>
+        <result>pass</result>
+        <human_result>2048-bit key</human_result>
+      </dkim>
+      <spf>
+        <domain>example.edu</domain>
+        <scope>mfrom</scope>
+        <result>pass</result>
+      </spf>
+    </auth_results>
+  </record>
+</feedback>


### PR DESCRIPTION
Thank you to all the maintainers.

In my use case, I encountered the below error.

```
Traceback (most recent call last):
  File "tests.py", line [39](https://github.com/yktakaha4/parsedmarc/actions/runs/7691856259/job/20957819252?pr=1#step:8:40), in testAggregateSamples
    parsedmarc.parsed_aggregate_reports_to_csv(parsed_report)
  File "/home/runner/work/parsedmarc/parsedmarc/parsedmarc/__init__.py", line 583, in parsed_aggregate_reports_to_csv
    rows = parsed_aggregate_reports_to_csv_rows(reports)
  File "/home/runner/work/parsedmarc/parsedmarc/parsedmarc/__init__.py", line 517, in parsed_aggregate_reports_to_csv_rows
    row["policy_override_reasons"] = ",".join(
TypeError: sequence item 0: expected str instance, NoneType found
```

It turned out that the None check was missing in the following places, so I fixed it.
I've also added test data to verify the fix.
https://github.com/domainaware/parsedmarc/blob/7d2b431e5f20bdcdb330c4fbb23ce7df5fb0642f/parsedmarc/__init__.py#L510

I believe that the CI failure will be resolved by merging the PR below.
https://github.com/domainaware/parsedmarc/pull/466