### PR TITLE
Add second-pass ASN-domain aliases for top remaining misses

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -54,6 +54,7 @@ acessoline.net.br,Alt Telecom,ISP
 ach.or.jp,Ageo Central General Hospital,Healthcare
 acim-pr.org.br,ACIM,Nonprofit
 ackermancancer.com,Ackerman Cancer Center,Healthcare
+aco.net,ACOnet,Education
 acornhost.com,Acorn Host,Web Host
 acropolis.org,New Acropolis,Education
 actcorp.in,ACT Fibernet,ISP
@@ -80,6 +81,7 @@ aeroinc.net,The Areo Group,Industrial
 aesbg.net,AESNET,ISP
 aeza.network,Aeza,Web Host
 af-k.de,I-NetPartner GmbH,ISP
+af.mil,U.S. Air Force,Defense
 afes.com,AFES Network Services,ISP
 afghan-wireless.com,Afghan Wireless,ISP
 afinet.com.br,OnTelecom,ISP
@@ -120,6 +122,7 @@ aknet.kg,AkNet,ISP
 akomp.com.pl,AKOMP,ISP
 akura.ne.jp,Akura,Logistics
 albatros.uz,Albatros Health Care,Healthcare
+alberta.ca,Government of Alberta,Government
 alcansservicos.com.br,Alcans Telecom,ISP
 alcanstelecom.com.br,Alcans Telecom,ISP
 alconn.it,Alconn,ISP
@@ -182,13 +185,16 @@ aopa.org,AOPA,Travel
 apaudit.eu,Transparent,Finance
 apexsol.com,Apex Technology,Marketing
 aplusgroup.net,A Plus International,Healthcare
+apnic.net,APNIC,Nonprofit
 apogeehost.com,ApogeeHOST,Web Host
+apol.com.tw,APOL,ISP
 apple.com,Apple,Email Provider
 applefibernet.com,Apple Fibernet,ISP
 applicationx.net,Application X,MSP
 appriver.com,OpenText AppRiver,Email Security
 aps-inc.co.jp,Arahi Polyslider,Industrial
 aptalaska.net,AP&T,ISP
+aptg.com.tw,APBT,ISP
 aptum.com,Aptum,Web Host
 aqmhost.net,AqmHost,Web Host
 aragon.es,Government of Aragon,Government
@@ -238,6 +244,7 @@ atw.ne.jp,ATW,Web Host
 au-net.ne.jp,KDDI,ISP
 au.com,au,ISP
 auone-net.jp,KDDI,ISP
+aureon.com,Aureon,ISP
 auriga.com,Auriga,Technology
 aussiebb.com.au,Aussie Broadband,ISP
 aussiebroadband.com.au,Aussie Broadband,ISP
@@ -286,6 +293,7 @@ bcs.org,BCS,Nonprofit
 bdcom.com,BDCOM Online,ISP
 bdconnectctg.net,BDconnect,ISP
 bdvco.com,Biodyne,Healthcare
+beanfield.com,Beanfield,ISP
 bearingdepot.com,Bearing Depot & Supply,Retail
 beaumont.org,Corewell Health (Formerly Beaumont),Healthcare
 bedbathandbeyond.com,Bed Bath & Beyond,Retail
@@ -533,6 +541,7 @@ cloudhost.web.id,PT Cloud Hosting Indonesia,Web Host
 clouditalia.com,Retelit,Web Host
 cloudwaysapps.com,Cloudways,Web Host
 cloudwebhosting.com,NameHero,Web Host
+clouvider.com,Clouvider,Web Host
 clsvrsystems.net,GMO Cloud,IaaS
 clubexpress.com,ClubExpress,SaaS
 clubnet.mz,ClubNet,ISP
@@ -617,6 +626,7 @@ convergent-interfreight.com,Convergent Interfreight,Logistics
 convergentindia.com,Convergent Wireless,MSP
 cooolbox.bg,Cooolbox,ISP
 coopenet.com.ar,Coopenet,ISP
+corbina.net,Beeline,ISP
 corbina.ru,PJSC VimpelCom,ISP
 corblock.com,Corblock,Industrial
 cordialmail.net,Cordial,Marketing
