### PR TITLE
Added 'since' option to search for messages since a certain time

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -153,6 +153,9 @@ The full set of configuration options are:
   - `check_timeout` - int: Number of seconds to wait for a IMAP
       IDLE response or the number of seconds until the next
       mail check (Default: `30`)
+  - `since` - str: Search for messages since certain time. (Examples: `5m|3h|2d|1w`) 
+      Acceptable units - {"m":"minutes", "h":"hours", "d":"days", "w":"weeks"}). 
+      Defaults to `1d` if incorrect value is provided.
 - `imap`
   - `host` - str: The IMAP server hostname or IP address
   - `port` - int: The IMAP server port (Default: `993`)

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1439,11 +1439,14 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
         _since = 1440  # default one day
         if re.match(r'\d+[mhd]$', since):
             s = re.split(r'(\d+)', since)
-            match s[2]:
-                case 'm': _since = int(s[1])
-                case 'h': _since = int(s[1])*60
-                case 'd': _since = int(s[1])*60*24
-                case 'w': _since = int(s[1])*60*24*7
+                if s[2] == 'm': 
+                    _since = int(s[1])
+                elif s[2] == 'h': 
+                    _since = int(s[1])*60
+                elif s[2] == 'd': 
+                    _since = int(s[1])*60*24
+                elif s[2] == 'w': 
+                    _since = int(s[1])*60*24*7
         else:
             logger.warning("Incorrect format for \'since\' option. \
                            Provided value:{0}, Expected values:(5m|3h|2d|1w). \

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1437,7 +1437,7 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
 
     if since:
         _since = 1440  # default one day
-        if re.match(r'\d{1,2}[mhd]$', since):
+        if re.match(r'\d+[mhd]$', since):
             s = re.split(r'(\d+)', since)
             match s[2]:
                 case 'm': _since = int(s[1])

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1450,7 +1450,9 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
         else:
             logger.warning("Incorrect format for \'since\' option. \
                            Provided value:{0}, Expected values:(5m|3h|2d|1w). \
-                           Ignoring option, fetching messages for last 24hrs"
+                           Ignoring option, fetching messages for last 24hrs" \
+                           "SMTP does not support a time or timezone in since." \
+                           "See https://www.rfc-editor.org/rfc/rfc3501#page-52"
                            .format(since))
 
         if isinstance(connection, IMAPConnection):

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1439,14 +1439,14 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
         _since = 1440  # default one day
         if re.match(r'\d+[mhd]$', since):
             s = re.split(r'(\d+)', since)
-                if s[2] == 'm': 
-                    _since = int(s[1])
-                elif s[2] == 'h': 
-                    _since = int(s[1])*60
-                elif s[2] == 'd': 
-                    _since = int(s[1])*60*24
-                elif s[2] == 'w': 
-                    _since = int(s[1])*60*24*7
+            if s[2] == 'm':
+                _since = int(s[1])
+            elif s[2] == 'h':
+                _since = int(s[1])*60
+            elif s[2] == 'd':
+                _since = int(s[1])*60*24
+            elif s[2] == 'w':
+                _since = int(s[1])*60*24*7
         else:
             logger.warning("Incorrect format for \'since\' option. \
                            Provided value:{0}, Expected values:(5m|3h|2d|1w). \

--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -404,6 +404,7 @@ def _main():
                      mailbox_test=False,
                      mailbox_batch_size=10,
                      mailbox_check_timeout=30,
+                     mailbox_since=None,
                      imap_host=None,
                      imap_skip_certificate_verification=False,
                      imap_ssl=True,
@@ -585,6 +586,8 @@ def _main():
             if "check_timeout" in mailbox_config:
                 opts.mailbox_check_timeout = mailbox_config.getint(
                     "check_timeout")
+            if "since" in mailbox_config:
+                opts.mailbox_since = mailbox_config["since"]
 
         if "imap" in config.sections():
             imap_config = config["imap"]
@@ -1312,6 +1315,7 @@ def _main():
                 nameservers=opts.nameservers,
                 test=opts.mailbox_test,
                 strip_attachment_payloads=opts.strip_attachment_payloads,
+                since=opts.mailbox_since,
             )
 
             aggregate_reports += reports["aggregate_reports"]

--- a/parsedmarc/mail/graph.py
+++ b/parsedmarc/mail/graph.py
@@ -144,17 +144,22 @@ class MSGraphConnection(MailboxConnection):
         folder_id = self._find_folder_id_from_folder_path(folder_name)
         url = f'/users/{self.mailbox_name}/mailFolders/' \
               f'{folder_id}/messages'
+        since = kwargs.get('since')
+        if not since:
+            since = None
         batch_size = kwargs.get('batch_size')
         if not batch_size:
             batch_size = 0
-        emails = self._get_all_messages(url, batch_size)
+        emails = self._get_all_messages(url, batch_size, since)
         return [email['id'] for email in emails]
 
-    def _get_all_messages(self, url, batch_size):
+    def _get_all_messages(self, url, batch_size, since):
         messages: list
         params = {
             '$select': 'id'
         }
+        if since:
+            params['$filter'] = f'receivedDateTime ge {since}'
         if batch_size and batch_size > 0:
             params['$top'] = batch_size
         else:
@@ -165,8 +170,9 @@ class MSGraphConnection(MailboxConnection):
         messages = result.json()['value']
         # Loop if next page is present and not obtained message limit.
         while '@odata.nextLink' in result.json() and (
+                since is not None or (
                 batch_size == 0 or
-                batch_size - len(messages) > 0):
+                batch_size - len(messages) > 0)):
             result = self._client.get(result.json()['@odata.nextLink'])
             if result.status_code != 200:
                 raise RuntimeError(f'Failed to fetch messages {result.text}')
@@ -181,13 +187,15 @@ class MSGraphConnection(MailboxConnection):
             raise RuntimeWarning(f"Failed to mark message read"
                                  f"{resp.status_code}: {resp.json()}")
 
-    def fetch_message(self, message_id: str):
+    def fetch_message(self, message_id: str, **kwargs):
         url = f'/users/{self.mailbox_name}/messages/{message_id}/$value'
         result = self._client.get(url)
         if result.status_code != 200:
             raise RuntimeWarning(f"Failed to fetch message"
                                  f"{result.status_code}: {result.json()}")
-        self.mark_message_read(message_id)
+        mark_read = kwargs.get('mark_read')
+        if mark_read:
+            self.mark_message_read(message_id)
         return result.text
 
     def delete_message(self, message_id: str):

--- a/parsedmarc/mail/imap.py
+++ b/parsedmarc/mail/imap.py
@@ -31,7 +31,11 @@ class IMAPConnection(MailboxConnection):
 
     def fetch_messages(self, reports_folder: str, **kwargs):
         self._client.select_folder(reports_folder)
-        return self._client.search()
+        since = kwargs.get('since')
+        if since:
+            return self._client.search([u'SINCE', since])
+        else:
+            return self._client.search()
 
     def fetch_message(self, message_id):
         return self._client.fetch_message(message_id, parse=False)


### PR DESCRIPTION
- Added `since` option under `mailbox` section to search for messages since a certain time instead of going through the complete mailbox during testing scenarios. Acceptable values -`5m|3h|2d|1w`, units - {"m":"minutes", "h":"hours", "d":"days", "w":"weeks"}). Defaults to `1d` if an incorrect value is provided.
- Not to mark messages as read if test option is selected (works only for MSGraphConnection)