### PR TITLE
Multithread the mail-message processing

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -106,6 +106,7 @@ def _parse_report_record(record, ip_db_path=None,
         reverse_dns_map_path=reverse_dns_map_path,
         reverse_dns_map_url=reverse_dns_map_url,
         offline=offline,
+        reverse_dns_map=REVERSE_DNS_MAP,
         nameservers=nameservers,
         timeout=dns_timeout)
     new_record["source"] = new_record_source
@@ -905,6 +906,7 @@ def parse_forensic_report(feedback_report,
             reverse_dns_map_path=reverse_dns_map_path,
             reverse_dns_map_url=reverse_dns_map_url,
             offline=offline,
+            reverse_dns_map=REVERSE_DNS_MAP,
             nameservers=nameservers,
             timeout=dns_timeout)
         parsed_report["source"] = parsed_report_source

--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
-from time import sleep
 from typing import List, Optional
 
 from azure.identity import UsernamePasswordCredential, \
@@ -153,6 +152,9 @@ class MSGraphConnection(MailboxConnection):
     def _get_all_messages(self, url, batch_size):
         messages: list
         params = {
+            # Include message size in result.
+            '$expand':
+                "singleValueExtendedProperties($filter=Id eq 'LONG 0x0E08')",
             '$select': 'id'
         }
         if batch_size and batch_size > 0:
@@ -171,6 +173,12 @@ class MSGraphConnection(MailboxConnection):
             if result.status_code != 200:
                 raise RuntimeError(f'Failed to fetch messages {result.text}')
             messages.extend(result.json()['value'])
+        # Return the largest messages first.
+        messages.sort(
+            key=lambda x:
+                int(x['singleValueExtendedProperties'][0]['value']),
+            reverse=True
+        )
         return messages
 
     def mark_message_read(self, message_id: str):
@@ -215,7 +223,7 @@ class MSGraphConnection(MailboxConnection):
     def watch(self, check_callback, check_timeout):
         """ Checks the mailbox for new messages every n seconds"""
         while True:
-            sleep(check_timeout)
+            # sleep(check_timeout)    don't wait before checking
             check_callback(self)
 
     @lru_cache(maxsize=10)


### PR DESCRIPTION
I have been experimenting with multithreading the mail-message processing.  Each mail message in a batch is processed "in parallel" so that when one thread is waiting for a DNS timeout or other I/O, another one can keep on processing.  I tried multiprocessing too, but could not work out how to share the cache files instead of duplicating (and diluting) them between the processes.  On my system at least, the CPU is not a bottleneck, so full multiprocessing does not provide much more benefit.

Let me know what you think.  There is probably more cleanup to be done.  Maybe a little more restructuring to handle saving the results in the thread.  This may also play into the goal of saving the results before moving or deleting the mail message.