### PR TITLE
Fix map-maintenance tooling and stale classifications

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -23,7 +23,6 @@ base_reverse_dns,name,type
 47.pl,AfterMarket.pl,Web Host
 4gbhost.com,4GBHost,Web Host
 99cloudhosting.com,99CloudHosting,Web Host
-United-domains.de,United Domains,Web Host
 a-hadar.co.il,Hadar Group,Real Estate
 a2hosting.com,A2Hosting,Web Host
 a2mobile.pl,a2mobile,ISP
@@ -630,7 +629,7 @@ dfn.nl,DELTA Fiber,ISP
 dgeduf.or.kr,Daegu Dong-gu Education Foundation,Education
 dgsys.es,DGsys,Web Host
 dhamma.org,Vipassana Meditation,Nonprofit
-dhl.com,DHL,logistics
+dhl.com,DHL,Logistics
 diako-dresden.de,Diakonissenanstalt Dresden,Healthcare
 diakovere.de,DIAKOVERE,Healthcare
 dialego.de,Dialego,Marketing
@@ -980,7 +979,7 @@ getkeepsafe.com,Keepsafe Software,SaaS
 getordained.org,Universal Life Church,Religion
 getresponse.com,GetResponse,Marketing
 ggsv.jp,Techorus,Web Host
-ghm-grenoble.fr,Groupe hospitalier mutualiste de Grenoble,healthcare
+ghm-grenoble.fr,Groupe hospitalier mutualiste de Grenoble,Healthcare
 giantpartners.com,Giant Partners,Marketing
 gigahost.dk,GigaHost,Web Host
 glasgow-ky.com,Glasgow EPB,ISP
@@ -1504,7 +1503,7 @@ loading.es,Loading,Web Host
 locaweb.com.br,Locaweb,Web Host
 locus-t.com.my,LOCUS-T,Marketing
 locustwalk.cc,Locust Walk,Finance
-lodestonegroup.com,Loadstone Insurance,Insurance
+lodestonegroup.com,Loadstone Insurance,Finance
 loftsinc.com,"Lofts, Inc.",Retail
 logika.ro,Logika IT Solutions,MSP
 logisticintegrators.com,Logistics Integrators,Logistics
@@ -2246,7 +2245,7 @@ regionaltelecom.net.br,Regional Telecom,ISP
 register.it,Register.it,Web Host
 registeredsite.com,Web.com,Web Host
 registrar-servers.com,Namecheap,Web Host
-regusnet.com,Regus,Real estate
+regusnet.com,Regus,Real Estate
 regxa.com,Regxa Cloud,Web Host
 relativity.one,RelativityOne,SaaS
 relmax.net,Relmax,Web Host
@@ -2282,7 +2281,7 @@ rrtelecomrs.net.br,RR Telecom,ISP
 rsa.com,RSA,Technology
 rsgsv.net,Intuit Mailchimp,Marketing
 rssulnet.com.br,RS Sul Net,ISP
-rt.ru,RT,Government Media
+rt.ru,Rostelecom,ISP
 rtctel.com,Ringgold Telephone Company,ISP
 ruelala.com,Rue La La,Retail
 runbox.com,Runbox,Email Provider
@@ -2838,6 +2837,7 @@ unin.hr,Sveučilište Sjever,Education
 unina.it,University of Naples Federico II,Education
 uninet-ide.com.mx,Telmex,ISP
 unionbank.com.bd,Union Bank,Finance
+United-domains.de,United Domains,Web Host
 united.net,United Communications,ISP
 unitedyacht.com,United Yacht Sales,Retail
 unitel.com.la,Unitel,ISP

--- a/parsedmarc/resources/maps/base_reverse_dns_types.txt
+++ b/parsedmarc/resources/maps/base_reverse_dns_types.txt
@@ -32,6 +32,7 @@ Physical Security
 Print
 Publishing
 Real Estate
+Religion
 Retail
 SaaS
 Science
@@ -41,4 +42,5 @@ Sports
 Staffing
 Technology
 Travel