@@ -694,11 +704,14 @@ dakotapro.biz,DakotaPro,ISP
 dal.net.tr,DALNET,Web Host
 damcogroup.com,Damco Solutions,MSP
 damel.com,Damel Group,Food
+danskkabeltv.dk,DKTV,ISP
 daouoffice.com,Dooray,SaaS
 daraju.com,Daraju,Healthcare
 darysoft.com,Dary Web Designs,Web Host
 data443.com,Data443,Email Security
+datacamp.co.uk,CDN77,Web Host
 datanat.com,Datanational Corporation,MSP
+datapipe.com,Rackspace,Web Host
 datawagon.net,DataWagon,Web Host
 datayard.us,DataYard,MSP
 datev.de,DATEV,SaaS
@@ -739,6 +752,7 @@ digi.ro,DIGI Romania,ISP
 digicelbroadband.com,Digicel,ISP
 digijadoo.net,Jadoo Digital,ISP
 digikabel.hu,One Hungary (Formerly DIGI),ISP
+digimobil.es,DIGI Spain,ISP
 digitalairstrike.com,Digital Air Strike,Marketing
 digitalmotion.co,Digital Motion Events,Event Planning
 digitalocean.com,DigitalOcean,Web Host
@@ -758,6 +772,7 @@ discoverflow.co,Flow,ISP
 discovergreene.com,"Greene County, New York",Government
 disenosweb.mx,Hive Studio,Web Host
 dishemail.com,DISH,ISP
+distributel.ca,Distributel,ISP
 ditscloud.com,DITSCloud,MSP
 divdav.com,DIV DAV,Marketing
 divide0.net,Divide Zero Networks,Web Host
@@ -859,6 +874,7 @@ edu.com,InstructionalAssistant,SaaS
 eduneering.com,UL EHS training,SaaS
 eforw.com,Eforw,Email Provider
 egasolutions.com.br,EGA Solutions,Logistics
+egihosting.com,EGIHosting,Web Host
 egov.com,Tyler Technologies,SaaS
 egress.cloud,Egress Software,Email Security
 egress.com,"Egress, a KnowBe4 Company",Email Security
@@ -989,6 +1005,7 @@ fareastone.com.tw,FarEasTone,ISP
 fast.net.id,Linknet-Fastnet,ISP
 fast.net.kg,Skynet Telecom,ISP
 fast.net.uk,FASTNET,ISP
+fastly.com,Fastly,SaaS
 fastnet.kg,FastNet,ISP
 fastspeed.dk,Fastspeed,ISP
 fastvps-server.com,P.A.G.M. OU,Web Host
@@ -1010,6 +1027,7 @@ fibertel.com.ar,Personal,ISP
 fiberup.com.br,Fiber UP,ISP
 fiberway.com.ar,Fiberway,ISP
 fibextelecom.net,Fibex Telecom,ISP
+fibia.dk,Fibia,ISP
 fibralink.net.br,Fibralink,ISP
 fibramax.ec,Fibramax,ISP
 fibranett.net.br,Fibranett,ISP
@@ -1197,6 +1215,7 @@ hammacher.com,Hammacher Schlemmer,Retail
 han-solo.net,hostNET,Web Host
 hanami.run,Mailwip (Formerly Hanami),Email Provider
 hanastar.net.id,HSnet,ISP
+hankyu-hanshin.co.jp,Hankyu Hanshin,Conglomerate
 hap.be,CHU Ambroise Paré,Healthcare
 harrishealth.org,Harris Health System,Healthcare
 harvard.edu,Harvard University,Education
@@ -1251,6 +1270,7 @@ hmcaguas.com,Puerto Rico Telephone Company,ISP
 hoaspace.com,HOA Space,SaaS
 hokudai.ac.jp,Hokkaido University,Education
 hol.gr,Vodafone,ISP
+home.cern,CERN,Science
 home.pl,home.pl,Web Host
 homesteadhealthcareservices.com,Homestead Health Care Services,Healthcare
 honeycrm.com,HoneyCRM,SaaS
@@ -1412,6 +1432,7 @@ instantprint.com,Instant Print Corp,Print
 intechonline.net,Intech Online,ISP
 integra.net.au,integra,MSP
 integratedlifecare.ca,Integrated Life Care,Healthcare
