### PR TITLE
Fix the tilde expansion for user home folder

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1713,6 +1713,7 @@ def save_output(results, output_directory="output",
     aggregate_reports = results["aggregate_reports"]
     forensic_reports = results["forensic_reports"]
     smtp_tls_reports = results["smtp_tls_reports"]
+    output_directory = os.path.expanduser(output_directory)
 
     if os.path.exists(output_directory):
         if not os.path.isdir(output_directory):


### PR DESCRIPTION
This will enable the tilde expansion to map the output dir to the home user using `~/path`. (Fix #485)