### PR TITLE
Coerce malformed <email> in aggregate report metadata to None

### DIFF
--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -729,6 +729,12 @@ def parse_aggregate_report_xml(
 
         report = xmltodict.parse(xml)["feedback"]
         report_metadata = report["report_metadata"]
+        if isinstance(report_metadata.get("email"), dict):
+            logger.debug(
+                "Discarding malformed <email> in report_metadata: %r",
+                report_metadata["email"],
+            )
+            report_metadata["email"] = None
         schema = "draft"
         if "version" in report:
             schema = report["version"]


### PR DESCRIPTION
## Summary
- xmltodict turns stray angle brackets in an aggregate report's `<email>` element (e.g. `<bad-xml@bad-xml.net>`, as in `samples/aggregate/invalid_xml.xml`) into a nested dict like `{"#text": "@bad-xml.net>", "bad-xml": None}`. That dict propagates to `org_email`, parsing succeeds, and the malformed value is only rejected downstream by Elasticsearch / OpenSearch, surfacing as:
  - `document_parsing_exception: failed to parse field [org_email] of type [text] ... '{#text=@bad-xml.net>, bad-xml=null}'` (Elasticsearch)
  - `mapper_parsing_exception` with the same preview (OpenSearch)
- `parse_aggregate_report_xml` now detects a dict-shaped `email`, logs it at debug, and discards it. The report still ingests with `org_email=None` instead of failing at index time.

## Test plan
- [x] `pytest tests.py::Test::testAggregateSamples` passes (covers `samples/aggregate/invalid_xml.xml`)
- [x] `ruff check .` / `ruff format --check .` clean
- [x] Manual: `parsedmarc.parse_report_file('samples/aggregate/invalid_xml.xml', always_use_local_files=True, offline=True)` returns `org_email=None` (was a `dict`)
- [ ] Re-run the OpenSearch / Elasticsearch ingest path against the sample set and confirm `invalid_xml.xml` no longer triggers the `document_parsing_exception` / `mapper_parsing_exception` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)