### PR TITLE
Fix new config variables previously not propagated in the code

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1290,6 +1290,9 @@ def parse_report_file(input_, nameservers=None, dns_timeout=2.0,
 def get_dmarc_reports_from_mbox(input_, nameservers=None, dns_timeout=2.0,
                                 strip_attachment_payloads=False,
                                 ip_db_path=None,
+                                always_use_local_files=False,
+                                reverse_dns_map_path=None,
+                                reverse_dns_map_url=None,
                                 offline=False):
     """Parses a mailbox in mbox format containing e-mails with attached
     DMARC reports
@@ -1301,6 +1304,9 @@ def get_dmarc_reports_from_mbox(input_, nameservers=None, dns_timeout=2.0,
         dns_timeout (float): Sets the DNS timeout in seconds
         strip_attachment_payloads (bool): Remove attachment payloads from
             forensic report results
+        always_use_local_files (bool): Do not download files
+        reverse_dns_map_path (str): Path to a reverse DNS map file
+        reverse_dns_map_url (str): URL to a reverse DNS map file
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
         offline (bool): Do not make online queries for geolocation or DNS
 
@@ -1327,6 +1333,9 @@ def get_dmarc_reports_from_mbox(input_, nameservers=None, dns_timeout=2.0,
                 sa = strip_attachment_payloads
                 parsed_email = parse_report_email(msg_content,
                                                   ip_db_path=ip_db_path,
+                                                  always_use_local_files=always_use_local_files,
+                                                  reverse_dns_map_path=reverse_dns_map_path,
+                                                  reverse_dns_map_url=reverse_dns_map_url,
                                                   offline=offline,
                                                   nameservers=nameservers,
                                                   dns_timeout=dns_timeout,
@@ -1352,6 +1361,9 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
                                    delete=False,
                                    test=False,
                                    ip_db_path=None,
+                                   always_use_local_files=False,
+                                   reverse_dns_map_path=None,
+                                   reverse_dns_map_url=None,
                                    offline=False,
                                    nameservers=None,
                                    dns_timeout=6.0,
@@ -1369,6 +1381,9 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
         delete (bool): Delete  messages after processing them
         test (bool): Do not move or delete messages after processing them
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
+        always_use_local_files (bool): Do not download files
+        reverse_dns_map_path (str): Path to a reverse DNS map file
+        reverse_dns_map_url (str): URL to a reverse DNS map file
         offline (bool): Do not query online for geolocation or DNS
         nameservers (list): A list of DNS nameservers to query
         dns_timeout (float): Set the DNS query timeout
@@ -1436,6 +1451,9 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
                                               nameservers=nameservers,
                                               dns_timeout=dns_timeout,
                                               ip_db_path=ip_db_path,
+                                              always_use_local_files=always_use_local_files,
+                                              reverse_dns_map_path=reverse_dns_map_path,
+                                              reverse_dns_map_url=reverse_dns_map_url,
                                               offline=offline,
                                               strip_attachment_payloads=sa,
                                               keep_alive=connection.keepalive)
@@ -1559,6 +1577,9 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
             strip_attachment_payloads=strip_attachment_payloads,
             results=results,
             ip_db_path=ip_db_path,
+            always_use_local_files=always_use_local_files,
+            reverse_dns_map_path=reverse_dns_map_path,
+            reverse_dns_map_url=reverse_dns_map_url,
             offline=offline
         )
 
@@ -1570,6 +1591,9 @@ def watch_inbox(mailbox_connection: MailboxConnection,
                 reports_folder="INBOX",
                 archive_folder="Archive", delete=False, test=False,
                 check_timeout=30, ip_db_path=None,
+                always_use_local_files=False,
+                reverse_dns_map_path=None,
+                reverse_dns_map_url=None,
                 offline=False, nameservers=None,
                 dns_timeout=6.0, strip_attachment_payloads=False,
                 batch_size=None):
@@ -1587,6 +1611,9 @@ def watch_inbox(mailbox_connection: MailboxConnection,
         check_timeout (int): Number of seconds to wait for a IMAP IDLE response
             or the number of seconds until the next mail check
         ip_db_path (str): Path to a MMDB file from MaxMind or DBIP
+        always_use_local_files (bool): Do not download files
+        reverse_dns_map_path (str): Path to a reverse DNS map file
+        reverse_dns_map_url (str): URL to a reverse DNS map file
         offline (bool): Do not query online for geolocation or DNS
         nameservers (list): A list of one or more nameservers to use
             (Cloudflare's public DNS resolvers by default)
@@ -1604,6 +1631,9 @@ def watch_inbox(mailbox_connection: MailboxConnection,
                                              delete=delete,
                                              test=test,
                                              ip_db_path=ip_db_path,
+                                             always_use_local_files=always_use_local_files,
+                                             reverse_dns_map_path=reverse_dns_map_path,
+                                             reverse_dns_map_url=reverse_dns_map_url,
                                              offline=offline,
                                              nameservers=nameservers,
                                              dns_timeout=dns_timeout,

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -1222,6 +1222,9 @@ def _main():
                                               dns_timeout=opts.dns_timeout,
                                               strip_attachment_payloads=strip,
                                               ip_db_path=opts.ip_db_path,
+                                              always_use_local_files=opts.always_use_local_files,
+                                              reverse_dns_map_path=opts.reverse_dns_map_path,
+                                              reverse_dns_map_url=opts.reverse_dns_map_url,
                                               offline=opts.offline)
         aggregate_reports += reports["aggregate_reports"]
         forensic_reports += reports["forensic_reports"]
@@ -1309,6 +1312,9 @@ def _main():
                 reports_folder=opts.mailbox_reports_folder,
                 archive_folder=opts.mailbox_archive_folder,
                 ip_db_path=opts.ip_db_path,
+                always_use_local_files=opts.always_use_local_files,
+                reverse_dns_map_path=opts.reverse_dns_map_path,
+                reverse_dns_map_url=opts.reverse_dns_map_url,
                 offline=opts.offline,
                 nameservers=opts.nameservers,
                 test=opts.mailbox_test,
@@ -1360,6 +1366,9 @@ def _main():
                 strip_attachment_payloads=opts.strip_attachment_payloads,
                 batch_size=opts.mailbox_batch_size,
                 ip_db_path=opts.ip_db_path,
+                always_use_local_files=opts.always_use_local_files,
+                reverse_dns_map_path=opts.reverse_dns_map_path,
+                reverse_dns_map_url=opts.reverse_dns_map_url,
                 offline=opts.offline)
         except FileExistsError as error:
             logger.error("{0}".format(error.__str__()))


### PR DESCRIPTION

#523 

The new config variables were not correctly propagated in the code (8.11.0).
```
always_use_local_files - Disables the download of the reverse DNS map
local_reverse_dns_map_path - Overrides the default local file path to use for the reverse DNS map
reverse_dns_map_url - Overrides the default download URL for the reverse DNS map
```

i.e. If you set the config variable `always_use_local_files = True` in the `parsedmarc.ini`, it will always be `False` while parsing the reports using a `mbox` or `mailbox`

There are 2 specific calls to `parse_report_email` that need the new arguments to be passed (in `__init__.py`)
Without passing them, the default value (`False `or `None`) will always be applied.
After that, this code should  be propagated back in the `__init__.py` and `cli.py` files




