### PR TITLE
fix: use namespace for separator

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1416,10 +1416,15 @@ def get_dmarc_reports_from_mailbox(connection: MailboxConnection,
     aggregate_report_msg_uids = []
     forensic_report_msg_uids = []
     smtp_tls_msg_uids = []
-    aggregate_reports_folder = "{0}/Aggregate".format(archive_folder)
-    forensic_reports_folder = "{0}/Forensic".format(archive_folder)
-    smtp_tls_reports_folder = "{0}/SMTP-TLS".format(archive_folder)
-    invalid_reports_folder = "{0}/Invalid".format(archive_folder)
+    folder_separator = connection.get_folder_separator()
+    aggregate_reports_folder = "{0}{1}Aggregate".format(archive_folder,
+                                                        folder_separator)
+    forensic_reports_folder = "{0}{1}Forensic".format(archive_folder,
+                                                      folder_separator)
+    smtp_tls_reports_folder = "{0}{1}SMTP-TLS".format(archive_folder,
+                                                      folder_separator)
+    invalid_reports_folder = "{0}{1}Invalid".format(archive_folder,
+                                                    folder_separator)
 
     if results:
         aggregate_reports = results["aggregate_reports"].copy()

--- a/parsedmarc/mail/imap.py
+++ b/parsedmarc/mail/imap.py
@@ -26,6 +26,14 @@ class IMAPConnection(MailboxConnection):
                                   timeout=timeout,
                                   max_retries=max_retries)
 
+    def get_folder_separator(self):
+        try:
+            namespaces = self._client.namespace()
+            personal = namespaces.personal[0]
+            return personal[1]
+        except (IndexError, NameError):
+            return '/'
+
     def create_folder(self, folder_name: str):
         self._client.create_folder(folder_name)
 

--- a/parsedmarc/mail/mailbox_connection.py
+++ b/parsedmarc/mail/mailbox_connection.py
@@ -6,6 +6,9 @@ class MailboxConnection(ABC):
     """
     Interface for a mailbox connection
     """
+    def get_folder_separator(self):
+        return "/"
+
     def create_folder(self, folder_name: str):
         raise NotImplementedError
 


### PR DESCRIPTION
Use the IMAP namespace separator based on the information retrieved from the IMAP command to retrieve namespaces, falling back to '/' if the command isn't available or the results don't include the private namespace.

Resolves #551 