+inteliquent.com,Inteliquent,ISP
 intellicentre.net.au,Macquarie Technology,IaaS
 intellisurvey.com,InteliSurvey,SaaS
 inter.net.il,Internet Gold,ISP
@@ -1421,9 +1442,11 @@ interdeal.co.il,Interdeal,Finance
 interhost.it,Genesys Informatica Srl,MSP
 interkam.pl,Interkam,ISP
 intermetalsa.co.mz,Intermetal,Construction
+internap.com,Internap,Web Host
 internet-webhosting.com,iWHOST,Web Host
 internet.co.za,Axxess,ISP
 internet.fo,Føroya Tele,ISP
+internet.gmo,GMO Internet,ISP
 internet10.net.br,Internet 10,ISP
 internetlocal.com.ar,Internet Local,ISP
 internetmailserver.net,Internet Mail Server Networks,Email Provider
@@ -1434,6 +1457,7 @@ investinmiddlesex.ca,"Middlesex County, Canada",Government
 inwi.ma,Inwi,ISP
 inxserver.de,Inxmail,Marketing
 ioflood.net,I/O Flood,Web Host
+ioh.co.id,IM3,ISP
 iomart.com,iomart,Web Host
 ionblade.com,IonBLADE,Web Host
 ionos.com,IONOS,Web Host
@@ -1578,6 +1602,7 @@ keio.ac.jp,Keio University,Education
 keio.jp,Keio University,Education
 keliweb.com,Keliweb,Web Host
 kendall.cz,GPS Praha,Healthcare
+kenet.or.ke,KENET,Education
 kennesawtrans.com,Kennesaw Transportation,Logistics
 kennypweb.com,Kenny P Computer Services,Web Host
 keralavisionisp.com,Keralavision Broadband,ISP
@@ -1695,6 +1720,7 @@ linkedin.com,LinkedIn,Social Media
 linode.com,Linode,Web Host
 linodeusercontent.com,Linode,Web Host
 linqtelecom.com.br,LinQ Telecom,ISP
+liquidtelecom.com,Liquid Intelligent Technologies,ISP
 liquidtelecom.net,Liquid Intelligent Technologies,ISP
 liteserverdns.in,The PowerHost,Web Host
 litiumdrift.se,Litium,SaaS
@@ -2037,6 +2063,7 @@ nano.uz,Nano Telecom,ISP
 nap.net.tw,Taiwan Network Access Point,ISP
 nasa.gov,NASA,Government
 nascoeducation.com,Nasco EDucation,Education
+nask.pl,NASK,Education
 nasstar.com,Nasstar,MSP
 nastech.bg,Nastech Plus,ISP
 nationalhha.com,National Home Health,Healthcare
@@ -2364,6 +2391,7 @@ peteralan.co.uk,Peter Alan,Real Estate
 petroed.com,PetroEd,Education
 pfcloud.io,pfcloud,Web Host
 pfmsys.com,Professional Flight Management (PFM),Logistics
+pg.com,Procter & Gamble,Manufacturing
 pgcps.org,Prince George's County Public Schools,Education
 phpwebhosting.com,PHPWebHosting,Web Host
 piedmonteye.com,Piedmont Eye Center,Healthcare
@@ -2583,6 +2611,7 @@ rsa.com,RSA,Technology
 rsgsv.net,Intuit Mailchimp,Marketing
 rssulnet.com.br,RS Sul Net,ISP
 rt.ru,Rostelecom,ISP
+rtcomm.ru,RTComm,ISP
 rtctel.com,Ringgold Telephone Company,ISP
 ruelala.com,Rue La La,Retail
 runbox.com,Runbox,Email Provider
@@ -2746,6 +2775,7 @@ simplystamps.com,Simply Stamps,Retail
 simpro.com.br,Simpro,Healthcare
 simus.uz,Simus,ISP
 sina.com.cn,Sina,Email Provider
+sinal.dk,Norlys,ISP
 sinaldoceu.com.br,Sinal do Céu,ISP
 sinectis.com.ar,Sinectis,ISP
 sinergit.com.do,Sinergit,MSP
