### PR TITLE
Use correct key names for elasticsearch/opensearch api keys

### DIFF
--- a/parsedmarc/cli.py
+++ b/parsedmarc/cli.py
@@ -1058,10 +1058,10 @@ def _main():
                 opts.elasticsearch_password = elasticsearch_config["password"]
             # Until 8.20
             if "apiKey" in elasticsearch_config:
-                opts.elasticsearch_apiKey = elasticsearch_config["apiKey"]
+                opts.elasticsearch_api_key = elasticsearch_config["apiKey"]
             # Since 8.20
             if "api_key" in elasticsearch_config:
-                opts.elasticsearch_apiKey = elasticsearch_config["api_key"]
+                opts.elasticsearch_api_key = elasticsearch_config["api_key"]
 
         if "opensearch" in config:
             opensearch_config = config["opensearch"]
@@ -1098,10 +1098,10 @@ def _main():
                 opts.opensearch_password = opensearch_config["password"]
             # Until 8.20
             if "apiKey" in opensearch_config:
-                opts.opensearch_apiKey = opensearch_config["apiKey"]
+                opts.opensearch_api_key = opensearch_config["apiKey"]
             # Since 8.20
             if "api_key" in opensearch_config:
-                opts.opensearch_apiKey = opensearch_config["api_key"]
+                opts.opensearch_api_key = opensearch_config["api_key"]
 
         if "splunk_hec" in config.sections():
             hec_config = config["splunk_hec"]


### PR DESCRIPTION
Resolves a bug introduced in #631 that prevents Elasticsearch API keys from being used. The `opts` key names were updated at the point of definition and read, but not at assignment.

Tested this locally against Elasticsearch 8.11.3. I haven't tested against Opensearch but the bug looks identical. I didn't see any test cases to update for this realm of functionality.

Fixes #653