### PR TITLE
Tune Codecov status checks for small PRs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: false


### PR DESCRIPTION
## Summary
- add a repository-level `codecov.yml`
- keep patch coverage as the meaningful status for small PRs
- mark project coverage status as informational to reduce noise from stale base comparisons

Closes #675