### PR TITLE
adding OpenSearch support, fixing minor typos, and code styling

### DIFF
--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -14,6 +14,14 @@
    :members:
 ```
 
+## parsedmarc.opensearch
+
+```{eval-rst}
+.. automodule:: parsedmarc.opensearch
+   :members:
+```
+
+
 ## parsedmarc.splunk
 
 ```{eval-rst}

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -26,7 +26,7 @@ Thanks to all [contributors]!
 ```
 
 `parsedmarc` is a Python module and CLI utility for parsing DMARC reports.
-When used with Elasticsearch and Kibana (or Splunk), it works as a self-hosted
+When used with Elasticsearch and Kibana (or Splunk), or with OpenSearch and Grafana, it works as a self-hosted
 open source alternative to commercial DMARC report processing services such
 as Agari Brand Protection, Dmarcian, OnDMARC, ProofPoint Email Fraud Defense,
 and Valimail.
@@ -40,7 +40,7 @@ and Valimail.
 - Consistent data structures
 - Simple JSON and/or CSV output
 - Optionally email the results
-- Optionally send the results to Elasticsearch and/or Splunk, for use with
+- Optionally send the results to Elasticsearch/OpenSearch and/or Splunk, for use with
   premade dashboards
 - Optionally send reports to Apache Kafka
 
@@ -52,6 +52,7 @@ installation
 usage
 output
 elasticsearch
+opensearch
 kibana
 splunk
 davmail

--- a/docs/source/opensearch.md
+++ b/docs/source/opensearch.md
@@ -1,0 +1,14 @@
+# OpenSearch and Grafana
+
+To set up visual dashboards of DMARC data, install OpenSearch and Grafana.
+
+## Installation
+
+OpenSearch: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/
+Grafana: https://grafana.com/docs/grafana/latest/setup-grafana/installation/
+
+## Records retention
+
+Starting in version 5.0.0, `parsedmarc` stores data in a separate
+index for each day to make it easy to comply with records
+retention regulations such as GDPR.

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -82,6 +82,10 @@ delete = False
 hosts = 127.0.0.1:9200
 ssl = False
 
+[opensearch]
+hosts = https://admin:admin@127.0.0.1:9200
+ssl = True
+
 [splunk_hec]
 url = https://splunkhec.example.com
 token = HECTokenGoesHere
@@ -220,6 +224,28 @@ The full set of configuration options are:
   - `hosts` - str: A comma separated list of hostnames and ports
       or URLs (e.g. `127.0.0.1:9200` or
       `https://user:secret@localhost`)
+
+    :::{note}
+    Special characters in the username or password must be
+    [URL encoded].
+    :::
+  - `user` - str: Basic auth username
+  - `password` - str: Basic auth password
+  - `apiKey` - str: API key
+  - `ssl` - bool: Use an encrypted SSL/TLS connection
+    (Default: `True`)
+  - `timeout` - float: Timeout in seconds (Default: 60)
+  - `cert_path` - str: Path to a trusted certificates
+  - `index_suffix` - str: A suffix to apply to the index names
+  - `monthly_indexes` - bool: Use monthly indexes instead of daily indexes
+  - `number_of_shards` - int: The number of shards to use when
+    creating the index (Default: `1`)
+  - `number_of_replicas` - int: The number of replicas to use when
+    creating the index (Default: `0`)
+- `opensearch`
+  - `hosts` - str: A comma separated list of hostnames and ports
+    or URLs (e.g. `127.0.0.1:9200` or
+    `https://user:secret@localhost`)
 
     :::{note}
     Special characters in the username or password must be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "lxml>=4.4.0",
     "mailsuite>=1.6.1",
     "msgraph-core==0.2.2",
+    "opensearch-py>=2.4.2,<=3.0.0",
     "publicsuffixlist>=0.10.0",
     "requests>=2.22.0",
     "tqdm>=4.31.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ imapclient>=2.1.0
 dateparser>=1.1.1
 elasticsearch<7.14.0
 elasticsearch-dsl>=7.4.0
+opensearch-py>=2.4.2,<=3.0.0
 kafka-python>=1.4.4
 mailsuite>=1.6.1
 nose>=1.3.7


### PR DESCRIPTION
Closes #480 

The change is tested with the following config:

- Python 3.11 on Alpine Linux 3.18
- OpenSearch 2.11.1
- Grafana 10.3.3 with the `grafana-opensearch-datasource` plugin version 2.14.4

Please see https://github.com/Szasza/dmarc-visualizer-opensearch where an OpenSearch-based dockerized config can be found. By updating the parsedmarc config, and installing the package including these changes it works.