### PR TITLE
build: move to `kafka-python-ng`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "google-auth-oauthlib>=0.4.6",
     "google-auth>=2.3.3",
     "imapclient>=2.1.0",
-    "kafka-python>=1.4.4",
+    "kafka-python-ng>=2.2.2",
     "lxml>=4.4.0",
     "mailsuite>=1.6.1",
     "msgraph-core==0.2.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ dateparser>=1.1.1
 elasticsearch<7.14.0
 elasticsearch-dsl>=7.4.0
 opensearch-py>=2.4.2,<=3.0.0
-kafka-python>=1.4.4
+kafka-python-ng>=2.2.2
 mailsuite>=1.6.1
 nose>=1.3.7
 wheel>=0.37.0


### PR DESCRIPTION
This PR fixes compatibility with Python 3.12 by resolving `ModuleNotFoundError: No module named 'kafka.vendor.six.moves'`.

The [README](https://github.com/dpkp/kafka-python/commit/a6d0579d3cadd3826dd364b01bc12a2173139abc) for `kafka-python` was updated to point to `kafka-python-ng` as the recommended package last month.