### PR TITLE
fix: webhook timeout parsing

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -1182,7 +1182,7 @@ def _main():
             if "smtp_tls_url" in webhook_config:
                 opts.webhook_smtp_tls_url = webhook_config["smtp_tls_url"]
             if "timeout" in webhook_config:
-                opts.webhook_timeout = webhook_config["timeout"]
+                opts.webhook_timeout = webhook_config.getint("timeout")
 
     logger.setLevel(logging.ERROR)
 


### PR DESCRIPTION
The example config values for `webhook` uses the field `timeout`. I kept getting the error `ERROR:webhook.py:51:Webhook Error: Timeout value connect was 60, but it must be an int, float or None.` when using `timeout = 60` and had to remove that field to make the process work, because the field is parsed as a `String`.

I'm not 100% used to this setup so feel free to let me know if this doesn't fully cover the bug.

Thanks for the work on the repo!