### PR TITLE
Validate that string is base64

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -892,7 +892,7 @@ def extract_report(content: Union[bytes, str, BinaryIO]) -> str:
     try:
         if isinstance(content, str):
             try:
-                file_object = BytesIO(b64decode(content))
+                file_object = BytesIO(b64decode(content, validate=True))
             except binascii.Error:
                 return content
             header = file_object.read(6)


### PR DESCRIPTION
Default behaviour for `b64decode` is to discard all characters that are not in the the base64 alphabet before doing a padding check. If, by chance, the remaining characters pass this check, the input is processed without error. This may cause non-base64 input to be processed as base64 by mistake.
See documentation [here](https://docs.python.org/3/library/base64.html#base64.b64decode).

The following xml snippet will fail to be parsed if it is compressed before parsing with `parsedmarc test.xml.gz`:
```xml
<?xml version="1.0" encoding="UTF-8" ?>
<feedback>
  <version>1.0</version>
  <report_metadata>
    <org_name>xxxxxx.xx</org_name>
    <email>xxxxxx-xxxxxx@xxxxxx.xx</email>
    <extra_contact_info>xxxxx@xxxxxx.xx</extra_contact_info>
    <report_id>x11x11$x1111x1=x1x1111x111x1xxx@xxxxxx.xx</report_id>
    <date_range>
      <begin>1111111111</begin>
      <end>1111111111</end>
    </date_range>
  </report_metadata>
  <policy_published>
    <domain>xxx.xxxxxx.xx</domain>
    <adkim>r</adkim>
    <aspf>r</aspf>
    <p>reject</p>
    <sp></sp>
    <pct>100</pct>
  </policy_published>
  <record>
    <row>
      <source_ip>10.100.10.1</source_ip>
      <count>1</count>
      <policy_evaluated>
        <disposition>none</disposition>
        <dkim>pass</dkim>
        <spf>pass</spf>
      </policy_evaluated>
    </row>
    <identifiers>
      <header_from>xxx.xxxxxx.xx</header_from>
      <envelope_from></envelope_from>
    </identifiers>
    <auth_results>
      <dkim>
        <domain>xxx.xxxxxx.xx</domain>
        <selector>x1</selector>
        <result>pass</result>
      </dkim>
      <spf>
        <domain>xx1.xx.xxx.xx</domain>
        <scope>helo</scope>
        <result>none</result>
      </spf>
    </auth_results>
  </record>
</feedback>
``` 
with the following error message:
```
ERROR:cli.py:1580:Failed to parse test.xml.gz - not a valid report.
```

This pull-request should fix this issue by setting `validate=True` in `b64decode` where applicable.