### PR TITLE
Add GELF support

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -98,6 +98,11 @@ path = parsedmarc
 [syslog]
 server = localhost
 port = 514
+
+[gelf]
+host = logger
+port = 12201
+mode = tcp
 ```
 
 The full set of configuration options are:
@@ -343,6 +348,10 @@ The full set of configuration options are:
   :::{note}
     Information regarding the setup of the Data Collection Rule can be found [here](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/tutorial-logs-ingestion-portal).
     :::
+- `gelf`
+  - `host` - str: The GELF server name or IP address
+  - `port` - int: The port to use
+  - `mode` - str: The GELF transport type to use. Valid modes: `tcp`, `udp`, `tls`
 
 :::{warning}
 It is **strongly recommended** to **not** use the `nameservers`

--- a/parsedmarc/gelf.py
+++ b/parsedmarc/gelf.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import logging.handlers
+import json
+import threading
+
+from parsedmarc import parsed_aggregate_reports_to_csv_rows, \
+    parsed_forensic_reports_to_csv_rows, parsed_smtp_tls_reports_to_csv_rows
+from pygelf import GelfTcpHandler, GelfUdpHandler, GelfTlsHandler
+
+
+log_context_data = threading.local()
+
+class ContextFilter(logging.Filter):
+
+    def filter(self, record):
+        record.parsedmarc = log_context_data.parsedmarc
+        return True
+
+
+class GelfClient(object):
+    """A client for the Graylog Extended Log Format"""
+
+    def __init__(self, host, port, mode):
+        """
+        Initializes the GelfClient
+        Args:
+            host (str): The GELF host
+            port (int): The GELF port
+            mode (str): The GELF transport mode
+        """
+        self.host = host
+        self.port = port
+        self.logger = logging.getLogger('parsedmarc_syslog')
+        self.logger.setLevel(logging.INFO)
+        self.logger.addFilter(ContextFilter())
+        self.gelf_mode = {
+            'udp': GelfUdpHandler,
+            'tcp': GelfTcpHandler,
+            'tls': GelfTlsHandler,
+        }
+        self.handler = self.gelf_mode[mode](host=self.host, port=self.port, include_extra_fields=True)
+        self.logger.addHandler(self.handler)
+
+    def save_aggregate_report_to_gelf(self, aggregate_reports):
+        rows = parsed_aggregate_reports_to_csv_rows(aggregate_reports)
+        for row in rows:
+            log_context_data.parsedmarc = row
+            self.logger.info('parsedmarc aggregate report')
+
+        log_context_data.parsedmarc = None
+
+    def save_forensic_report_to_gelf(self, forensic_reports):
+        rows = parsed_forensic_reports_to_csv_rows(forensic_reports)
+        for row in rows:
+            self.logger.info(json.dumps(row))
+
+    def save_smtp_tls_report_to_gelf(self, smtp_tls_reports):
+        rows = parsed_smtp_tls_reports_to_csv_rows(smtp_tls_reports)
+        for row in rows:
+            self.logger.info(json.dumps(row))

--- a/parsedmarc/gelf.py
+++ b/parsedmarc/gelf.py
@@ -12,6 +12,7 @@ from pygelf import GelfTcpHandler, GelfUdpHandler, GelfTlsHandler
 
 log_context_data = threading.local()
 
+
 class ContextFilter(logging.Filter):
 
     def filter(self, record):
@@ -40,7 +41,8 @@ class GelfClient(object):
             'tcp': GelfTcpHandler,
             'tls': GelfTlsHandler,
         }
-        self.handler = self.gelf_mode[mode](host=self.host, port=self.port, include_extra_fields=True)
+        self.handler = self.gelf_mode[mode](host=self.host, port=self.port,
+                                            include_extra_fields=True)
         self.logger.addHandler(self.handler)
 
     def save_aggregate_report_to_gelf(self, aggregate_reports):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "tqdm>=4.31.1",
     "urllib3>=1.25.7",
     "xmltodict>=0.12.0",
+    "pygelf>=0.4.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Implement the ability to log to a GELF server/input, via the use of [pygelf](https://github.com/keeprocking/pygelf).

This is my initial stab at it; similar to `SyslogClient`, I opted to use `parsed_aggregate_reports_to_csv_rows`.

This is all sent in one field to GELF (`parsedmarc`), where then it is normal practice to split the sub-fields out within your logging app (eg. Graylog).

This would be an example Graylog pipeline rule:

```
rule "DMARC GELF"
when
  has_field("parsedmarc")
then
  let json = parse_json(to_string($message.parsedmarc));
  let map = to_map(json);
  set_fields(map, "dmarc_");
end
```