### PR TITLE
Do not stop processing when we encounter an invalid dmarc report

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1294,7 +1294,7 @@ def parse_report_email(
                     "is not a valid "
                     "aggregate DMARC report: {1}".format(subject, e)
                 )
-                raise ParserError(error)
+                raise InvalidDMARCReport(error)
 
             except Exception as e:
                 error = "Unable to parse message with " 'subject "{0}": {1}'.format(


### PR DESCRIPTION
We receive a lot of non compliant reports we have no control over. Those reports currently abort parsing and prevent us from checking the rest of the reports:

```
+ parsedmarc --offline split/dmarc.mbox.2024-02
Traceback (most recent call last):
  File "/home/bendem/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 528, in parse_aggregate_report_xml
    raise InvalidAggregateReport(_error)
parsedmarc.InvalidAggregateReport: Time span > 24 hours - RFC 7489 section 7.2

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bendem/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 1272, in parse_report_email
    aggregate_report = parse_aggregate_report_xml(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bendem/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 621, in parse_aggregate_report_xml
    raise InvalidAggregateReport("Unexpected error: {0}".format(error.__str__()))
parsedmarc.InvalidAggregateReport: Unexpected error: Time span > 24 hours - RFC 7489 section 7.2

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bendem/.local/bin/parsedmarc", line 8, in <module>
    sys.exit(_main())
             ^^^^^^^
  File "/home/bendem/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/cli.py", line 1440, in _main
    reports = get_dmarc_reports_from_mbox(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bendem/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 1462, in get_dmarc_reports_from_mbox
    parsed_email = parse_report_email(
                   ^^^^^^^^^^^^^^^^^^^
  File "/home/bendem/.local/pipx/venvs/parsedmarc/lib64/python3.11/site-packages/parsedmarc/__init__.py", line 1297, in parse_report_email
    raise ParserError(error)
parsedmarc.ParserError: Message with subject "Report Domain: liege.be Submitter: armonea.be Report-ID:
 <2024.2.1.168009>" is not a valid aggregate DMARC report: Unexpected error: Time span > 24 hours - RFC 7489 section 7.2
```

This patch correctly transforms the exception when parsing an invalid dmarc report from `InvalidAggregateReport` to `InvalidDMARCReport` instead of `ParserError`, which causes the `get_dmarc_reports_from_mbox` loop to continue processing and displays a warning.