### PR TITLE
remove newlines before b64decode

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -892,7 +892,11 @@ def extract_report(content: Union[bytes, str, BinaryIO]) -> str:
     try:
         if isinstance(content, str):
             try:
-                file_object = BytesIO(b64decode(content, validate=True))
+                file_object = BytesIO(
+                    b64decode(
+                        content.replace("\n", "").replace("\r", ""), validate=True
+                    )
+                )
             except binascii.Error:
                 return content
             header = file_object.read(6)


### PR DESCRIPTION
Fix for errors in parsing b64-strings caused by [PR-648](https://github.com/domainaware/parsedmarc/pull/648).
This removes newlines before trying `b64decode`, since `b64decode` with `validate=True` does not accept any characters that are not in the base64 alphabet (even newlines).