### PR TITLE
Sorted usage of TLS on SMTP

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -1586,6 +1586,7 @@ def _main():
                 username=opts.smtp_user,
                 password=opts.smtp_password,
                 subject=opts.smtp_subject,
+                require_encryption=opts.smtp_ssl,
             )
         except Exception:
             logger.exception("Failed to email results")


### PR DESCRIPTION
Added a line for the `email_results` function to take into account the smtp_ssl setting, based on the proposed solutions on issue #258 