### PR TITLE
Fix SyntaxError in elastic forensic report

### DIFF
--- a/parsedmarc/elastic.py
+++ b/parsedmarc/elastic.py
@@ -661,11 +661,10 @@ def save_forensic_report_to_elasticsearch(
         try:
             forensic_doc.save()
         except Exception as e:
-            raise ElasticsearchError("Elasticsearch error: {0}".format(e.__str__())
+            raise ElasticsearchError("Elasticsearch error: {0}".format(e.__str__()))
     except KeyError as e:
         raise InvalidForensicReport(
             "Forensic report missing required field: {0}".format(e.__str__()))
-        )
 
 
 def save_smtp_tls_report_to_elasticsearch(


### PR DESCRIPTION
This PR fixes a `SyntaxError` that occurs in `parsedmarc/elastic.py` within the `save_forensic_report_to_elasticsearch` function.