### PR TITLE
Bump mailsuite to >=2.0.2 for 9.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 9.11.1
+
+### Fixed
+
+- Bump required `mailsuite` version to `>=2.0.2` to address `RuntimeError: Event loop is closed` failures in the Microsoft Graph mailbox backend (#742).
+
 ## 9.11.0
 
 ### Changes

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "9.11.0"
+__version__ = "9.11.1"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "expiringdict>=1.1.4",
     "kafka-python-ng>=2.2.2",
     "lxml>=4.4.0",
-    "mailsuite[gmail,msgraph]>=2.0.0",
+    "mailsuite[gmail,msgraph]>=2.0.2",
     "maxminddb>=2.0.0",
     "opensearch-py>=2.4.2,<=4.0.0",
     "publicsuffixlist>=0.10.0",


### PR DESCRIPTION
## Summary
- Bump required `mailsuite` to `>=2.0.2` to pull in the fix for `RuntimeError: Event loop is closed` in the MS Graph mailbox backend (#742).
- Bump parsedmarc version to 9.11.1 and add a CHANGELOG entry.

## Test plan
- [ ] CI green
- [ ] `pip install .` resolves `mailsuite>=2.0.2`
- [ ] Run `parsedmarc -c <config>` with the MS Graph backend and confirm folder fetch no longer raises `RuntimeError: Event loop is closed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)