@@ -2815,6 +2845,7 @@ sogomail.eu,Alinto,Email Provider
 solentnewsletters.uk,Solent Newsletters,Marketing
 solfibraotica.com.br,Sol Internet Fibra Óptica,ISP
 somelec.mr,SOMELEC,Industrial
+sonatel.com,Sonatel,ISP
 sonic.com,Sonic,ISP
 sonichealthcareusa.com,Sonic Healthcare USA,Healthcare
 sonynetwork.co.jp,So-net,ISP
@@ -2970,6 +3001,8 @@ tarhely.eu,Tárhely.Eu,Web Host
 tatacommunications.com,Tata Communications,ISP
 tataidc.co.in,Tata Tele Business Services (TTBS),ISP
 tatatelebusiness.com,Tata Teleservices,ISP
+tattelecom.ru,Tattelecom,ISP
+tbc.net.tw,TBC,ISP
 tbntelecom.com.br,TBN Telecom,ISP
 tbonet.net.br,Infix Telecom,ISP
 tcell.tj,Tcell,ISP
@@ -3232,11 +3265,14 @@ umbc.edu,"University of Maryland, Baltimore County",Education
 umich.edu,University of Michigan,Education
 umin.ac.jp,University Hospital Medical Information Network (UHIN) of Japan,Healthcare
 umn.edu,University of Minnesota,Education
+unb.ca,University of New Brunswick,Education
 une.com.co,UNE,ISP
 une.net.co,UNE,ISP
 uni-halle.de,Martin Luther University Halle-Wittenberg,Education
+uni-mainz.de,Johannes Gutenberg University Mainz,Education
 unicanetworking.com.br,Única Networking,ISP
 unifiedlayer.com,UnifiedLayers,Web Host
+unifique.com.br,Unifique,ISP
 unifique.net,Unifique,ISP
 unimedjp.com.br,Unimed João Pessoa,SaaS
 unin.hr,Sveučilište Sjever,Education
@@ -3244,12 +3280,13 @@ unina.it,University of Naples Federico II,Education
 uninet-ide.com.mx,Telmex,ISP
 uninett.no,Uninett,Education
 unionbank.com.bd,Union Bank,Finance
-United-domains.de,United Domains,Web Host
 unitasglobal.com,Unitas Global,MSP
+United-domains.de,United Domains,Web Host
 united.net,United Communications,ISP
 unitedyacht.com,United Yacht Sales,Retail
 unitel.ao,Unitel Angola,ISP
 unitel.com.la,Unitel,ISP
+uniti.com,Uniti,MSP
 unity-health.org,Unity Health,Healthcare
 univac.com.sg,Univac,Industrial
 universal-shoji.co.jp,Universal Shoji,Industrial
@@ -3270,6 +3307,7 @@ usda.gov,U.S. Department of Agriculture,Government
 usg.edu,University System of Georgia,Education
 usgs.gov,U.S. Geological Survey,Government
 usp.br,University of São Paulo,Education
+ussignal.com,US Signal,MSP
 ussignalcom.net,US Signal,MSP
 usssa.com,USSSA,Sports
 usu.edu,Utah State University,Education
@@ -3277,7 +3315,9 @@ utah.edu,University of Utah,Education
 utah.gov,State of Utah,Government
 utclonline.co.ug,Uganda Telecom,ISP
 utelesup.edu.pe,Universidad privada Telesup,Education
+utexas.edu,University of Texas at Austin,Education
 utilprovedor.psi.br,Util Provedor,ISP
+utoronto.ca,University of Toronto,Education
 utsystem.edu,University of Texas System,Education
 uvawise.edu,UVA Wise,Education
 uvm.edu,University of Vermont,Education
@@ -3313,6 +3353,7 @@ vgohosting.com,HostPapa,Web Host
 vgonline.com,Video Graphics,Web Host
 viaccess.net,ONE Communications,ISP
 viasat.com,Viasat,ISP
+viawest.com,Flexential,Web Host
 vibconexao.com.br,Vib Conexão,ISP
 vibrantwellnessvoyage.com,Vibrant Wellness Voyage,Healthcare
 vicc.co,Venco Imtiaz Contracting Co,Industrial
