### PR TITLE
msgraph DeviceFlow selecting wrong scope

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -537,12 +537,13 @@ def _main():
                                     "msgraph config section")
                     exit(-1)
 
-            if "client_secret" in graph_config:
-                opts.graph_client_secret = graph_config["client_secret"]
-            else:
-                logger.critical("client_secret setting missing from the "
-                                "msgraph config section")
-                exit(-1)
+            if opts.graph_auth_method == AuthMethod.ClientSecret.name:
+                if "client_secret" in graph_config:
+                    opts.graph_client_secret = graph_config["client_secret"]
+                else:
+                    logger.critical("client_secret setting missing from the "
+                                    "msgraph config section")
+                    exit(-1)
 
             if "client_id" in graph_config:
                 opts.graph_client_id = graph_config["client_id"]

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -524,6 +524,10 @@ def _main():
                     logger.critical("password setting missing from the "
                                     "msgraph config section")
                     exit(-1)
+            
+            if opts.graph_auth_method == AuthMethod.DeviceCode.name:
+                if "user" in graph_config:
+                        opts.graph_user = graph_config["user"]
 
             if opts.graph_auth_method != AuthMethod.UsernamePassword.name:
                 if "tenant_id" in graph_config:

--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -50,7 +50,6 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
     if auth_method == AuthMethod.DeviceCode.name:
         credential = DeviceCodeCredential(
             client_id=kwargs['client_id'],
-            client_secret=kwargs['client_secret'],
             disable_automatic_authentication=True,
             tenant_id=kwargs['tenant_id'],
             **_get_cache_args(
@@ -60,7 +59,6 @@ def _generate_credential(auth_method: str, token_path: Path, **kwargs):
     elif auth_method == AuthMethod.UsernamePassword.name:
         credential = UsernamePasswordCredential(
             client_id=kwargs['client_id'],
-            client_credential=kwargs['client_secret'],
             disable_automatic_authentication=True,
             username=kwargs['username'],
             password=kwargs['password'],


### PR DESCRIPTION
While trying to use the DeviceCode flow to log in to an account and read from its own mailbox using delegated permissions I was constantly hit with the "Admin consent is required for the permissions requested by this application." message.

This is because the property "user" from the config is ignored when using DeviceCode, so "Mail.ReadWrite.Shared" is always selected, wheras it should be "Mail.ReadWrite" when user and mailbox match.
https://github.com/domainaware/parsedmarc/blob/7d2b431e5f20bdcdb330c4fbb23ce7df5fb0642f/parsedmarc/mail/graph.py#L107-L113

Also neither the DeviceCodeCredential nor the UsernamePasswordCredential classes from the Azure library require a client_secret, but the config parsing of parsedmarc does. However I cannot verify this change for UsernamePasswordCredential in practice, as it is only available for personal Microsoft accounts.

For those coming along: For the DeviceCode flow it is required that the app in Microsoft Entra / Azure allows "public client flows", otherwise the login works but parsedmarc immediatly throws AADSTS7000218 afterwards while trying to call the API. The setting is found under "Manage" and then "Authentication" in the app registrations, not enterprise applications.