### PR TITLE
Fix Python 3.14 support metadata and require imapclient 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ for RHEL or Debian.
 | 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12) |
 | 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)    |
 | 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13) |
-| 3.14    | ✅         | Actively maintained                                        |
+| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                  |

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -61,7 +61,7 @@ for RHEL or Debian.
 | 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12) |
 | 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)    |
 | 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13) |
-| 3.14    | ✅         | Actively maintained                                        |
+| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                  |
 
 ```{toctree}
 :caption: 'Contents'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "hatchling>=1.27.0",
 ]
-requires_python = ">=3.10,<3.14"
+requires_python = ">=3.10,<3.15"
 build-backend = "hatchling.build"
 
 [project]
@@ -45,7 +45,7 @@ dependencies = [
     "google-auth-httplib2>=0.1.0",
     "google-auth-oauthlib>=0.4.6",
     "google-auth>=2.3.3",
-    "imapclient>=2.1.0",
+    "imapclient>=3.1.0",
     "kafka-python-ng>=2.2.2",
     "lxml>=4.4.0",
     "mailsuite>=1.11.2",


### PR DESCRIPTION
## Summary

  - Require imapclient>=3.1.0 to ensure Python 3.14 compatibility for IMAP TLS.
  - Align package metadata by changing build-system.requires_python from >=3.10,<3.14 to >=3.10,<3.15.
  - Update Python 3.14 compatibility notes in README/docs to match the actual dependency requirement.

  ## Problem

  The repository currently indicates Python 3.14 support in CI/docs, but dependency metadata still permits older imapclient versions that can fail on Python 3.14 with:

  AttributeError: property 'file' of 'IMAP4_TLS' object has no setter

  This behavior is addressed in imapclient 3.1.0.

  ## Why this change

  - Prevent runtime failures on Python 3.14 caused by older imapclient.
  - Keep packaging metadata consistent with documented and tested support.
  - Reduce confusion for users installing on Python 3.14.

  ## Files changed

  - pyproject.toml
      - requires_python = ">=3.10,<3.15"
      - imapclient>=3.1.0
  - README.md
      - Clarify Python 3.14 support note (requires imapclient>=3.1.0)
  - docs/source/index.md
      - Same compatibility clarification as README

  ## Validation

  - Built docs locally: cd docs && make html
  - Ran unit test sanity check: python -m unittest tests.Test.testBase64Decoding -v