+Utilities
 Web Host

--- a/parsedmarc/resources/maps/sortlists.py
+++ b/parsedmarc/resources/maps/sortlists.py
@@ -156,11 +156,9 @@ def _main():
     types_file = "base_reverse_dns_types.txt"
 
     with open(types_file) as f:
-        types = f.readlines()
-        while "" in types:
-            types.remove("")
+        types = [line.strip() for line in f if line.strip()]
 
-    map_allowed_values = {"Type": types}
+    map_allowed_values = {"type": types}
 
     for list_file in list_files:
         if not os.path.exists(list_file):
@@ -175,7 +173,12 @@ def _main():
         print(f"Error: {map_file} does not exist")
         exit(1)
     try:
-        sort_csv(map_file, map_key, allowed_values=map_allowed_values)
+        sort_csv(
+            map_file,
+            map_key,
+            case_insensitive_sort=True,
+            allowed_values=map_allowed_values,
+        )
     except CSVValidationError as e:
         print(f"{map_file} did not validate: {e}")
 


### PR DESCRIPTION
## Summary

Fixes three bugs in `sortlists.py` that silently disabled `type`-column validation on `base_reverse_dns_map.csv`, sorts the map consistently with documented behavior, and corrects nine pre-existing stale or malformed map entries that were only noticed because the validator wasn't running.

### sortlists.py bugs

1. **Validator column mis-cased.** `map_allowed_values = {"Type": types}` — the CSV header is `type` (lowercase), so the allowed-values check never matched any column and silently passed every row.
2. **Types read with trailing newlines.** `types = f.readlines()` returned values like `"ISP\n"`, which wouldn't have matched trimmed row values even if the column name had been correct. Now stripped at read time.
3. **Sort order didn't match the spec.** README and AGENTS.md both state the map is sorted alphabetically case-insensitive, but `sort_csv` was called without `case_insensitive_sort=True`. Fixing it moves exactly one row: `United-domains.de` (the file's sole mixed-case key) from the top of the file into the "united" range.

Added a verification that the validator now actually flags bad rows — with the fixes in place, injecting a row like `dhl.com,DHL,NotAType` produces `base_reverse_dns_map.csv did not validate: Line 632: 'NotAType' is not an allowed value for 'type'`.

### Stale classifications surfaced by the now-working validator

| Row | Before | After | Reason |
|---|---|---|---|
| `dhl.com` | `logistics` | `Logistics` | Casing |
| `ghm-grenoble.fr` | `healthcare` | `Healthcare` | Casing |
| `regusnet.com` | `Real estate` | `Real Estate` | Casing |
| `lodestonegroup.com` | `Insurance` | `Finance` | `Insurance` is not in the README's industry list; Finance is the closest listed category for an insurance brokerage |
| `rt.ru` | `RT,Government Media` | `Rostelecom,ISP` | `rt.ru` is Rostelecom (Russian telco) — RT / Russia Today uses `rt.com`. The row was misclassifying a major ISP as state media |

### types.txt ↔ README sync

`Religion` and `Utilities` are listed as industries in `README.md` but were missing from `base_reverse_dns_types.txt`. README explicitly states types.txt "should match the industry list in this README". Added both. This also legitimizes three rows (`atonementonline.com`, `getordained.org`, `gospellight.sg` typed `Religion`, and `xcelenergy.com` typed `Utilities`) that had been silently invalid until the validator was fixed.

## Test plan

- [x] `python sortlists.py` runs clean on the repo
- [x] Manually injecting an invalid `type` value now triggers the validator (`... did not validate: Line N: 'NotAType' is not an allowed value for 'type' ...`)
- [x] `ruff check` and `ruff format --check` pass
- [x] Map file preserves CRLF line endings, no bare LFs, 3,133 unique keys
- [x] Case-insensitive sort verified via `keys == sorted(keys, key=str.lower)`
- [x] All rows have a `type` that appears in `base_reverse_dns_types.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)