### PR TITLE
Add six base_reverse_dns_map entries from MMDB coverage-gap analysis

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -23,6 +23,7 @@ base_reverse_dns,name,type
 180medical.com,180 Medical,Healthcare
 1blu.de,1blu,Web Host
 1e100.net,Google,Technology
+1gservers.com,1GServers,Web Host
 1stdibs.com,1stDibs,Retail
 1und1.net,1&1,ISP
 21cn.com,21CN,Email Provider
@@ -501,6 +502,7 @@ centerasecurity.dk,Centera Email Defence,Email Security
 centralesupelec.fr,CentraleSupélec,Education
 centralinteractiva.com.mx,Central Interactiva,Marketing
 centralnetx.com.br,Centralnet,ISP
+centrilogic.com,Centrilogic,MSP
 centurylink.com,CenturyLink,ISP
 centurylink.com.pe,Cirion,MSP
 centurylink.net,CenturyLink,ISP
@@ -1050,6 +1052,7 @@ etb.com,ETB,ISP
 etb.net.co,ETB,ISP
 etc.uz,East Telecom,ISP
 etex.net,Etex,ISP
+etherni.com,Ethernic,MSP
 ethunder-hosting.com,Ethunder Hosting,Web Host
 etik-cloud.com,Infomaniak,IaaS
 etipres.com,ETIPRES,Print
@@ -1262,6 +1265,7 @@ globalconnect.dk,GlobalConnect,ISP
 globalconnect.net,GlobalConnect,ISP
 globalconnect.se,GlobalConnect,ISP
 globalit.com,Global IT,MSP
+globconnex.com,Global Connectivity Solutions,ISP
 globe.com.ph,Globe Telecom,ISP
 gmailify.com,Gmailify,Email Provider
 gmdp.net.id,GMDP,ISP

--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -1071,7 +1071,9 @@ evertecpr.com,Evertec,Finance
 everythere.com.au,Everythere,SaaS
 evicertia.com,Evicertia,SaaS
 evo-net.it,evonet,ISP
+evolus-it.com,Evolus IX,ISP
 evolus-ix.com,Evolus IX,ISP
+evolusfibre.com,Evolus IX,ISP
 ewe.com,EWE,ISP
 ewp.live,EasyWP,Web Host
 exacthosting.com,Exact Hosting,Web Host


### PR DESCRIPTION
## Summary

Six new rows in [base_reverse_dns_map.csv](parsedmarc/resources/maps/base_reverse_dns_map.csv), all discovered via coverage-gap analysis against the bundled IPinfo Lite MMDB. Two are ASN-domain aliases of an existing brand; four are new brand entries.

## Why the ASN-fallback path matters

For any IP lookup:

- **PTR present** → `get_base_domain(PTR)` is used as the map key
- **PTR absent** → the MMDB's `as_domain` for that IP is used as the map key

Both paths read the same CSV, so map keys are a mixed namespace of rDNS-base domains and ASN domains. An operator only present under its rDNS-base key will fall through to the raw `as_name` string (no service type) for any IP in its ASN that lacks a PTR. These additions close those gaps.

## Aliases of an existing brand

`evolus-ix.com` was already mapped as `Evolus IX,ISP`, but the MMDB stores this operator's blocks under two *other* domains that both resolve to `as_name = \"Evolus IT Solutions GmbH\"`:

- `evolus-it.com` — the corporate domain (Evolus IT Solutions GmbH)
- `evolusfibre.com` — their consumer fiber ISP brand

Both added as aliases pointing at the existing `(Evolus IX, ISP)` entry, matching the `comcast.net`/`comcast.com` pattern documented in AGENTS.md.

## New brand entries

None of these four brands are currently represented in the map under any key.

- **`centrilogic.com` → `Centrilogic,MSP`** — 82 MMDB nets, ~62K IPv4. Homepage describes the company as an \"end-to-end I.T. transformation\" managed-services provider.
- **`1gservers.com` → `1GServers,Web Host`** — 117 nets, ~23K IPv4. Homepage: bare-metal dedicated servers and Phoenix colocation.
- **`etherni.com` → `Ethernic,MSP`** — 2 nets, 768 IPv4. Homepage: cloud-migration / cloud-native consulting. Operates its own small ASN under Ethernic LLC.
- **`globconnex.com` → `Global Connectivity Solutions,ISP`** — 687 nets, ~63K IPv4. Homepage unreachable (self-signed cert); WHOIS privacy-redacted. Classification is inferred from the MMDB \`as_name\` \"GLOBAL CONNECTIVITY SOLUTIONS LLP\" and the routed-network scale.

## Test plan

- [x] \`python3 sortlists.py\` clean (no new validator warnings)
- [x] \`file base_reverse_dns_map.csv\` still \`CSV Unicode text, UTF-8 text\` with CRLF line endings preserved
- [x] \`pytest tests.py\` — all 327 tests pass
- [x] Verified in a REPL that \`get_base_domain(\"host.evolus-ix.com\") == \"evolus-ix.com\"\` still resolves correctly (the existing PTR path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)