### PR TITLE
Error Caused by too Many Headers from Elasticsearch/OpenSearch

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -14,6 +14,7 @@ import json
 from ssl import CERT_NONE, create_default_context
 from multiprocessing import Pipe, Process
 import sys
+import http.client
 from tqdm import tqdm
 
 from parsedmarc import (
@@ -47,6 +48,8 @@ from parsedmarc.mail.graph import AuthMethod
 from parsedmarc.log import logger
 from parsedmarc.utils import is_mbox, get_reverse_dns
 from parsedmarc import SEEN_AGGREGATE_REPORT_IDS
+
+http.client._MAXHEADERS = 200 # pylint:disable=protected-access
 
 formatter = logging.Formatter(
     fmt="%(levelname)8s:%(filename)s:%(lineno)d:%(message)s",


### PR DESCRIPTION
Since the last update I get the following error quite often:

`ERROR:cli.py:134:Elasticsearch Error: Elasticsearch's search for existing report error: ConnectionError(('Connection aborted.', HTTPException('got more than 100 headers'))) caused by: ProtocolError(('Connection aborted.', HTTPException('got more than 100 headers')))`

Googling around reveals that this some kind of issue in the Python http where you cannot set the maximum allowed headers. Elasticsearch (OpenSearch in my case) seems to send more than the default 100 headers. Since this change the error does no longer occur in my Docker Compose deployment.