@@ -3425,6 +3466,7 @@ web.de,Web.de,ISP
 webbytelecom.com.br,Webby Internet,ISP
 webd.pl,WEBD.PL,Web Host
 webetic.net,Webetic,Web Host
+webex.com,Cisco Webex,SaaS
 webformix.com,Webformix,ISP
 webglobe.com,Webglobe,Web Host
 webhorizon.net,WebHorizon,Web Host
@@ -3466,6 +3508,7 @@ wifeet.com.do,Wifeet,ISP
 wifire.ru,MegaFon,ISP
 wightman.ca,Wrightman Telecom,ISP
 wikitelecom.com.br,Wki Telecom,ISP
+wilhelm-tel.de,wilhelm.tel,ISP
 willnet.org,WilliNet,ISP
 wilsonss.com,Wilson Computer Support,MSP
 wind.it,WINDTRE,ISP

--- a/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
+++ b/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
@@ -2201,7 +2201,6 @@ name.tools
 namethatserver.com
 nano.lv
 nanshenqfurniture.com
-nask.pl
 nationwidenotaryregistry.com
 natomsvete.ru
 natrohost.com


### PR DESCRIPTION
## Summary

Second pass on the ASN-domain alias work from #712. Adds 43 more aliases from the top IPv4-weighted ASN-domain misses that remained after that PR merged.

Coverage of the bundled `ipinfo_lite.mmdb`, measured by IPv4 addresses per `as_domain`:

- After #712: 84.0%
- After this PR: **85.0%**

The gain is modest (~1%) and that's by design. Beyond this point it's a long tail of small local ISPs, low-volume hosters, resellers, and ASNs with genuinely ambiguous operator attribution — classification cost scales linearly while coverage gain decays sharply. This is the last bulk alias pass; any remaining gap should be filled at attribution time by falling back to the raw `as_name` from the MMDB, not by continuing to hand-classify thousands of small ASNs.

Notable additions (confident brand matches):

- **CDN/hosting:** `fastly.com` → Fastly, `internap.com` → Internap, `viawest.com` → Flexential, `datacamp.co.uk` → CDN77, `datapipe.com` → Rackspace (acquired DataPipe in 2017), `egihosting.com` → EGIHosting, `clouvider.com` → Clouvider
- **SaaS:** `webex.com` → Cisco Webex
- **Carriers / ISPs:** `uniti.com` → Uniti (matches existing `teche.net`), `inteliquent.com` → Inteliquent, `corbina.net` → Beeline, `sonatel.com` → Sonatel, `ioh.co.id` → IM3 (matches existing), `liquidtelecom.com` → Liquid Intelligent Technologies (matches existing `liquidtelecom.net`), `digimobil.es` → DIGI Spain, `distributel.ca` → Distributel, `beanfield.com` → Beanfield, `unifique.com.br` → Unifique (matches existing `unifique.net`), `tbc.net.tw` → TBC, `tattelecom.ru` → Tattelecom, `rtcomm.ru` → RTComm, `aptg.com.tw` → APBT, `apol.com.tw` → APOL, `aureon.com` → Aureon, `sinal.dk` → Norlys, `danskkabeltv.dk` → DKTV, `fibia.dk` → Fibia, `wilhelm-tel.de` → wilhelm.tel, `internet.gmo` → GMO Internet, `ussignal.com` → US Signal (matches existing `ussignalcom.net`)
- **Education / research:** `home.cern` → CERN, `apnic.net` → APNIC, `utexas.edu`, `utoronto.ca`, `uni-mainz.de`, `unb.ca`, `aco.net` → ACOnet, `kenet.or.ke` → KENET, `nask.pl` → NASK (promoted from known_unknown)
- **Government / defense:** `af.mil` → U.S. Air Force, `alberta.ca` → Government of Alberta
- **Other:** `pg.com` → Procter & Gamble, `hankyu-hanshin.co.jp` → Hankyu Hanshin

All naming conventions match existing entries where the same brand is already represented under a different key.

## Test plan

- [x] `python sortlists.py` runs clean (validates and re-sorts)
- [x] `ruff check` and `ruff format --check` pass
- [x] 3,633 unique keys, CRLF preserved, no bare LFs
- [x] Post-merge IPv4-weighted coverage = 85.0% (up from 84.0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)