### PR TITLE
IP_ADDRESS_CACHE cache improvements

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -48,7 +48,7 @@ MAGIC_GZIP = b"\x1F\x8B"
 MAGIC_XML = b"\x3c\x3f\x78\x6d\x6c\x20"
 MAGIC_JSON = b"\7b"
 
-IP_ADDRESS_CACHE = ExpiringDict(max_len=10000, max_age_seconds=1800)
+IP_ADDRESS_CACHE = ExpiringDict(max_len=10000, max_age_seconds=14400)
 REVERSE_DNS_MAP = dict()
 
 

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -172,7 +172,8 @@ def get_reverse_dns(ip_address, cache=None, nameservers=None, timeout=2.0):
                              nameservers=nameservers,
                              timeout=timeout)[0]
 
-    except dns.exception.DNSException:
+    except dns.exception.DNSException as e:
+        logger.warning(f"get_reverse_dns({ip_address}) exception: {e}")
         pass
 
     return hostname
@@ -379,10 +380,6 @@ def get_ip_address_info(ip_address, ip_db_path=None,
         if info:
             logger.debug(f"IP address {ip_address} was found in cache")
             return info
-        else:
-            logger.debug(f"IP address {ip_address} not found in cache")
-    else:
-        logger.debug("IP address cache was not specified")
     info = OrderedDict()
     info["ip_address"] = ip_address
     if offline:
@@ -407,8 +404,11 @@ def get_ip_address_info(ip_address, ip_db_path=None,
         info["type"] = service["type"]
         info["name"] = service["name"]
 
-    if cache is not None:
-        cache[ip_address] = info
+        if cache is not None:
+            cache[ip_address] = info
+            logger.debug(f"IP address {ip_address} added to cache")
+    else:
+        logger.debug(f"IP address {ip_address} reverse_dns not found")
 
     return info
 


### PR DESCRIPTION
- Only add entries to the cache if the lookup was successful.  (The ones that fail may work next time.)
- Retain IP_ADDRESS_CACHE entries for up to four hours.  (It takes almost a day to import a day's reports, so the lookups don't need to be extremely fresh.)