### PR TITLE
Fixed msgraph-core requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "kafka-python>=1.4.4",
     "lxml>=4.4.0",
     "mailsuite>=1.6.1",
-    "msgraph-core>=0.2.2",
+    "msgraph-core==0.2.2",
     "publicsuffixlist>=0.10.0",
     "requests>=2.22.0",
     "tqdm>=4.31.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ sphinx_rtd_theme>=0.4.3
 codecov>=2.0.15
 lxml>=4.4.0
 boto3>=1.16.63
-msgraph-core>=0.2.2
+msgraph-core==0.2.2
 azure-identity>=1.8.0
 azure-monitor-ingestion>=1.0.0
 google-api-core>=2.4.0


### PR DESCRIPTION
The new release of `msgraph-core` `1.0.0` will break the current (docker) version.

This will set a fixed version of `0.2.2` for `msgraph-core`.