### PR TITLE
updates process_reports to respect newly added prettify_json option

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -620,7 +620,7 @@ def _main():
         la_dcr_forensic_stream=None,
         la_dcr_smtp_tls_stream=None,
         gelf_host=None,
-        gelf_port=None,p
+        gelf_port=None,
         gelf_mode=None,
         webhook_aggregate_url=None,
         webhook_forensic_url=None,


### PR DESCRIPTION
I want to facilitate the parsing of JSON logs directly with Grafana Alloy + Loki. To do this, it would be beneficial to output the JSON logs as a single line to be then parsed within Grafana. Currently, because the report is "prettified" it treats each new line of the log, as a different log entry within grafana. Collapsing the log to a single line, will allow it to be parsed properly within Grafana.