### PR TITLE
Fix since option to correctly work with weeks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 - Fix CSV download
 
+- Fix since option to correctly work with weeks
+
 8.18.4
 ------
 
@@ -693,7 +695,7 @@ in the ``elasticsearch`` configuration file section (closes issue #78)
 -----
 
 - Add filename and line number to logging output
-- Improved IMAP error handling  
+- Improved IMAP error handling
 - Add CLI options
 
   ```text

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -1580,7 +1580,7 @@ def get_dmarc_reports_from_mailbox(
 
     if since:
         _since = 1440  # default one day
-        if re.match(r"\d+[mhd]$", since):
+        if re.match(r"\d+[mhdw]$", since):
             s = re.split(r"(\d+)", since)
             if s[2] == "m":
                 _since = int(s[1])


### PR DESCRIPTION
The regex for the since option was missing the `w` so when the since option would be set to something like `1w`  the "Incorrect format for 'since' option." error would be triggered.