### PR TITLE
Classify ~1,650 more reverse DNS map entries from MMDB ASN-domain coverage gap

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -1,7 +1,11 @@
 base_reverse_dns,name,type
 0101host.com,0101HOST,Web Host
 012.net.il,012Mobile (Partner),ISP
+018.co.il,XPhone (XFone 018),ISP
+02online.de,Telefonica O2 Germany,ISP
 1-2-1marketing.com,foreUP,SaaS
+1-grid.com,1-grid,Web Host
+1-net.com.sg,1-Net Singapore,ISP
 1000island.net,1000 Island,ISP
 10086.cn,China Mobile,ISP
 1111systems.com,11:11 Systems,MSP
@@ -29,11 +33,14 @@ base_reverse_dns,name,type
 1blu.de,1blu,Web Host
 1e100.net,Google,Technology
 1gservers.com,1GServers,Web Host
+1scom.com,Millennium Telcom,ISP
 1stdibs.com,1stDibs,Retail
 1und1.net,1&1,ISP
 21cn.com,21CN,Email Provider
 21vbluecloud.com,21Vianet,IaaS
 21viamail.com,21Vianet,Email Provider
+23m.com,23M,Web Host
+24shells.net,24 Shells,Web Host
 263.net,263,Email Provider
 2day.kz,2DAY Telecom LLP,ISP
 2degrees.nz,2degrees,ISP
@@ -53,13 +60,17 @@ base_reverse_dns,name,type
 3s.com.tn,3S Tunisie,MSP
 3s.pl,Play,ISP
 3utilities.com,No-IP,Web Host
+3xktech.cloud,3xK Tech,Web Host
 3z.net,3z,MSP
 3zden.cloud,3z,MSP
 45ru.net.au,HostAway,Web Host
 47.pl,AfterMarket.pl,Web Host
+4d-dc.com,Redcentric,Web Host
 4gbhost.com,4GBHost,Web Host
+5gnetworks.com.au,5G Networks Australia,MSP
 6dg.co.uk,Six Degrees,MSP
 6ptelecom.com.br,6P Telecom,ISP
+702com.com,702 Communications,ISP
 8x8.com,8x8,SaaS
 99cloudhosting.com,99CloudHosting,Web Host
 a-hadar.co.il,Hadar Group,Real Estate
@@ -69,6 +80,7 @@ a1.hr,A1,ISP
 a1.mk,A1,ISP
 a1.net,A1,ISP
 a1.si,A1,ISP
+a2b-internet.com,A2B Internet,ISP
 a2hosted.com,A2 Hosting,Web Host
 a2hosting.com,A2 Hosting,Web Host
 a2mobile.pl,a2mobile,ISP
@@ -76,6 +88,7 @@ a2telecomfibra.com.br,A2 Telecom Fibra,ISP
 a2webhosting.com,hosting.com,Web Host
 a2zcreatorz.ca,A2Z Creatorz,Technology
 aa.net.uk,Andrews & Arnold,ISP
+aalto.fi,Aalto University,Education
 aaltoscientific.com,Aalto Scientific,Healthcare
 aamranetworks.com,Aamra Networks,ISP
 aams6.jp,"BroadBand Security, Inc",MSSP
@@ -93,24 +106,33 @@ abn.co.kr,Areum Broadcasting Network,ISP
 abnamro.com,ABN AMRO,Finance
 abnormal-email.com,Abnormal AI,Email Security
 abogados.or.cr,Colegio de Abogados de Costa Rica,Legal
+abs.gov.au,Australian Bureau of Statistics,Government
+abv.bg,ABV Mail,Email Provider
 ac-net.se,AC-Net,ISP
 academiasupport.org,Academia Support Japan,Education
+acadiau.ca,Acadia University,Education
 acantho.it,Acantho,ISP
+accelecom.net,Accelecom,ISP
+accelia.net,Accelia,SaaS
 accenture.com,Accenture,Consulting
 accesshaiti.net,Access Haiti,ISP
 accessmedlab.com,Access Medical Labs,Healthcare
 accessnet.com.br,AccessNet,ISP
 accesstel.net,AccessTEL,ISP
+accretive-networks.net,Accretive Technology Group,SaaS
+acd.net,ACD.net,ISP
 acedatacenter.com,Ace Data Centers,Web Host
 acedatacenters.com,Ace Data Centers,Web Host
 acelerate.net,AXS Bolivia S. A.,ISP
 acems2.com,ActiveCampaign,Marketing
 acemsa1.com,ActiveCampaign,Marketing
 acens.com,acens,Web Host
+acentek.net,AcenTek,ISP
 acessecomunicacao.com.br,Acesse,ISP
 acessoline.net.br,Alt Telecom,ISP
 ach.or.jp,Ageo Central General Hospital,Healthcare
 acim-pr.org.br,ACIM,Nonprofit
+aciworldwide.com,ACI Worldwide,SaaS
 ackermancancer.com,Ackerman Cancer Center,Healthcare
 aco.net,ACOnet,Education
 acoe.org,Alameda County Office of Education,Education
@@ -125,6 +147,7 @@ active24.cz,Active24,Web Host
 activecampaign.com,ActiveCampaign,Marketing
 activegate-ss.jp,Active! gate SS,Email Security
 activetrail.biz,ActiveTrail,Marketing
+acu.edu,Abilene Christian University,Education
 acuperfectwebsites.com,AcuPerfect Websites,Web Host
 adabank.com.tr,Dünya Katılım,Finance
 adairit.com,Adair IT,MSP
@@ -133,6 +156,7 @@ adams.net,Adams Fiber,ISP
 adamthecomputerguy.com,Adam the Computer Guy,MSP
 additionnetworks.net,CherryRoad Technologies,MSP
 adelaide.edu.au,University of Adelaide,Education
+adient.com,Adient,Manufacturing
 adista.fr,Adista,ISP
 admin.ch,Swiss Federal Government,Government
 admintek.net,Admintek,Web Host
@@ -145,14 +169,19 @@ adobe.com,Adobe,Technology
 adp.com,ADP,Finance
 adrz.nl,Adrz,Healthcare
 adsl-pool.sx.cn,China Unicom,ISP
+adsl.cat,SkyQuantum,ISP
 advancedhosters.com,Advanced Hosting,Web Host
 advancedhosting.com,Advanced Hosting,Web Host
+advania.com,Advania,MSP
+advania.is,Advania Iceland,MSP
 adventconstructions.co.tz,Advent Construction Limited,Industrial
+adyl.com.br,Adyl Telecom,ISP
 aebc.com,AEBC Internet,ISP
 aegon.com,Aegon,Finance
 aeneas.com,Aeneas Internet and Telephone,ISP
 aeneas.net,Aeneas Internet and Telephone,ISP
 aep.com,American Electric Power,Utilities
+aero.org,The Aerospace Corporation,Defense
 aeroinc.net,The Areo Group,Industrial
 aesbg.net,AESNET,ISP
 aevengroup.com,Aeven,MSP
@@ -165,6 +194,8 @@ afghan-wireless.com,Afghan Wireless,ISP
 afilias.info,Identity Digital (Afilias),Technology
 afinet.com.br,OnTelecom,ISP
 afnet.net,AFNET,ISP
+afp.com,Agence France-Presse,News
+afranet.com,Afranet,ISP
 africaoncloud.net,Africa on Cloud,IaaS
 afrihost.com,Afrihost,ISP
 afriminesa.com,Afrimine Southern Africa,Industrial
@@ -174,12 +205,16 @@ agatepmedia.net,Agatep Media,Marketing
 agencia-atlas.com,Groupo Atlas,Logistics
 agfa.com,Agfa HealthCare,Healthcare
 agnat.pl,Domena.pl,Web Host
+agni.com,Agni Systems Bangladesh,ISP
 agoda.com,Agoda,Travel
 agom.net,AGOM,Web Host
 agrestelink.com.br,Agreste Link,ISP
 agribank.com,AgriBank,Finance
 agtnet.com.br,AGT Net,ISP
 ahi.ca,Alexandra Hospital,Healthcare
+ahold.com,Ahold,Retail
+aholddelhaize.com,Ahold Delhaize,Retail
+ahrt.hu,4iG Telecommunications,ISP
 aichi-colony.jp,Aichi Developmental Disability Center,Healthcare
 aigmedical.com,Affiliates in Gastroenterology,Healthcare
 aila.org,American Immigration Lawyers Association,Nonprofit
@@ -188,9 +223,11 @@ airbus.com,Airbus,Defense
 aircleaningspecialists.com,"Air Cleaning Specialists, Inc.",Industrial
 aircomusa.com,FaxPipe (Formerly AirCom USA),SaaS
 airenetworks.es,AIRE Networks,ISP
+airespring.com,AireSpring,MSP
 airetech.es,AIRE Networks,ISP
 airgas.com,Airgas,Industrial
 airlinkrb.com,Air Link Rural Broadband,ISP
+airnewzealand.com,Air New Zealand,Travel
 airport.kr,Incheon International Airport,Travel
 airstreamcomm.net,Airstream Communications,ISP
 airtekinternet.com,Airtek Solutions,ISP
@@ -205,12 +242,14 @@ airtel.mw,Airtel,ISP
 airtel.ne,Airtel,ISP
 airtelbroadband.in,Airtel,ISP
 airtelkenya.com,Airtel,ISP
+airulimited.com,Airu,Web Host
 ais.co.th,AIS,ISP
 ais.th,AIS,ISP
 aist.go.jp,National Institute of Advanced Industrial Science and Technology,Government
 ait.com,AIT,Web Host
 aitcom.net,AIT,Web Host
 aiwacorp.co.jp,Aiwa,Industrial
+aixit.com,Aixit,Web Host
 ajrmexico.com,AJR,Logistics
 ajrmexico.net,AJR,Logistics
 ajusa.com,AJ-USA,Retail
@@ -222,6 +261,8 @@ akamaiedge.net,Akamai,Technology
 akamaihd.net,Akamai,Technology
 akamaitechnologies.com,Akamai,Technology
 akamaized.net,Akamai,Technology
+akari.hk,Akari Networks HK,ISP
+akilecloud.com,AkileCloud,Web Host
 akkodis.com,AKKODiS,Staffing
 aknet.kg,AkNet,ISP
 akomp.com.pl,AKOMP,ISP
@@ -234,18 +275,22 @@ alaresinternet.com.br,Alares,ISP
 alaska.edu,University of Alaska,Education
 alaska.gov,Alaska Government,Government
 alaskaair.com,Alaska Airlines,Travel
+albany.edu,University at Albany SUNY,Education
 albatros.uz,Albatros Health Care,Healthcare
 alberta.ca,Government of Alberta,Government
 albertahealthservices.ca,Alberta Health Services,Healthcare
 alcansservicos.com.br,Alcans Telecom,ISP
 alcanstelecom.com.br,Alcans Telecom,ISP
+alcom.ax,Alcom Aland,ISP
 alconn.it,Alconn,ISP
 alembic.co.in,Alembic Pharmaceuticals,Healthcare
 alestra.com.mx,Alestra,ISP
 alestra.net.mx,Alestra,ISP
+alexhost.com,AlexHost,Web Host
 alfatelecom.cz,Alfa Telecom,ISP
 alfenas.mg.gov.br,Prefeitura Municipal de Alfenas,Government
 alfred.edu,Alfred University,Education
+alfredstate.edu,SUNY Alfred,Education
 algar.com.br,Algar Telecom,ISP
 algartelecom.com.br,Algar Telecom,ISP
 algerietelecom.dz,Algérie Telecom,ISP
@@ -254,15 +299,21 @@ alibabacloud.com,Alibaba Cloud,IaaS
 alibabagroup.com,Alibaba,Technology
 alinto.com,Alinto,Email Provider
 aliyun.com,Alibaba Cloud,Web Host
+aljeel.ly,Aljeel Aljadeed,ISP
 alkimnet.net,Alkim Basin Yayin Iletisim,ISP
 all-in-1.com,All In One,Technology
 allamericanspeakers.com,All American Speakers Bureau,Event Planning
 allconecta.net.br,All Conecta,ISP
+allete.com,ALLETE,Utilities
 alliancebroadband.co.in,Alliance Broadband,ISP
 alliancebroadband.in,Alliance Broadband,ISP
 allianzsna.com,SNA Insurance,Finance
+alliedtelecom.net,Allied Telecom,ISP
 alligacom.com,TrueCommerce,SaaS
+allinahealth.org,Allina Health,Healthcare
 allocommunications.com,ALLO,ISP
+allpointsfibre.uk,AllPoints Fibre,ISP
+allrede.com.br,Allrede Telecom,ISP
 allrede.tec.br,Allrede,ISP
 allstate.com,Allstate,Finance
 alltecinternet.com.br,Alltec Internet,ISP
@@ -276,6 +327,7 @@ almobile.com,AL Mobile,SaaS
 alorica.com,Alorica,Staffing
 alpha-mail.net,Otsuka Corporation,MSP
 alpha-prm.jp,Otsuka Corporation,MSP
+alphacron.de,AlphaCron Datensysteme,Web Host
 alphalink.fr,Alphalink,ISP
 alsatwireless.com,Air Link Rural Broadband,ISP
 alsk.com,Alaska Communications,ISP
@@ -285,6 +337,7 @@ altarede.com.br,AltaRede,ISP
 altayer.om,Al-Tayer Engineering Services,Construction
 altel.kz,Atal,ISP
 altemica.net,Altemica,MSP
+alterway.fr,Alter Way,MSP
 altibox.net,Altibox,ISP
 altice.com.do,Altice Dominicana,ISP
 alticor.com,Alticor,Retail
@@ -294,12 +347,14 @@ altnet.md,Altnet,ISP
 altovalenet.com.br,Alto Vale Net,ISP
 alwaysdata.com,alwaysdata,Web Host
 alwaysdata.net,alwaysdata,Web Host
+amatechtel.com,AMA TechTel,ISP
 amazon.com,Amazon,Technology
 amazonasnettelecom.com.br,Amazonas Net,ISP
 amazonaws.com,Amazon Web Services (AWS),PaaS
 amazonett.com.br,Amazonet,ISP
 amazoninter.net.br,Amazon Inter.Net,ISP
 amazonses.com,Amazon SES,SaaS
+amberit.com.bd,Amber IT,ISP
 amberit.net,Amber IT,ISP
 ambisys.net,Ambisys,Healthcare
 ambit.com.tw,Ambit Microsystem,Manufacturing
@@ -308,9 +363,13 @@ america-net.com.br,America-NET,ISP
 america.net,America.net,Web Host
 american.edu,American University,Education
 americanam.org,American Advanced Management,Healthcare
+americanet.com.br,Vero,ISP
+americanexpress.com,American Express,Finance
 americantower.com,American Tower,Technology
 americantower.com.br,American Tower,Technology
+americatelnet.com.pe,Americatel Peru,ISP
 amerinoc.com,AmeriNOC,Web Host
+ameslab.gov,Ames Laboratory,Government
 amethyst.co.jp,Amethyst,Healthcare
 amfam.com,American Family Insurance,Finance
 amobia.com,Amobia,ISP
@@ -319,7 +378,10 @@ amplia.co.tt,AMPLIA,ISP
 amplifyapp.com,Amazon AWS,PaaS
 amplitudo.me,Amplitudo,SaaS
 amres.ac.rs,AMRES,Education
+amur.ru,Rostelecom Amur,ISP
 analabs.com.sg,ANALABS,Construction
+andorratelecom.ad,Andorra Telecom,ISP
+andrews.edu,Andrews University,Education
 andritz.com,Andritz,Manufacturing
 anet.net.th,ANET,ISP
 anexia-it.com,Anexia,Web Host
@@ -335,13 +397,18 @@ antboxnetworks.com,Antbox Networks,Web Host
 antel.com.uy,Antel,ISP
 antelecom.net,Antelecom,ISP
 antelecom.net.br,AN Telecom,ISP
+anthembroadband.com,Anthem Broadband,ISP
 anti-spam-premium.com,Liquid Web,Web Host
+antietambroadband.com,Antietam Broadband,ISP
 antilles-sante.com,AAS Medical,Healthcare
 antispamcloud.com,N-able,Email Security
 antispameurope.com,Hornetsecurity,Email Security
+anydigital.sg,AnyDigital,Web Host
 anylogic.com,AnyLogic,SaaS
 aoc.gov,Architect of the Capitol,Government
+aoiot.ru,IOT (Skolkovo),IaaS
 aopa.org,AOPA,Travel
+aoyama.ac.jp,Aoyama Gakuin University,Education
 apa-it.at,APA-Tech,MSP
 apa.at,APA-Tech,MSP
 apaudit.eu,Transparent,Finance
@@ -356,6 +423,7 @@ apple.com,Apple,Email Provider
 applefibernet.com,Apple Fibernet,ISP
 applicationx.net,Application X,MSP
 appliedmaterials.com,Applied Materials,Manufacturing
+appnexus.com,Microsoft Advertising (Xandr),Marketing
 appriver.com,OpenText AppRiver,Email Security
 apps-1and1.com,IONOS,Web Host
 apps-1and1.net,IONOS,Web Host
@@ -367,6 +435,8 @@ aptalaska.net,AP&T,ISP
 aptg.com.tw,APBT,ISP
 aptum.com,Aptum,Web Host
 apxnetprovedor.com.br,Apx Net,ISP
+aql.com,aql,ISP
+aqmd.gov,South Coast AQMD,Government
 aqmhost.net,AqmHost,Web Host
 aragon.es,Government of Aragon,Government
 araguaianetmt.com.br,ARAGUAIANET,ISP
@@ -379,6 +449,7 @@ arelion.com,Arelion,ISP
 arena.ne.jp,WebARENA,ISP
 arenatelecom.net.br,Arena Telecom,ISP
 areon.net,AREON,Education
+ariadne-t.gr,Ariadne-T,ISP
 ariastelecom.com.br,Arias Telecom,ISP
 arij.org,ARIJ Institute,Nonprofit
 arikiinternet.com.br,Ariki Internet,ISP
@@ -386,24 +457,31 @@ ariskisp.com,Arisk Communications,ISP
 aristotle.net,Aristotle Internet,ISP
 arizona.edu,University of Arizona,Education
 arkansas.gov,Arkansas Government,Government
+arkdna.com,ARK Data Centers,Web Host
 arkitech.it,Arkitech,Technology
+arlingtonva.us,Arlington County Virginia,Government
 armstrongonewire.com,Armstrong,ISP
 arnes.si,ARNES,Education
 arosscloud.com,AROSSCLOUD,Web Host
 arpinet.am,Arpinet,ISP
+arsat.com.ar,ARSAT,ISP
 arsys.net,Arsys,Web Host
 artectelecom.net,Artec Telecom,ISP
 artehosting.com.mx,Artehosting,Web Host
 artelecom.pt,AR Telecom,ISP
 arteria-net.com,ARTERIA Networks,ISP
+artfiles.de,Artfiles,Web Host
 aruba.it,Aruba.it,Web Host
+arvancloud.ir,Arvancloud,IaaS
 arvato-systems.de,Arvato Systems,MSP
 arvig.com,Arvig,ISP
+aryaka.com,Aryaka Networks,SaaS
 as1101.net,SURF,Education
 as29550.net,Simply Transit,ISP
 as42831.net,UK Dedicated Servers,Web Host
 as48500.net,Irpinia Net-Com,ISP
 as60011.net,Mythic Beasts,Web Host
+as6723.net,AS6723 Ukrainian Operator,ISP
 as979.net,NetLab Global,ISP
 asahi-net.jp,ASAHI Net,ISP
 asahi-net.or.jp,ASAHI Net,ISP
@@ -411,12 +489,16 @@ asahikawa-med.ac.jp,Asahikawa Med,Healthcare
 asanetce.com.br,ASANET,ISP
 asavie.com,Akamai,Technology
 asc.edu,Alabama Supercomputer Authority,Education
+ascension.org,Ascension Health,Healthcare
+ascensionhealth.org,Ascension,Healthcare
+ascenty.com,Ascenty,Web Host
 asdasd.it,ASDASD,ISP
 asem-tech.com,ASEMtech,Industrial
 aserv.co.za,Afrihost,ISP
 asfsteelco.com,ASF Steel,Manufacturing
 ashtelstudios.com,Ashtel Studios,Healthcare
 asiaitserver.com,Asia IT Solution Co.,MSP
+asianaidt.com,Asiana IDT,MSP
 asianet.co.th,Ttur Internet Corporation,ISP
 asianetbroadband.in,Asianet Broadband,ISP
 asianvision.ph,Asian Vision,ISP
@@ -432,22 +514,32 @@ aspirets.com,Aspire Technology Solutions,MSP
 assaytechnology.com,Assay Technology,Industrial
 assentportal.com,Assent,SaaS
 assp.org,American Society of Safety Professionals,Healthcare
+asta-net.pl,Asta-Net,ISP
+astate.edu,Arkansas State University,Education
 asteria.com,Asteria,SaaS
 astound.com,Astound Broadband,ISP
 astralinfo.co.uk,Astral Informatics,Marketing
 asu-vei.ru,ASU-VEI,Industrial
 asu.edu,Arizona State University,Education
 at-home.ru,еТелеком,ISP
+atb-nett.no,ATB-Nett (Telefiber),ISP
 ateky.net.br,Ateky Internet,ISP
 atextelecom.com.br,ATEX Telecom,ISP
 athleanx.com,ATHLEAN-X,Retail
+ati.org,ATI Advanced Technology International,Defense
+ati.tn,Agence Tunisienne d'Internet,Government
 atiinternet.com.br,ATI Internet,ISP
+atlantech.net,Atlantech Online,ISP
 atlantic.net,Atlantic.Net,Web Host
 atlanticmetro.net,365 Data Centers,Web Host
 atlas-elektronik.com,Atlas Elektronik,Defense
+atlax.com,ATLAX,Web Host
+atlink.net,AtLink Services,ISP
 atmailcloud.com,atmail,Email Provider
 atman.pl,Atman,IaaS
+atmc.com,Focus Broadband (ATMC),ISP
 atmc.net,FOCUS Broadband,ISP
+atni.com,ATN International,ISP
 atomic.ac,Atomic,ISP
 atonementonline.com,Our Lady of the Atonement,Religion
 atos.net,Atos,Consulting
@@ -459,17 +551,24 @@ atw.jp,ATW,Web Host
 atw.ne.jp,ATW,Web Host
 au-net.ne.jp,KDDI,ISP
 au.com,au,ISP
+au.edu,Assumption University of Thailand,Education
+auburn.edu,Auburn University,Education
 auckland.ac.nz,University of Auckland,Education
+audi.com,Audi,Automotive
+augusta.edu,Augusta University,Education
 auone-net.jp,KDDI,ISP
 aup.edu.pk,"University of Agriculture, Peshawar",Education
 aura.dk,AURA Fiber,ISP
 aureon.com,Aureon,ISP
 auriga.com,Auriga,Technology
+auspost.com.au,Australia Post,Logistics
 aussiebb.com.au,Aussie Broadband,ISP
 aussiebroadband.com.au,Aussie Broadband,ISP
 australianjewishnews.com,The Australian Jewish News,News
+aut.ac.nz,Auckland University of Technology,Education
 auth.gr,Aristotle University of Thessaloniki,Education
 autodesk.com,Autodesk,SaaS
+automattic.com,Automattic,SaaS
 autoplus.bg,Auto Plus Bulgaria,Automotive
 autotask.net,Kaseya,SaaS
 avalon.hr,cyber_Folks,Web Host
@@ -480,6 +579,7 @@ avantnet.ru,Avant,ISP
 avatel.es,Avatel,ISP
 avato.com.br,Brasil TecPar,ISP
 avaya.com,Avaya,Technology
+avci.net,Agri-Valley Communications,ISP
 aveniq.ch,Aveniq,MSP
 aventelfrance.com,Aventel,ISP
 aventelkz.com,Aventel,ISP
@@ -492,6 +592,10 @@ awm.com.tr,Yöncü Bilişim Çözümleri Limited Şirketi,Web Host
 awn.co.th,AIS Advanced Wireless Network,ISP
 awsapprunner.com,Amazon AWS,PaaS
 awusa.net,All West Communications,ISP
+axarnet.es,Axarnet,Web Host
+axelspringer.com,Axel Springer,Publishing
+axera.it,Axera,ISP
+axioma24.ru,Axioma,ISP
 axsbolivia.com,AXS Bolivia,ISP
 axspace.com,AXspase,Web Host
 axtel.mx,Axtel,ISP
@@ -512,21 +616,29 @@ azure.com,Microsoft Azure,PaaS
 azureedge.net,Microsoft Azure,Technology
 azurestaticapps.net,Microsoft Azure,PaaS
 azurewebsites.net,Microsoft Azure,PaaS
+azza.net.br,Azza,ISP
 babilon-t.com,Babilon-T,ISP
+babson.edu,Babson College,Education
 backland.net,Backland Communications,MSP
 baesystems.com,BAE Systems,Defense
 bahnhof.se,Bahnhof,ISP
 baidu.com,Baidu,Search Engine
 balifiber.id,BaliFiber,ISP
+ball.com,Ball Corporation,Manufacturing
+balt.net,Baltneta,ISP
 baltcom.lv,Bite,ISP
 balticom.lv,Balticom,ISP
+balticum.lt,Balticum TV,ISP
 banchero.org,Bancharo Disability Services,Healthcare
+bancogalicia.com,Banco Galicia,Finance
 bandwidth.co.uk,Bandwidth Technologies,ISP
 bangla.net,ISN Bangla,ISP
+bank-banque-canada.ca,Bank of Canada,Government
 bankofamerica.com,Bank of America,Finance
 barak-online.net,Netvision,ISP
 barclays.co.uk,Barclays,Finance
 baremetal.co.za,Baremetal,ISP
+barings.com,Barings,Finance
 barracuda.com,Barracuda,Email Security
 barvanet.kz,Barvanet,MSP
 basf.com,BASF,Industrial
@@ -536,25 +648,35 @@ basketnews.lt,BasketNews,Sports
 basmail.jp,TOKI Communications Corporation,ISP
 batelco.com,Batelco,ISP
 bates.edu,Bates College,Education
+battelle.org,Battelle Memorial Institute,Science
+bausch.com,Bausch and Lomb,Healthcare
 baxetgroup.com,Baxet Group,Web Host
 bayada.com,BAYADA Home Health Care,Healthcare
 bayer.com,Bayer,Healthcare
 bayer.de,Bayer,Healthcare
 baykonur.ru,Baykonur Svyazinform,ISP
 baylor.edu,Baylor University,Education
+baynet.ne.jp,Tokyo Bay Network,ISP
 bayoulandcs.com,Bayouland Computer Solutions,MSP
+bb.com.br,Banco do Brasil,Finance
 bbbell.it,BBBell,ISP
 bbc.com,BBC,News
 bbemaildelivery.com,BombBomb,Marketing
 bbned.nl,Odido,ISP
 bbnetup.com,BBNET UP,ISP
 bbnetup.com.br,BBNET UP,ISP
+bbraun.de,B. Braun Melsungen,Healthcare
 bbtel.com,BBTEL,ISP
+bbtower.co.jp,BroadBand Tower,Web Host
 bc.edu,Boston College,Education
 bc.net,BCNET,Education
+bcbsm.com,Blue Cross Blue Shield of Michigan,Healthcare
 bcdtravelmexico.com.mx,BCD Travel Mexico,Travel
+bcit.ca,British Columbia Institute of Technology,Education
+bcm.edu,Baylor College of Medicine,Education
 bcnetsp.com.br,BC Net,ISP
 bcs.org,BCS,Nonprofit
+bcsbeavers.org,Madison-Oneida BOCES,Education
 bcx.co.za,BCX,MSP
 bdcom.com,BDCOM Online,ISP
 bdconnectctg.net,BDconnect,ISP
@@ -563,8 +685,11 @@ be.ch,Canton of Bern,Government
 beanfield.com,Beanfield,ISP
 bearingdepot.com,Bearing Depot & Supply,Retail
 beaumont.org,Corewell Health (Formerly Beaumont),Healthcare
+bec.uk,BE Computing,IaaS
+bedag.ch,Bedag Informatik,MSP
 bedbathandbeyond.com,Bed Bath & Beyond,Retail
 bedge.com,BEDGE,Web Host
+bee.net.tn,Bee (Smart Solutions Tunisia),ISP
 beecreek.net,Bee Creek Communications,ISP
 beeline.kz,Beeline,ISP
 beeline.ru,Beeline,ISP
@@ -588,6 +713,7 @@ benlomandconnect.com,Ben Lomand Rural Telephone Cooperative,ISP
 beotel.net,BeotelNet,ISP
 berea.edu,Berea College,Education
 berkeley.edu,UC Berkley,Education
+bernco.gov,Bernalillo County,Government
 berneyassocies.com,Berney Associés,Consulting
 bernofarm.com,Bernofarm,Healthcare
 bestbuy.com,Best Buy,Retail
@@ -595,11 +721,16 @@ bestel.com.mx,Bestel,ISP
 bestwestern.com,Best Western,Travel
 bethel.edu,Bethel University,Education
 betterhomeowners.com,InTouch Systems,Marketing
+bevcomm.net,Bevcomm,ISP
 bezeq.co.il,Bezeq,ISP
 bezeqint.net,Bezeq International,ISP
+bfh.ch,Berner Fachhochschule,Education
 bgctv.com.cn,Beijing Gehua CATV,ISP
+bgp.net,BGP Network HK,ISP
 bgsu.edu,Bowling Green State University,Education
+bgwan.com,VarnaLan (Geodim),ISP
 bhtelecom.ba,BH Telecom,ISP
+bia.gov,US Bureau of Indian Affairs,Government
 bigbiz.com,BigBiz Internet Services,Web Host
 bigcommerce.net,BigCommerce,SaaS
 bigleaf.net,Bigleaf Networks,ISP
@@ -607,8 +738,12 @@ biglobe.co.jp,BIGLOBE,ISP
 biglobe.ne.jp,BIGLOBE,ISP
 bigpond.com,Telstra,ISP
 bigpond.net.au,Telstra,ISP
+bigrivertelephone.com,Big River Telephone,ISP
 bigscoots.com,BigScoots,Web Host
 bilink.com.br,Bilink Telecomunicações,ISP
+bilink.ua,Bilink,ISP
+bilkent.edu.tr,Bilkent University,Education
+binat.net.il,Binat,ISP
 binero.com,Binero,Web Host
 binero.se,Binero,Web Host
 binghamton.edu,Binghamton University,Education
@@ -622,26 +757,38 @@ bisno1.co.jp,"Bis Co., Ltd.",Construction
 bisping.de,Bisping & Bisping,ISP
 bisv.ru,Bisv.ru,ISP
 bit-drive.ne.jp,NURO Biz,ISP
+bit.nl,BIT BV,Web Host
 bite.lt,Bite,ISP
 bite.lv,Bite,ISP
+bitel.com.pe,Bitel,ISP
+bitel.de,BITel Bielefeld,ISP
+biterika.ru,Biterika,Web Host
 bitmail.com.br,Bitmail Telcom,ISP
+biznetgio.com,Biznet Gio,IaaS
 biznetnetworks.com,Biznet Networks,ISP
+bjc.org,BJC HealthCare,Healthcare
 bkm.uz,Uzbektelekom,ISP
 bkup.com.br,Bkup Telecom,ISP
+blackberry.com,BlackBerry,SaaS
 blackfoot.net,Blackfoot,ISP
 blackfriarsam.com,Blackfriars Asset Management,Finance
 blackgate.nl,BlackGATE,Web Host
 blacknight.com,Blacknight Solutions,Web Host
 blacksun.ca,MSP Corp,Web Host
 blanksoft.dev,BlankSoft,MSP
+blazenet.biz,BlazeNet,ISP
+blazingseollc.com,Rayobyte (Blazing SEO),SaaS
 bleucloud.fr,Bleu,IaaS
 blic.net,Supernova,ISP
 blickle.com,Blickle,Manufacturing
 blinktelecom.com.br,Blink Telecom,ISP
 blitzmediahosting.ca,Blitz Media,Web Host
+blix.com,Blix Solutions,ISP
+blizzard.com,Blizzard Entertainment,Entertainment
 bloomberg.com,Bloomberg,Finance
 blowtech.com.tw,Blowplas Technology,Manufacturing
 bls.gov,U.S. Bureau of Labor Statistics,Government
+bluebirdnetwork.com,Bluebird Fiber,ISP
 bluehost.com,Bluehost,Web Host
 bluemission.net,Blue Mission,Web Host
 bluesea.org,Blue Sea Foundation,Marketing
@@ -650,10 +797,13 @@ bluetie.com,BlueTie,MSP
 bluevalley.net,Blue Valley,ISP
 bluevps.com,BlueVPS,Web Host
 blueweb.co.kr,BlueWeb,Web Host
+bme.hu,Budapest University of Technology and Economics,Education
+bmhcc.org,Baptist Memorial Health Care,Healthcare
 bmjnet.com.br,BMJ Net,ISP
 bnehost.com.au,Bnehosting,Web Host
 bnet-bd.com,Business Network,ISP
 bnet.com.br,Bnet Telecom,ISP
+bnl.gov,Brookhaven National Laboratory,Government
 bnpparibas.com,BNP Paribas,Finance
 bnpparibas.fr,Banque BNP Paribas,Finance
 bnsf.com,BNSF Railway,Logistics
@@ -661,13 +811,17 @@ bny.com,BNY Mellon,Finance
 bnymellon.com,BNY Mellon,Finance
 boavistanet.net.br,Boa Vista Net,ISP
 boeing.com,Boeing,Defense
+bof.fi,Bank of Finland,Government
 bohc.co.jp,Benefit One Inc.,Retail
+boisestate.edu,Boise State University,Education
 boku.ac.at,University of Natural Resources and Life Sciences Vienna,Education
 bol-online.com,Bangladesh Online,ISP
 bol.net.in,MTNL,ISP
 boldyn.com,Boldyn,ISP
+bolignet-aarhus.dk,Bolignet-Aarhus,ISP
 bombbomb.com,BombBomb,Marketing
 bond.edu.au,Bond University,Education
+bonline.com.kw,Gulfnet Communications,ISP
 bontechnologies.com,Bontechnologies,Consulting
 bonterratech.com,Bonterra,Marketing
 bookingtimes.com,BookingTimes,SaaS
@@ -686,8 +840,11 @@ bplaced.com,bplaced,Web Host
 bplaced.de,bplaced,Web Host
 bplaced.net,bplaced,Web Host
 bpweb.net,BPWEB,Web Host
+br.digital,BR Digital Telecom,ISP
+braathe.net,iteam Braathe,MSP
 bracnet.net,BRACNet Limited,ISP
 brandeis.edu,Brandeis University,Education
+brandenburgtel.com,Brandenburg Telephone,ISP
 branet.com.br,Branet,MSP
 brasildigital.net.br,Brasil Digital Telecom,ISP
 brasillike.com.br,Brasil Like,ISP
@@ -702,9 +859,14 @@ breedbanddelft.nl,Stichting Breedband Delft,ISP
 breezein.net,BRIZ,ISP
 breezeline.com,Breezeline,ISP
 breezelineohio.net,Breezeline,ISP
+bren.bg,BREN Bulgarian Research and Education Network,Education
+brennanit.com.au,Brennan IT,MSP
+brennercom.it,Brennercom,ISP
 brevo.com,Brevo (Sendinblue),Marketing
+bridgewater.edu,Bridgewater College,Education
 bright.net,CNI,ISP
 brightok.net,BrightNet Oklahoma,ISP
+brightridge.com,BrightRidge,Utilities
 brightspace.com,D2l Brightspace,SaaS
 brightspeed.com,Brightspeed,ISP
 brinkster.com,Brinkster,Web Host
@@ -718,28 +880,45 @@ broadband.hu,One Hungary,ISP
 broadbandidc.com,BROADBANDIDC,Web Host
 broadcom.com,Broadcom Enterprise Messaging Security,Email Security
 broadridge.com,Broadridge,Finance
+brockport.edu,SUNY Brockport,Education
+brocku.ca,Brock University,Education
+brown.edu,Brown University,Education
 brownrice.com,Brownrice Internet,Web Host
+brucepower.com,Bruce Power,Utilities
+brynmawr.edu,Bryn Mawr College,Education
 bs-telecom.net,БС-Телеком (BS-Telecom),ISP
 bsc.rw,Broadband Systems Corporation,ISP
 bsconect.com.br,BS Conect,ISP
+bsd.nl,BSD Software Development,Technology
+bsd405.org,Bellevue School District,Education
 bse.ch,SolNet,ISP
 bsnews.com.br,BS News,ISP
 bsnl.co.in,BSNL,ISP
 bsnl.in,BSNL,ISP
+bsp.com.bn,Brunei Shell Petroleum,Industrial
 bsu.edu,Ball State University,Education
 bt.com,BT,ISP
 bta.net.cn,China Networks Inter-Exchange,ISP
 btc-net.bg,Viacom,ISP
 btc.bw,Botswana Telecommunications,ISP
+btcbahamas.com,BTC Bahamas Telecommunications,ISP
 btcentralplus.com,BT,ISP
+btcl.com.bd,Bangladesh Telecommunications Company,ISP
+btcl.gov.bd,BTCL Bangladesh Telecommunications,ISP
 btopenworld.com,BT,ISP
 btussel.com,Bug Tussel,ISP
+btvm.ne.jp,BTV,ISP
 bu.edu,Boston University,Education
+buap.mx,Universidad Autonoma de Puebla,Education
+buckeye.com,Buckeye Partners,Utilities
 buckeyebroadband.com,Buckeye Broadband,ISP
 buckeyebusiness.net,Buckeye Business Solutions,MSP
+bucknell.edu,Bucknell University,Education
 buffalo.edu,University at Buffalo,Education
+buffalostate.edu,Buffalo State College,Education
 bugtusselwireless.com,Bug Tussel,ISP
 buildingmaterials.com.my,Building Materials,Construction
+bulloch.net,Bulloch County RTC,ISP
 bulsat.com,Bulsatcom,ISP
 bumblebeelinens.com,Bumbletree Linens,Retail
 bumrungrad.com,Bumrungrad International Hospital,Healthcare
@@ -752,11 +931,15 @@ burnhamholdings.com,Burnham Holdings,Industrial
 buroserv.net.au,Brunoserv,ISP
 busse-computer.de,Busse Computertechnik,MSP
 busse.cloud,Busse Computertechnik,MSP
+buysecure.com,Monmouth Internet,Web Host
 bvconline.com.ar,BVC,ISP
+bvu-optinet.com,BVU OptiNet (Point Broadband),ISP
 bytedance.com,ByteDance,Technology
 bytemark.co.uk,Bytemark,Web Host
 byteplus.com,BytePlus,IaaS
+bytes.co.za,Altron Bytes,MSP
 byu.edu,BYU,Education
+byui.edu,Brigham Young University Idaho,Education
 c-able.co.jp,Yamaguchi Cable Vision,ISP
 c3.net.pl,C3 NET,ISP
 c3po3090.com.br,Núcleo Brasil Servidores,Web Host
@@ -764,6 +947,7 @@ ca.gov,State of California,Government
 cable.net.co,Cablenet,ISP
 cablebahamas.com,Cable Bahamas,ISP
 cablecolor.com.gt,Cable Color,ISP
+cablecolor.hn,Cable Color Honduras,ISP
 cablecom.ch,UPC,ISP
 cablecomm.ie,CableComm,ISP
 cablelink.at,Salzburg AG,Utilities
@@ -780,26 +964,37 @@ cablevision.net.mx,Izzi Telecom,ISP
 cableworld.es,Cableworld,ISP
 cabonnet.com.br,Cabonnet,ISP
 cabotelecom.com.br,Alares,ISP
+cabq.gov,City of Albuquerque,Government
 cairohost.com,Black Host,Web Host
 caiway.nl,Caiway,ISP
 caiweb.net.br,Caiweb,ISP
 calero.com,Calero,MSP
+calltower.com,CallTower,SaaS
 calpoly.edu,Cal Poly,Education
 caltech.edu,California Institute of Technology,Education
 calvin.edu,Calvin University,Education
 cam.ac.uk,University of Cambridge,Education
 campaigner.com,Campaigner,Marketing
+camtel.cm,Camtel,ISP
 canadianwebhosting.com,Canadian Web Hosting,Web Host
 canalplustelecom.com,Canal+ Telecom,ISP
+canar.sd,Canar Telecom Sudan,ISP
+cancer.gov,National Cancer Institute,Government
 cancom.com,CANCOM Austria,MSP
 cancom.de,CANCOM,MSP
+canisius.edu,Canisius University,Education
+canon-its.co.jp,Canon IT Solutions,MSP
 canonet.ne.jp,Canonet,MSP
 canonical.com,Canonical,Technology
 canspace.ca,CanSpace,Web Host
 cantecsystems.com,Cantec Systems,MSP
+canterbury.ac.nz,University of Canterbury,Education
+canton.edu,SUNY Canton,Education
 cantv.com.ve,CANTV,ISP
+capetown.gov.za,City of Cape Town,Government
 capgemini.com,Capgemini,Consulting
 capinfo.com.cn,CAPNET,Government
+capita-cs.co.uk,Capita Business Services,MSP
 carandainet.com.br,CN Internet,ISP
 cardhealth.com,Cardinal Health,Healthcare
 cardinal-health.com,Cardinal Health,Healthcare
@@ -807,6 +1002,8 @@ cardinal.com,Cardinal Health,Healthcare
 cardinalhealth.com,Cardinal Health,Healthcare
 cardinalscriptnet.com,Cardinal Health,Healthcare
 carecentrix.com,CareCentrix,Healthcare
+cargill.com,Cargill,Agriculture
+carleton.ca,Carleton University,Education
 carleton.edu,Carlton College,Education
 carnet.hr,CARNET,Education
 carrd.co,Carrd,SaaS
@@ -814,11 +1011,16 @@ carrierzone.com,carrierzone,Email Security
 carrytel.ca,Carrytel,ISP
 carsforkids.org,Cars For Kids,Nonprofit
 cas.org,Chemical Abstracts Service,Publishing
+casablanca.cz,Casablanca INT,Web Host
 case.edu,Case Western Reserve University,Education
 castrum.com.br,Castrum Internet,ISP
 cat.com,Caterpillar,Industrial
 cat.net.th,National Telecom (Thailand),ISP
+catawba.edu,Catawba College,Education
 catnet.jp,Honjo Cable,ISP
+catonetworks.com,Cato Networks,SaaS
+catvmics.ne.jp,Mics Network,ISP
+cau.ac.kr,Chung-Ang University,Education
 cbe.ae,CBE,Construction
 cbn.id,CBN Fiber,ISP
 cbsimaging.com,CBS Imaging,Retail
@@ -826,17 +1028,27 @@ cbssports.com,CBS Sports,Entertainment
 cbtel.net.ar,CBTEL,ISP
 cbu.ca,Cape Breton University,Education
 cbwchc.org,Charles B. Wang Community Health,Healthcare
+cc9.jp,Cable TV Tochigi (CC9),ISP
+ccac.edu,Community College of Allegheny County,Education
 ccc-group.com,Canada Colors and Chemicals Limited (CCC),Industrial
+ccc.co.il,Triple C Cloud Computing,Web Host
+cccd.edu,Coast Community College District,Education
+cccoe.k12.ca.us,Contra Costa County Office of Education,Education
+cccs.edu,Colorado Community Colleges System,Education
 ccinternet.cz,CC Internet,ISP
+ccs.co.kr,CCS,ISP
 ccsd.net,Clark County School District,Education
 cctv.com,China Central Television,News
 cdbhospital.com,CBD Hospital,Healthcare
 cdc.gov,US Centers for Disease Control and Prevention,Government
 cdkglobal.com,CDK Global,SaaS
 cdn77.com,CDN77,Web Host
+cdnvideo.com,CDNvideo,SaaS
 cdsglobalcloud.com,CDS Global Cloud,Web Host
 cdt.ca,CDT Connexion,MSP
+cdt.cz,CD-Telematika,MSP
 cdu.edu.au,Charles Darwin University,Education
+cdw.com,CDW,MSP
 cea.fr,CEA,Government
 cec-ltd.co.jp,Computer Engineering & Consulting,MSP
 cei.gov.cn,China eGovNet Information Center,Government
@@ -846,11 +1058,14 @@ celerity.ec,Celerity (Puntonet),ISP
 celeste.fr,CELESTE,ISP
 cellc.co.za,Cell C,ISP
 cellcom.co.il,Cellcom Israel,ISP
+cello.co.nz,Cello Group,ISP
 celsiainternet.com,Celsia Internet,ISP
 cenic.org,CENIC,Nonprofit
 cenitex.vic.gov.au,Cenitex,Government
 centerasecurity.com,Centera Email Defence,Email Security
 centerasecurity.dk,Centera Email Defence,Email Security
+centersquaredc.com,Centersquare (Csquare),Web Host
+centralaccess.com,Central Access,ISP
 centralesupelec.fr,CentraleSupélec,Education
 centralinteractiva.com.mx,Central Interactiva,Marketing
 centralnet.com.br,CentralNet Web Services,IaaS
@@ -861,17 +1076,21 @@ centralofertao.com.br,Central Ofertão,Retail
 centralserver.com,Central Server,IaaS
 centralserver.com.br,Central Server,IaaS
 centrilogic.com,Centrilogic,MSP
+centrin.net.id,Centrin Utama,ISP
 centurylink.com,CenturyLink,ISP
 centurylink.com.pe,Cirion,MSP
 centurylink.net,CenturyLink,ISP
 cerebel.com,CereBel Interactive,Marketing
+cerner.com,Cerner,Healthcare
 cernet.edu.cn,CERNET,Education
+certh.gr,CERTH Centre for Research and Technology Hellas,Science
 certha.net,Certha.Net,ISP
 certronic.com.ar,Certronic,SaaS
 certronic.io,Certronic,SaaS
 certto.com.br,Certto,ISP
 cesnet.cz,CESNET,Education
 cetin.cz,CETIN,ISP
+cetin.hu,CETIN Hungary,ISP
 cetin.rs,CETIN,ISP
 ceystel.com.ar,CeySTEL,ISP
 ceznet.cz,ČEZNET,ISP
@@ -894,30 +1113,42 @@ chateauclos.com,Chateauclos,MSP
 chatsignal.in,Chat Signal,ISP
 chcmed.com,Family Medicine Orlando,Healthcare
 cheapairportparking.org,Cheap Airport Parking,Travel
+checkpoint.com,Check Point Software,Email Security
 cheetahmail.com,Marigold,SaaS
 chello.sk,UPC,ISP
+cherryservers.com,Cherry Servers,Web Host
 chess.no,Telia Norge,ISP
 chevron.com,Chevron,Industrial
 chiba-u.jp,Chiba University,Education
 chicago.gov,City of Chicago,Government
+chief.com.tw,AboveNet Communications Taiwan (Chief),ISP
 chikamori.com,Chikamori Health Care Group,Healthcare
 childrenscolorado.org,Children's Hospital Colorado,Healthcare
 childrenshospital.org,Boston Children's Hospital,Healthcare
+china-entercom.net,China Enterprise Communications,ISP
 chinabtn.com,China Broadcasting Network,ISP
 chinamobile.com,China Mobile,ISP
 chinatelecom.cn,China Telecom,ISP
 chinatelecom.com.cn,China Telecom,ISP
+chinatelecomglobal.com,China Telecom Global (CTGNet),ISP
 chinatietong.com,China TieTong,ISP
 chinaunicom.cn,China Unicom,ISP
+chinaunicomglobal.com,China Unicom Global,ISP
 chinaxingye.com,Suzhou Sinye Materials Technology,Industrial
+chop.edu,Children's Hospital of Philadelphia,Healthcare
+chrobinson.com,C.H. Robinson,Logistics
 chronos.com.tr,Chronos Teknoloji,Technology
 chrysler.com,Stellantis North America,Automotive
 cht.com.tw,Chunghwa Telecom,ISP
 chu-lyon.fr,Hospices Civils de Lyon,Healthcare
+chubu.ac.jp,Chubu University,Education
+chukai.co.jp,Chukai Television,ISP
 chula.ac.th,Chulalongkorn University,Education
+chuo-u.ac.jp,Chuo University,Education
 churchdev.com,ChurchDev,Web Host
 cibc.com,CIBC,Finance
 ciberlynx.com,CiberLynx,Technology
+cica.es,CICA Centro Informatico Cientifico de Andalucia,Science
 cicese.edu.mx,CICESE,Education
 ciktel.com,CIK Telecom,ISP
 cilio.io,Cilio,SaaS
@@ -925,14 +1156,19 @@ ciliotech.com,Cilio,SaaS
 cimcorp.com,Cimcorp,Industrial
 cincinnatibell.com,altafiber,ISP
 cinternetbycat.com,National Telecom,ISP
+cipherwave.co.za,Cipherwave,ISP
 circit.de,CircIT,MSP
 circleamedical.com,Circle A Medical,Healthcare
 cirrushosting.com,Cirrus Hosting,Web Host
 cisco.com,Cisco,Technology
+citadel.edu,The Citadel,Education
 citec.com.au,CITEC (Queensland Government),Government
 citic.com,CITIC,Conglomerate
 citictel-cpc.com,CITIC Telecom CPC,ISP
+citigroup.com,Citi (Citigroup),Finance
 citizensmemorial.com,Citizens Memorial Hospital,Healthcare
+citycable.ch,Lausanne SiL Multimedia,ISP
+citycom-austria.com,Citycom Austria,ISP
 cityemail.com,CityEmail,Email Provider
 cityfibre.com,CityFibre,ISP
 citynet.kg,Citynet KG,ISP
@@ -940,12 +1176,18 @@ citynet.net,Citynet,ISP
 cityoftacoma.org,City of Tacoma,Government
 cityonlinebd.net,City Online,ISP
 cityu.edu.hk,City University of Hong Kong,Education
+citywest.ca,CityWest,ISP
 ciu.com.uy,Cámara de Industrias del Uruguay,Nonprofit
+cizgi.net.tr,Cizgi Telekomunikasyon,ISP
 cjas.org,Cornell Anime Club,Education
 ckt.net,Craw-Kan Telephone Cooperative,ISP
+clackesd.k12.or.us,Clackamas Education Service District,Education
 claranet.co.uk,Claranet,Web Host
 claranet.com,Claranet,Web Host
+claremont.edu,Claremont University Consortium,Education
 clarix.com,Clarix,MSP
+clarkson.edu,Clarkson University,Education
+clarksvillede.com,Clarksville Department of Electricity,Utilities
 claro.com.ar,Claro,ISP
 claro.com.br,Claro,ISP
 claro.com.co,Claro,ISP
@@ -960,10 +1202,12 @@ classicofficesystems.com,Classic Office Systems,MSP
 claytonindustries.com,Clayton Industries,Industrial
 cldin.eu,Yourhosting,Web Host
 cleannet.com.br,Clean Net Telecom,ISP
+clearaccess.co.za,Clear Access,ISP
 clearwave.com,Clearwave Fiber,ISP
 clearwavefiber.com,Clearwave Fiber,ISP
 clemson.edu,Clemson University,Education
 clermontcountyohio.gov,Clermont County Ohio,Government
+cleura.com,Cleura,IaaS
 clevelandclinic.org,Cleveland Clinic,Healthcare
 clicfacilitb.com.br,Clicfacil Telecom,ISP
 clicknetpe.com.br,ClickNet PE,ISP
@@ -997,22 +1241,30 @@ cloudhosting.rs,SBB,ISP
 clouditalia.com,Retelit,Web Host
 cloudmark.com,Proofpoint Cloudmark,Email Security
 cloudsite.builders,Rad Web Hosting,Web Host
+cloudsouth.com,Cloud South,Web Host
 cloudwaysapps.com,Cloudways,Web Host
 cloudwebhosting.com,NameHero,Web Host
+cloudwm.com,Kamatera (CloudWM),Web Host
+cloudzy.com,Cloudzy,Web Host
 clouvider.com,Clouvider,Web Host
+clp.com.hk,CLP Power Hong Kong,Utilities
 clsvrsystems.net,GMO Cloud,IaaS
 clubexpress.com,ClubExpress,SaaS
 clubnet.mz,ClubNet,ISP
 cmaginet.com,Cmaginet,Marketing
 cmb.co.kr,CMB,ISP
+cmcnetworks.net,CMC Networks,ISP
 cmctelecom.vn,CMC Telecom,ISP
 cmich.edu,Central Michigan University,Education
 cmo.de,CMO,Web Host
 cmorlando.com.ar,Carpintería Metálica Orlando,Manufacturing
+cmsinter.net,CMS Internet,ISP
 cmtietong.com,China TieTong,ISP
 cmu.edu,Carnegie Mellon University,Education
 cn.at,Cablevision Nöhmer,ISP
+cn.ca,Canadian National Railway,Logistics
 cn4e.com,35.com,Web Host
+cna.ne.jp,Cable Networks Akita,ISP
 cnci.co.jp,Community Network Center,ISP
 cncm.ne.jp,Nagasaki Cable Media,ISP
 cndata.com,China Telecom,ISP
@@ -1020,33 +1272,49 @@ cnic.cn,CNIC,Education
 cniteam.com,CNI,ISP
 cnnet.com.br,Conexao Networks,ISP
 cnnic.cn,CNNIC,Nonprofit
+cnnic.net.cn,CNNIC,Nonprofit
 cnservers.com,CNSERVERS,Web Host
+cnsnext.com,CNS Internet,ISP
 cnt.gob.ec,CNT EP,ISP
 cnt.ru,Central Telegraph,ISP
 cntelecom.com.br,CN Telecom,ISP
 cntfiber.net.br,CNT Fiber,ISP
 cnti.gob.ve,CNTI,Government
+cnu.ac.kr,Chungnam National University,Education
+cnw.com,Connect Northwest,ISP
 cnx.net.br,CNX Telecom,ISP
+co-mo.net,Co-Mo Connect,ISP
 co.ge,Caucasus Online,ISP
 coastalhosting.net,coastalhosting.net,Web Host
+coastconnect.com,CoastConnect,ISP
+cobbcounty.org,Cobb County Georgia,Government
+cobranet.ng,Cobranet,ISP
 coconet.com,Coconet,ISP
 cod.edu,College of DuPage,Education
+code200.global,code200,ISP
+codelco.cl,Codelco,Industrial
 codetel.net.do,codetel.net.do,ISP
 codibee.com,Codibee,SaaS
 coeficiente.net.mx,Coeficiente,ISP
 coex.co.kr,COEX,Marketing
+coextro.com,Coextro Ontario,ISP
 coface.com,Coface,Finance
+cofc.edu,College of Charleston,Education
 cogeco.ca,Cogeco,ISP
 cogeco.com,Cogeco,ISP
 cogeco.net,Cogoco,ISP
 cogentco.com,Cogent,ISP
 cognizant.com,Cognizant,Technology
+coj.net,City of Jacksonville,Government
+colby.edu,Colby College,Education
 coldwellbankerhomes.com,Coldwell Banker,Real Estate
 coles.com.au,Coles,Retail
+colgate.edu,Colgate University,Education
 collascrill.com,Collas Crill,Legal
 collectivhosting.com,Collectiv,Web Host
 collectorsaddition.com,The Collector's Addition,Retail
 collinsaerospace.com,Collins Aerospace,Defense
+coloblox.com,Coloblox Data Centers,Web Host
 colocationamerica.com,Colocation America,Web Host
 colocrossing.com,ColoCrossing,ISP
 cologix.com,Cologix,IaaS
@@ -1057,9 +1325,11 @@ colos.kz,IFC COLOS,Logistics
 colostate.edu,Colorado State University,Education
 colt.net,Colt,ISP
 columbia.edu,Columbia University,Education
+columbus.k12.oh.us,Columbus Public Schools,Education
 columbus.te.ua,MAXNET,ISP
 combell.com,Combell,Web Host
 combolivre.net.br,Connection Multimidia,ISP
+comcare.gov.au,Comcare,Government
 comcast.com,Comcast,ISP
 comcast.net,Comcast,ISP
 comcastbusiness.net,Comcast Business,ISP
@@ -1067,13 +1337,17 @@ comcel.com.co,Claro Colombia,ISP
 comcor.ru,AKADO Telecom,ISP
 comentum.com,Comentum,Technology
 comfori.com,Comfori,SaaS
+comfortel.pro,Comfortel,ISP
 comline.com,West Coast Internet (WCI),ISP
+commbank.com.au,Commonwealth Bank of Australia,Finance
+commerce.gov,US Department of Commerce,Government
 commonwealthu.edu,Commonwealth University of Pennsylvania,Education
 communilink.com,CommuniLink,Web Host
 communilink.net,CommuniLink,Web Host
 communitect.com,Solutionreach,SaaS
 communityfibre.co.uk,Community Fibre,ISP
 communitymedical.org,Community Medical Centers,Healthcare
+comnet.bg,Comnet Bulgaria,ISP
 comnet.net.id,Comtronics Systems,MSP
 comnett.com.br,Comnett Provedor de Internet,ISP
 complemar.com,Complemar,Logistics
@@ -1088,6 +1362,7 @@ computerdoctor-usa.com,The Computer Doctor,MSP
 computerguyz.ca,Computer Guyz,MSP
 computerstlouis.com,Computer St. Louis,MSP
 computronics.com,Computronics,Technology
+comteco.com.bo,Comteco,ISP
 comune.livorno.it,Città di Livorno,Government
 comunitel.net,Vodafone,ISP
 comwave.net,Comwave (Rogers),ISP
@@ -1105,21 +1380,27 @@ conectrj.com.br,Conect Internet,ISP
 conecttelecom.com.br,Connect Telecom,ISP
 conectv.com.br,Conectv,ISP
 conectvirtua.com.br,Conect Virtua,ISP
+conestogac.on.ca,Conestoga College,Education
 conexaoi9.com.br,Conexão I9,ISP
 conexiondigitalsas.net,Conexión Digital,ISP
 conexonconnect.com,Conexon Connect,ISP
+conncoll.edu,Connecticut College,Education
+connect.net.pk,Connect Communications Pakistan,ISP
 connect10.com.br,Connect 10,ISP
 connectalagoas.com.br,Connect Alagoas,ISP
+connectctc.com,Consolidated Telephone (CTC),ISP
 connectit.com.au,Connect I.T.,MSP
 connectmax.com.br,Algar Mogi (ConnectMax),ISP
 connectrio.com.br,Connect Rio,ISP
 connectsul.com.br,Connectsul,ISP
+connectwave.co.kr,ConnectWave,SaaS
 connectworld.psi.br,Connect World Telecom,ISP
 connectzone.in,Connect Broadband,ISP
 connextelecom.com.br,Connex Fibra,ISP
 conoha.ne.jp,ConoHa,Web Host
 consideredcreative.com,Considered Creative,Marketing
 consilio.com,Consilio,Legal
+consol.com,Consolidated Edison (ConEd),Utilities
 consolidated.com,Consolidated Communications,ISP
 consolidatedlabel.com,Consolidated Label,Print
 consolidatednd.com,Consolidated Telcom,ISP
@@ -1130,32 +1411,47 @@ consumeroptions.co.ke,Consumer Options,Consulting
 contabo.com,Contabo,Web Host
 contaboserver.net,Contabo,Web Host
 contato.net,Contato Internet,ISP
+continent8.com,Continent 8,Web Host
 convention.co.jp,Japan Convention Services,Marketing
 convergeict.com,Converge,ISP
 convergencegroup.co.uk,Convergence Group,ISP
 convergent-interfreight.com,Convergent Interfreight,Logistics
 convergentindia.com,Convergent Wireless,MSP
 convergentwireless.com,Convergent Wireless,MSP
+convergenze.it,Convergenze,ISP
+convergeone.com,C1 (ConvergeOne),MSP
+conwaycorp.com,Conway Corp,ISP
 coolideas.co.za,Cool Ideas,ISP
 cooolbox.bg,Cooolbox,ISP
 coopenet.com.ar,Coopenet,ISP
 cooperatelecom.com.br,Coopera Telecom,ISP
+cooptel.qc.ca,Cooptel,ISP
 cooptortu.com.ar,Cooperativa de Tortuguitas,ISP
 copaco.com.py,Copaco,ISP
 copreltelecom.com.br,Coprel Telecom,ISP
+coprosys.cz,Coprosys,ISP
+coquitlam.ca,City of Coquitlam,Government
 corbina.net,Beeline,ISP
 corbina.ru,PJSC VimpelCom,ISP
 corblock.com,Corblock,Industrial
 cordialmail.net,Cordial,Marketing
+core-backbone.com,Core-Backbone,ISP
+coreix.net,Coreix,Web Host
 corephp.com,corePHP,Marketing
 coreserver.jp,CORESERVER,Web Host
+coresite.com,CoreSite,Web Host
 corespace.com,CoreSpace,Web Host
 coreweave.com,CoreWeave,IaaS
 corewellhealth.org,Corewell Health,Healthcare
+coriolis-telecom.fr,Coriolis Telecom,ISP
 cornell.edu,Cornell University,Education
+cornellcollege.edu,Cornell College,Education
 cornerstoneondemand.com,Cornerstone,SaaS
 corp-email.com,Shanghai Qingyu Computer Technology,Email Security
 corporativafiber.com.br,Corporativa Fiber,ISP
+cortland.edu,SUNY Cortland,Education
+cosmonova.net,Cosmonova,ISP
+cosmopolitanlasvegas.com,The Cosmopolitan of Las Vegas,Travel
 costalogistica.com,Costa Logística,Logistics
 cotas.com,Cotas,ISP
 cotas.com.bo,Cotas,ISP
@@ -1163,15 +1459,18 @@ cotea.com.ar,COTEA,ISP
 cotecal.com.ar,Cotecal,ISP
 cotton-warehouse.com,Cotton Warehouse Classic Cars,Automotive
 coucou-networks.fr,Free Mobile,ISP
+countyofriverside.us,County of Riverside,Government
 covage.com,Covage,ISP
 cox.com,Cox Communications,ISP
 cox.net,Cox Communications,ISP
+coxenterprises.com,Cox Enterprises,Conglomerate
 cp247.net,M247,Web Host
 cpa1040.com,CPA 1040,Finance
 cpanelhost.cl,cPanelHost,Web Host
 cpcc.edu,Central Piedmont Community College,Education
 cpi.ad.jp,CPI,Web Host
 cpi340b.com,Contract Pharmacy Insight,Healthcare
+cpp.edu,Cal Poly Pomona,Education
 cprapid.com,cPanel,Web Host
 cpserver.com,A2 Hosting,Web Host
 cpsinet.com,TruBridge,Healthcare
@@ -1185,6 +1484,7 @@ creaworld.com.sg,Creative eWorld,Marketing
 credit-agricole.com,Crédit Agricole,Finance
 credo-telecom.ru,Credo Telecom,ISP
 creehan.com,Inovalon (Formerly Creehan & Company),Healthcare
+creighton.edu,Creighton University,Education
 crelcom.ru,Crelcom,ISP
 creolink.com,Creolink Communications,ISP
 crim.ca,Centre de Recherche Informatique de Montréal,Education
@@ -1192,23 +1492,28 @@ crisis24.com,Crisis24,SaaS
 criticalcase.com,Criticalcase,Web Host
 criticalhub.com,Critical Hub Networks,ISP
 cromptonpartners.com,Crompton Partners Abu Dhabi,Real Estate
+cronomagic.com,Cronomagic,Web Host
 crossinx.com,Unifiedpost Group,SaaS
 crowncastle.com,Crown Castle,ISP
 crowncloud.net,CrownCloud,Web Host
 crxmgmt.com,The Medicine Shoppe Franchisee,Healthcare
 csc.fi,CSC Finland,Science
+csf.ne.jp,Cable Station Fukuoka (CSF),ISP
 cshl.edu,Cold Spring Harbor Laboratory,Education
 csipiemonte.it,CSI Piemonte,Government
 csiro.au,CSIRO,Science
+csl.de,CSL Computer Service Langenbach,ISP
 cslox.com,CS LoxInfo,ISP
 csloxinfo.com,CSL,MSP
 csloxinfo.net,CS Loxinfo,ISP
 csnet.inf.br,CSNET,ISP
 csod.com,Cornerstone,SaaS
+cspire.com,C Spire,ISP
 cspirefiber.com,C Spire,ISP
 csr24.com,Applied Systems,SaaS
 csu.edu.au,Charles Sturt University,Education
 csuc.cat,CSUC,Education
+csufresno.edu,California State University Fresno,Education
 csuohio.edu,Cleveland State University,Education
 csus.edu,California State University Sacramento,Education
 ct.edu,Connecticut State Colleges and Universities,Education
@@ -1216,15 +1521,20 @@ ct.gov,Connecticut Government,Government
 ct1000.com,China Telecom,ISP
 ctbcbank.com.ph,CTBC Bank (Philippines) Corp.,Finance
 ctbctelecom.com.br,Algar Telecom,ISP
+ctc-g.co.jp,ITOCHU Techno-Solutions (CTC),MSP
 ctc.co.jp,Chubu Telecommunications,ISP
 ctctel.com,Consolidated Telcom,ISP
 ctedunet.net,Connecticut Education Network,Education
 ctgserver.com,CTG Server,Web Host
+cthosp.org,Connecticut Hospital Association,Nonprofit
+cti.gr,CTI Diophantus Greek Research Institute,Science
 ctl.one,CenturyLink,ISP
 ctm.net,CTM,ISP
 ctrls.com,CtrlS,Web Host
 ctrls.in,CtrlS,Web Host
+ctstelecom.com,CTS Communications,ISP
 ctt.ne.jp,Cable Television Toyama,ISP
+ctvbeam.com,Beam Broadband,ISP
 cty-cns.jp,Suzuka Cable,ISP
 cubiespot.net.id,Cubiespot,ISP
 cuenote.jp,Cuenote,SaaS
@@ -1232,11 +1542,16 @@ cuhk.edu.hk,Chinese University of Hong Kong,Education
 cultureamp.com,Culture Amp,SaaS
 cumberlandconnect.org,Cumberland Connect,ISP
 cuny.edu,City University of New York,Education
+curtin.edu.au,Curtin University,Education
 customer.speedpartner.de,SpeedPartner,Web Host
 customercontrolpanel.de,netcup,Web Host
+cut.net,Central Utah Telephone,ISP
 cvent-planner.com,Cvent,SaaS
 cvent.com,Cvent,SaaS
+cvtelecom.cv,Cabo Verde Telecom,ISP
 cvtsv.com,Cvent,SaaS
+cw-e.ca,Connecting Windsor-Essex,Nonprofit
+cwc.com,Cable and Wireless Turks and Caicos,ISP
 cwdom.dm,Cable & Wireless Dominica,ISP
 cwmc.com.br,CWMC,ISP
 cwnetworks.com,Liberty Networks,ISP
@@ -1246,6 +1561,7 @@ cybasp.com,CyberlinkASP,Web Host
 cyber-folks.pl,cyber_Folks,Web Host
 cyber.net.pk,Cybernet,ISP
 cybera.net,Cybera,ISP
+cybercon.com,Digital Space (Cybercon),Web Host
 cyberfolks.hr,cyber_Folks,Web Host
 cyberfolks.pl,cyber_Folks,Web Host
 cyberfolks.ro,cyber_Folks,Web Host
@@ -1261,9 +1577,12 @@ cybernextech.com,CYBER NEXTECH,Web Host
 cybersmart.co.za,Cybersmart,ISP
 cybertelecom.com.br,Cyber Telecom,ISP
 cybertelecom.net.br,Cyber Telecom,ISP
+cybertrails.com,CyberTrails,Web Host
+cyberwurx.com,Cyberwurx,Web Host
 cyberzonehub.com,Cyberzone,Web Host
 cyfronet.pl,Cyfronet,Education
 cyfrowypolsat.pl,Polsat Box,ISP
+cyfuture.com,Cyfuture,Web Host
 cynet.com.my,Cynet,Web Host
 cynethost.com,Cynet,Web Host
 cyon.ch,cyon,Web Host
@@ -1272,9 +1591,11 @@ cyon.net,Cyon,Web Host
 cyon.site,cyon,Web Host
 cyrusone.com,CyrusOne,IaaS
 cyta.com.cy,Cyta,ISP
+d-hosting.de,d-hosting,Web Host
 d2l.com,D2l Brightspace,SaaS
 d2s.cloud,d2s.cloud,Web Host
 daakbabu.com,Daak Babu,Email Provider
+dacor.de,suc dacor,ISP
 dadabroadband.com,DaDa Broadband,ISP
 daemonmail.ner,DaemonMail,Email Provider
 daemonmail.net,TierraNet,Web Host
@@ -1283,6 +1604,7 @@ dailyrazor.com,DailyRazor,Web Host
 dakotapro.biz,DakotaPro,ISP
 dal.ca,Dalhousie University,Education
 dal.net.tr,DALNET,Web Host
+dallascollege.edu,Dallas College,Education
 dalnet.tr,DALNET,Web Host
 damcogroup.com,Damco Solutions,MSP
 damel.com,Damel Group,Food
@@ -1292,13 +1614,19 @@ daouoffice.com,Dooray,SaaS
 daraju.com,Daraju,Healthcare
 darpa.mil,DARPA,Defense
 dartmouth-hitchcock.org,Dartmouth-Hitchcock,Healthcare
+dartmouth.edu,Dartmouth College,Education
 darysoft.com,Dary Web Designs,Web Host
+data-tronics.com,ArcBest Technologies,Logistics
+data102.com,Hivelocity (Data102),Web Host
 data443.com,Data443,Email Security
 databank.com,DataBank,Web Host
 datacamp.co.uk,CDN77,Web Host
+datacentrum.sk,DataCentrum Slovakia,Government
 datacom.com,Datacom,MSP
 datacom.com.au,Datacom,MSP
+dataforest.net,dataforest,Web Host
 datagroup.ua,Datagroup,ISP
+datak.ir,Datak,ISP
 datanat.com,Datanational Corporation,MSP
 datapipe.com,Rackspace,Web Host
 dataport.de,Dataport,Government
@@ -1313,14 +1641,24 @@ dattorelay.com,Datto,MSP
 dattoweb.com,Datto,MSP
 dauphintelecom.com,Dauphin Telecom,ISP
 daystar.io,Daystar Email Service,Email Provider
+db.com,Deutsche Bank,Finance
+dbcity.com,Waller Creek Communications,ISP
 dbl-group.com,DBL Group,Conglomerate
 dbug.com.br,DBUG Telecom,ISP
 dc.gov,District of Columbia Government,Government
 dc37.net,District Council 37,Nonprofit
+dca.net,DCANet,ISP
+dcc.bg,Cifrova Kabelna Korporacia,ISP
+dcceew.gov.au,Australian Department of Climate Change Energy Environment Water,Government
+dcdi.net,Direct Communications Rockland (DCDI),ISP
 dcfa.net,Douglas College,Education
+dcsmanage.com,DCS Pacific Star,MSP
+dcta.mil.br,DCTA Brazil Aerospace Science and Technology,Defense
+dctv.net.tw,Digidom CableTV,ISP
 dcz.gov.ua,State Employment Service of Ukraine,Government
 ddccommunications.com,DDC public affairs,Marketing
 ddcpublicaffairs.com,DDC public affairs,Marketing
+ddfr.nl,DDFr IT Infra and Security,MSP
 ddns.net,No-IP,Web Host
 ddnsgeek.com,Dynu,Web Host
 ddnsking.com,No-IP,Web Host
@@ -1329,16 +1667,24 @@ ddnss.org,DDNSS,Web Host
 deadline.com,Deadline,News
 deakin.edu.au,Deakin University,Education
 dealerscloud.com,DealersCloud,SaaS
+deanza.edu,Foothill-DeAnza Community College District,Education
 dec.net.ua,Donbass Electronic Communications,ISP
+dec.nsw.edu.au,NSW Department of Education,Education
+dedicado.com,Dedicado Uruguay,ISP
+dedicated.com,Dedicated.com,Web Host
 deere.com,John Deere,Agriculture
 deerfieldhosting.net,Deerfield Hosting,Web Host
 default-host.net,INHOSTED LP,Web Host
 deic.dk,DeiC,Education
+delaware.gov,State of Delaware,Government
+delhi.edu,SUNY Delhi,Education
 delhitel.com,Delhi Telephone Company,ISP
 delhitel.net,Delhi Telephone Company,ISP
 deliverychain.io,Delivery Chain,SaaS
 dell.com,Dell,Technology
 deloitte.com,Deloitte,Consulting
+delska.com,Delska,Web Host
+delta-telecom.net,Delta Telecom Azerbaijan,ISP
 delta.com,Delta Air Lines,Travel
 delta.nl,DELTA Fiber,ISP
 deltaativa.net.br,Delta Ativa,ISP
@@ -1347,24 +1693,29 @@ deltahost-ptr,DeltaHost,Web Host
 deltainternet.net.br,Ired Internet,ISP
 demandware.net,Salesforce Commerce Cloud,SaaS
 democrats.com,Democrats.com,Nonprofit
+denvergov.org,City and County of Denver,Government
 depaul.edu,DePaul University,Education
 deshaw.com,D. E. Shaw,Finance
 designerstudio.it,Designer Studio,Marketing
 desktop.com.br,Desktop,ISP
 deskwing.net,DESKWING,Email Provider
 desy.de,DESY,Government
+detroitedison.com,DTE Energy,Utilities
 deutsche-glasfaser.de,Deutsche Glasfaser,ISP
 deutschepost.de,Deutsche Post,Logistics
+devoli.com,Devoli,ISP
 dewr.gov.au,Australian Department of Employment and Workplace Relations,Government
 dexanet.co.id,Dexanet,ISP
 deztelecom.net.br,Dez Telecom,ISP
 dfn.de,DFN,Education
+dfn.net,Douglas Fast Net,ISP
 dfn.nl,DELTA Fiber,ISP
 dgeduf.or.kr,Daegu Dong-gu Education Foundation,Education
 dgsys.es,DGsys,Web Host
 dgtelecom.com.br,DG Telecom,ISP
 dh.bytemark.co.uk,Bytemark,Web Host
 dhamma.org,Vipassana Meditation,Nonprofit
+dhiraagu.com.mv,Dhiraagu,ISP
 dhl.com,DHL,Logistics
 diako-dresden.de,Diakonissenanstalt Dresden,Healthcare
 diakovere.de,DIAKOVERE,Healthcare
@@ -1379,6 +1730,7 @@ digi.ro,DIGI Romania,ISP
 digicelbroadband.com,Digicel,ISP
 digicelgroup.com,Digicel,ISP
 digicelsr.com,Digicel,ISP
+digicert.com,DigiCert,Email Security
 digijadoo.net,Jadoo Digital,ISP
 digikabel.hu,One Hungary (Formerly DIGI),ISP
 digimobil.es,DIGI Spain,ISP
@@ -1402,9 +1754,11 @@ digiturunc.com,Digiturunc,Web Host
 digitusinfo.com.br,Digitus Informatica,ISP
 digivate.com,Digivate,Marketing
 digiweb.ie,Digiweb,ISP
+digsys.bg,Digital Systems Bulgaria,ISP
 diltechnology.com,DIL Technology,ISP
 dimenoc.com,HostDime.com,Web Host
 dimensiondata.com,NTT DATA,Consulting
+dimensionet.com,Dimension Network and Communication,ISP
 dinamichosting.com,Dinamic Hosting,Web Host
 dinaserver.com,Dinahosting,Web Host
 dipelnet.com.br,Dipelnet,ISP
@@ -1417,24 +1771,31 @@ discoverflow.co,Flow,ISP
 discovergreene.com,"Greene County, New York",Government
 disenosweb.mx,Hive Studio,Web Host
 dishemail.com,DISH,ISP
+disney.com,Disney,Entertainment
 distributel.ca,Distributel,ISP
+dito.ph,DITO Telecommunity,ISP
 ditscloud.com,DITSCloud,MSP
 divdav.com,DIV DAV,Marketing
 divide0.net,Divide Zero Networks,Web Host
 djaweb.dz,Telecom Algeria,ISP
 dji.com,DJI,Technology
+djiboutitelecom.dj,Djibouti Telecom,ISP
 dktv.dk,DKTV,ISP
 dkw-akademie.com,DKW Akademie,Education
 dlife.cn,21CN,Email Provider
 dlive.kr,DLIVE,ISP
 dlivry.co,Twilio SendGrid,Marketing
+dls.net,DLS Internet Services,ISP
+dmc.org,Detroit Medical Center,Healthcare
 dmctelecom.com.br,DMC Telecom,ISP
+dmit.com,DMIT Cloud Services,Web Host
 dmmhosts.com,DMM Hosts,Web Host
 dna.fi,DNA,ISP
 dnchosting.com,Directnic,Web Host
 dnetprovider.id,D~NET,ISP
 dnetsurabaya.id,D~NET,ISP
 dnns.net,No-IP Dynamic DNS,Web Host
+dns-net.de,DNS:NET,ISP
 dnsalias.com,DynDNS,Web Host
 dnsalias.net,DynDNS,Web Host
 dnsalias.org,DynDNS,Web Host
@@ -1451,6 +1812,7 @@ docusign.net,Docusign,SaaS
 dodea.edu,U.S. Department of Defense Education Activity,Education
 dogado.de,dogado,Web Host
 dokom21.de,DOKOM21,ISP
+dolsat.pl,Dolsat,ISP
 dom.ru,ER-Telecom,ISP
 domaincentral.com.au,Domain Central,Web Host
 domaineinternet.ca,Rapidenet Canada,Web Host
@@ -1461,6 +1823,7 @@ domene.shop,Domeneshop,Web Host
 domeneshop.no,Domeneshop,Web Host
 domru.ru,ER-Telecom,ISP
 domtel.com.pl,DOMTEL,ISP
+donga.ac.kr,Dong-A University,Education
 donotspam.de,indevis,MSSP
 donpac.ru,Rostelecom,ISP
 doruk.net.tr,DorukNet,Web Host
@@ -1474,9 +1837,12 @@ dotinternetbd.com,DOT Internet,ISP
 dotmailer.com,Dotdigital,Marketing
 dotroll.com,DotRoll,Web Host
 downloaddatarecovery.com,KernelApps,Technology
+dqecom.com,DQE Communications,ISP
 draminski.com,Dramiński Technology,Healthcare
 draper.com,Draper Laboratory,Defense
+dravanet.hu,Dravanet,ISP
 drayddns.com,DrayTek,Web Host
+drc.gov.cn,Development and Research Center of State Council,Government
 dreamcompute.com,Dreamhost,Web Host
 dreamhost.com,Dreamhost,Web Host
 dreamhosters.com,Dreamhost,Web Host
@@ -1493,9 +1859,11 @@ drive.ne.jp,Drive Network,Web Host
 drivepath.net,DrivePath Hosting,Web Host
 drjapan-jp.com,"Dr. Japan Co., Ltd.",Healthcare
 dropboxinc.com,Dropbox,SaaS
+drpeng.com.cn,Dr. Peng,ISP
 drreddys.ro,Dr. Reddy's,Healthcare
 dslon.ws,Dslon Wireless,ISP
 dsmc.or.kr,Keimyung University Dongsan Medical Center,Healthcare
+dstl.gov.uk,Defence Science and Technology Laboratory,Defense
 dstny.com,Dstny,SaaS
 dsu.edu,Dakota State University,Education
 dsv.com,DSV,Logistics
@@ -1504,6 +1872,8 @@ dtac.co.th,dtac,ISP
 dtctelecom.com.br,DTC Telecom,ISP
 dtel.com.br,Dtel Telecom,ISP
 dtel.ru,Dagomys Telecom (Dtel),ISP
+dtln.ru,Data Storage Center,Web Host
+dtmicro.com,DT Micro,Web Host
 dts-security.de,DTS,MSP
 dts.de,DTS,MSP
 du.ae,du,ISP
@@ -1516,10 +1886,14 @@ duke.edu,Duke University,Education
 dunyakatilim.com.tr,Dünya Katılım,Finance
 duo-county.com,DUO Broadband,ISP
 duobroadband.com,DUO Broadband,ISP
+duocast.nl,Duocast,Web Host
 duplexcleaning.au,Duplex Cleaning Machines,Manufacturing
 duq.edu,Duquesne University,Education
+durand.com.br,Durand do Brasil,ISP
 dvcotechnology.com,Cision,Marketing
 dvois.com,D-VoiS,ISP
+dvusd.org,Deer Valley Unified School District,Education
+dwango.co.jp,Dwango,Entertainment
 dwd.de,Deutscher Wetterdienst,Government
 dwgreen.com,DW Green Company,Marketing
 dwit.co.kr,Daewon Information Technology Co.,MSP
@@ -1540,24 +1914,34 @@ dyndns.ws,DynDNS,Web Host
 dyndns1.de,DDNSS,Web Host
 dynv6.net,dynv6,Web Host
 dyspatchit.net,Dyspatchit,Marketing
+dyx-tech.com,DYXnet,ISP
 dyxnet.com,DYXnet,MSP
+e-catv.ne.jp,Ehime CATV,ISP
 e-i.com,Euro-Information,MSP
 e-kei.pl,Kei,Web Host
 e-mmunity.net,VIPRE,Email Security
+e-quest.nl,e-Quest,MSP
+e1b.org,Erie 1 BOCES,Education
+e2enetworks.com,E2E Networks,IaaS
 e2ma.net,Emma,Marketing
 e4.cz,E4YOU,Web Host
+ea.com,Electronic Arts,Entertainment
 eagerweb.com,Eager Web Services,Web Host
 eaglecom.net,Vyve Broadband,ISP
 earthlink-vadesecure.net,Vade Secure,Email Security
+earthlink.iq,Earthlink Iraq,ISP
 earthlink.net,EarthLink,ISP
 eastern-tele.com,Eastern Communications,ISP
 eastern.com.ph,Eastern Telecoms,ISP
 easterndsl.com.ph,Eastern Communications,ISP
+eastex.com,Eastex Telephone Cooperative,ISP
 eastlink.ca,Eastlink,ISP
+eastwest.com.pl,East&West,ISP
 easy-hebergement.fr,Easy-Hébergement,Web Host
 easy-hebergement.net,Easy-Hébergement,Web Host
 easydns.com,easyDNS,Web Host
 easydns.net,easyDNS,Web Host
+easyhost.be,Easyhost,Web Host
 easykeys.com,EasyKeys,Retail
 easymail.ca,easyMail,Email Provider
 easyname.com,easyname,Web Host
@@ -1566,13 +1950,18 @@ easyseo.com.my,SEO Services Malaysia,Marketing
 easyweb.com,easyDNS,Web Host
 eatel.com,REV,ISP
 eaton.com,Eaton,Industrial
+ebayinc.com,eBay,Retail
+ebb.my,Extreme Broadband,ISP
+ebonenet.com,Ebone Network,ISP
 eboundhost.com,eBoundhost,Web Host
 ebox.ca,EBOX,ISP
 ebsco.com,EBSCO Industries,Publishing
+ec.com.cn,CIETNET China International Electronic Commerce,SaaS
 ec2software.com,ec² Software Solutions,Healthcare
 echolabs.net,Echo Labs,MSP
 echoworx.net,Echoworx,Email Security
 ecm8.com,Campaign Master (UK),Marketing
+ecmc.edu,Erie County Medical Center,Healthcare
 ecohost.la,ecohost Latinoamerica,Web Host
 econsave.com.my,Econsave,Retail
 ecosoft.com,Ecosoft,Industrial
@@ -1584,23 +1973,33 @@ ecritel.fr,Ecritel,MSP
 ecritel.net,Ecritel,MSP
 ecu.edu,East Carolina University,Education
 edge.uol,Edge UOL,IaaS
+edgecenter.ru,EdgeCenter,IaaS
 edgecompute.app,Fastly,Technology
 edgekey.net,Akamai,Technology
+edgenext.com,EdgeNext,Web Host
 edgepark.com,Edgepark,Healthcare
 edgesuite.net,Akamai,Technology
 edgetelecom.com.br,Edge Telecom,ISP
+edgeuno.com,EdgeUno,ISP
 edion.co.jp,EDION,Retail
+edis.at,EDIS,Web Host
+ediscom.de,e.discom Telekommunikation,ISP
 edisglobal.com,EDIS Global,Web Host
 editorx.io,Wix,SaaS
+edmonton.ab.ca,City of Edmonton,Government
 edpnet.be,EDPnet,ISP
 edpnet.net,EDPnet,ISP
 edu.com,InstructionalAssistant,SaaS
 eduneering.com,UL EHS training,SaaS
+edwardjones.com,Edward Jones,Finance
+edwardrose.com,Edward Rose Manifold Services,Real Estate
 ee.net,eNET,ISP
+eenet.ee,EENet Estonian Research and Education Network,Education
 efit.net.br,FIT Telecom,ISP
 eforw.com,Eforw,Email Provider
 egasolutions.com.br,EGA Solutions,Logistics
 egate.net,E-Gate Communications,ISP
+ege.edu.tr,Ege University,Education
 egihosting.com,EGIHosting,Web Host
 egov.com,Tyler Technologies,SaaS
 egress.cloud,Egress Software,Email Security
@@ -1612,15 +2011,19 @@ ehaf.com,EHAF Consulting Engineers,Construction
 ehafconsulting.org,EHAF Consulting Engineers,Construction
 ehime-u.ac.jp,Ehime University,Education
 ehostsolution.net,E Host Solution,Web Host
+ehu.eus,University of the Basque Country,Education
+eidsiva.net,Eidsiva,ISP
 eigbox.net,Newfold Digital,Web Host
 einsteinemail.com,Einstein Industries,Web Host
 einsteinmail.com,Einstein Industries,Web Host
 eir.ie,eir,ISP
 eircom.net,Eir,ISP
+eisenhowercareers.com,Eisenhower Health,Healthcare
 eiu.edu,Eastern Illinois University,Education
 ejmnet.com.br,ILogNet,ISP
 ejpress.com,eJournalPress,SaaS
 ekoline.net.pl,Eko-Line,ISP
+eku.edu,Eastern Kentucky University,Education
 elasticbeanstalk.com,Amazon AWS,PaaS
 elcat.kg,ElCat,ISP
 elcom.ru,Rostelcom,ISP
@@ -1629,14 +2032,18 @@ electric.coop,NRECA,Nonprofit
 electric.net,VIPRE,Email Security
 electriclightwave.com,Allstream,ISP
 elementa.com,Elementa,MSP
+elementmedia.com,ElementMedia,Web Host
 elevartelecom.com.br,Elevar Telecom,ISP
+elevate.uk,Elevate (Telcom Networks),ISP
 elevatedstudios.tech,Elevated Studios,Web Host
 eleven-dynamics.nl,Eleven Dynamics,MSP
 eleven.mx,Eleven Marketing Labs,Marketing
 elim.net,Elimnet,MSSP
 elisa.ee,Elisa,ISP
 elisa.fi,Elisa,ISP
+elisteka.lt,Serveriai.lt (Elisteka),Web Host
 elitechgroup.com,ELITechGroup,Healthcare
+elitework.com,EliteWork,SaaS
 elive.net,Elive,Web Host
 elkdata.ee,Elkdata,Web Host
 elkem.com,Elkem,Manufacturing
@@ -1644,6 +2051,7 @@ ellipse.net,Ellipse,MSP
 elmecnet.net,Elmec Informatica,MSP
 elnk.net,Earthlink,ISP
 elntelecom.com.br,ELN Telecom,ISP
+elon.edu,Elon University,Education
 elte.hu,Eötvös Loránd University,Education
 email-od.com,SocketLabs,SaaS
 emailarray.com,Emailarray,Email Provider
@@ -1659,12 +2067,15 @@ embriq.no,Embriq,MSP
 emcali.com.co,EMCALI,Utilities
 emeraldonion.net,Emerald Onion,Nonprofit
 emeraldonion.org,Emerald Onion,Nonprofit
+emerson.com,Emerson,Manufacturing
 emexinternet.com.br,Emex Internet,ISP
 emirates.net.ae,Etisalat,ISP
 emma-solutions.nl,Emma Solutions (Formerly Wylance),MSP
 emory.edu,Emory University,Education
 empaquesmundiales.com,Empaques Mundiales,Industrial
+empireaccess.com,Empire Access,ISP
 emporiaresearch.com,Emporia,SaaS
+empower-retirement.com,Empower Retirement,Finance
 emsecure.net,Selligent,Marketing
 emsend2.com,ActiveCampaign,Marketing
 emtel.com,Emtel,ISP
@@ -1674,16 +2085,22 @@ endurance.com,Newfold Digital,Web Host
 enduranceinternational.com,Newfold Digital,Web Host
 enecom.co.jp,Enecom,ISP
 enel.com,Enel,Utilities
+energieag.at,Energie AG,Utilities
+energotel.sk,Energotel,ISP
 energy.gov,U.S. Department of Energy,Government
 energyhousedigital.co.uk,Digivate,Marketing
 energytransfer.com,Energy Transfer,Industrial
 enet.ie,Enet,ISP
+enetworks.co.za,Datacentrix eNetworks,ISP
+enfo.fi,Enfo,MSP
 eng.it,Engineering,Consulting
 enginet.az,Birlink,ISP
 enguard.com,EnGuard,Email Security
 eni.com,Eni,Industrial
 eninetworks.com,ENI Networks,ISP
+enitel.net.ni,Enitel Cablenet Nicaragua,ISP
 enivest.net,Enivest,ISP
+enjoyvc.com,Enjoyvc Cloud,Web Host
 enova.com,Enova International,Finance
 enreach.com,Enreach,SaaS
 ensono.com,Ensono,MSP
@@ -1701,9 +2118,11 @@ enterprisecloud.nu,Zitcom,Web Host
 entrata.com,Entrata,SaaS
 entrustedmail.net,EntrustedMail,Email Security
 enviatel.de,envia TEL,ISP
+enzu.com,Enzu,Web Host
 eodatacenter.com,EO Data Center,IaaS
 eolo.it,EOLO,ISP
 eonemedia.com,eOneMedia,Photography
+eons.cloud,Eons Data Communications,Web Host
 eop.gov,Executive Office of the President,Government
 epa.gov,U.S. Environmental Protection Agency,Government
 epb.com,EPB,ISP
@@ -1711,6 +2130,7 @@ epb.net,EPB,ISP
 epbfi.com,EPB,ISP
 epbnet.com,Russellville Electric Plant Board,ISP
 epfl.ch,EPFL,Education
+epic.com.cy,Epic Cyprus,ISP
 epic.com.mt,Epic (Formerly Vodafone Malta),ISP
 epichs.org,Epic Health,Healthcare
 epicpc.com,Epic Health,Healthcare
@@ -1723,6 +2143,7 @@ eqservers.com,EqServers,Web Host
 equinix.com,Equinix,IaaS
 equinor.com,Equinor,Industrial
 eranyacloud.com,Eranyacloud,IaaS
+erau.edu,Embry-Riddle Aeronautical University,Education
 ereline.com.br,Ereline,ISP
 ericsson.com,Ericsson,Technology
 erie.gov,"Erie County, New York",Government
@@ -1730,12 +2151,16 @@ erlabrunn.de,Kliniken Erlabrunn,Healthcare
 ertelecom.ru,ER-Telecom,ISP
 es.net,ESnet,Education
 esavezone.co.kr,SaveZone,Retail
+esc.net.au,EscapeNet,ISP
+escom.bg,Escom Bulgaria,ISP
 esited.com,eSited,Web Host
 eskerondemand.com,Esker,SaaS
+eskom.co.za,Eskom,Utilities
 esolutionsgroup.ca,Govstack (eSolutions Group),Technology
 esosoft.net,EcoSoft,Web Host
 esqsites123.com,ESQ Sites 123,Web Host
 estruxture.com,eStruxture Data Centers,IaaS
+esuhsd.org,East Side Union High School District,Education
 esvacloud.com,Libraesva,Email Security
 etapa.net.ec,ETAPA EP,ISP
 etb.com,ETB,ISP
@@ -1745,6 +2170,7 @@ etcnow.com,ETC,ISP
 etecsa.cu,ETECSA,ISP
 eternet.cc,Eternet,ISP
 etex.net,Etex,ISP
+ethernet.edu.et,EthERNet (Ethiopian Education Research Network),Education
 etherni.com,Ethernic,MSP
 ethiotelecom.et,Ethio Telecom,ISP
 ethunder-hosting.com,Ethunder Hosting,Web Host
@@ -1752,6 +2178,8 @@ etik-cloud.com,Infomaniak,IaaS
 etipres.com,ETIPRES,Print
 etisalat.com.eg,Etisalat Egypt,ISP
 etius.jp,WebArena,Web Host
+etl.co.ls,Econet Lesotho,ISP
+etop.pl,eTOP,Web Host
 etouches.com,Stova,SaaS
 etri.re.kr,ETRI,Government
 etronsol.com,Etron Solutions,MSP
@@ -1759,6 +2187,7 @@ etsmtl.ca,École de technologie supérieure,Education
 etsu.edu,East Tennessee State University,Education
 eudonet.com,Eudonet,SaaS
 eunetworks.com,euNetworks,ISP
+euro-net.pl,Euronet Bialystok,ISP
 eurocontrol.int,EUROCONTROL,Government
 eurofiber.com,Eurofiber,ISP
 europa.eu,European Union,Government
@@ -1769,8 +2198,10 @@ euskaltel.es,Euskaltel,ISP
 eutelsat.com,Eutelsat,ISP
 ev2.hu,EV2 INTERNET,ISP
 evaair.com,EVA Air,Travel
+evanzo.de,Evanzo,Web Host
 eventelecom.com.br,Even Telecom,ISP
 eventsairmail.com,EventsAir,SaaS
+eveo.com.br,EVEO,Web Host
 everest.vn.ua,Everest TV,ISP
 evernet.net.co,Evernet,ISP
 eversource.com,Eversource Energy,Utilities
@@ -1780,30 +2211,44 @@ everythere.com.au,Everythere,SaaS
 evicertia.com,Evicertia,SaaS
 eviden.com,Eviden,Consulting
 eviny.no,Eviny,Utilities
+evms.edu,Eastern Virginia Medical School,Education
 evo-net.it,evonet,ISP
+evocative.com,Evocative Data Centers,Web Host
+evolink.com,Evolink,ISP
 evolus-it.com,Evolus IX,ISP
 evolus-ix.com,Evolus IX,ISP
 evolusfibre.com,Evolus IX,ISP
 evonik.de,Evonik,Manufacturing
+evoxt.com,Evoxt,Web Host
 ewe-ip-backbone.de,EWE,ISP
 ewe.com,EWE,ISP
 ewp.live,EasyWP,Web Host
+ewu.edu,Eastern Washington University,Education
 eww.at,eww,Utilities
+exa.net.uk,Exa Networks,ISP
 exacthosting.com,Exact Hosting,Web Host
 exactt.com,Salesforce Marketing Cloud (Formerly ExactTarget),Marketing
 exacttarget.com,Salesforce Marketing Cloud (Formerly ExactTarget),Marketing
 exainternet.com.br,EXA Internet,ISP
 exatatelecom.com.br,Exata Telecom,ISP
 exatel.pl,Exatel,ISP
+excellmedia.net,Excell Media,ISP
+excitel.com,Excitel Broadband,ISP
+excom.es,Excom,ISP
 execulink.ca,Execulink Telecom,ISP
 execulink.net,Execulink Telecom,ISP
+exeloncorp.com,Exelon,Utilities
+exepto.ru,Exepto,ISP
 exetel.com.au,Exetel,ISP
+exlibrisgroup.com,Ex Libris,SaaS
 exonhost.com,ExonHost,Web Host
+exoscale.ch,Exoscale,IaaS
 expandtelecom.com.br,Expand Telecom,ISP
 expandtelecom.net.br,Expand Telecom,ISP
 expedia.com,Expedia,Travel
 expedia.net,Expedia,Travel
 expedient.com,Expedient,IaaS
+expereo.com,Expereo,ISP
 experian.com,Experian,Finance
 explorernet.com.br,ExplorerNet,ISP
 explori.com,Explori,Event Planning
@@ -1813,14 +2258,18 @@ express-scripts.com,Express Scripts,Healthcare
 express.com.ar,Express Telecomunicaciones,ISP
 expressinformatica.art.br,Express Fibra,ISP
 extendedcare.com,CarePort,Healthcare
+extra-lan.com.tw,Extra-Lan Technologies,ISP
 extrememt.com.br,Extreme Provedor de Internet,ISP
 extremeserv.net,extremeserv,Web Host
+ey.com,Ernst and Young,Consulting
 ezecom.com.kh,EZECOM,ISP
 ezeefiber.com,Ezee Fiber,ISP
 ezhostingserver.com,Hostek,Web Host
 ezinternetsolutions.com,EZ Internet Solutions,Web Host
 ezorg.nl,E-Zorg,Healthcare
+f-i.de,Finanz Informatik,MSP
 f-integra.org,Fundacion Integra,Nonprofit
+f2x.nl,F2X Fiber Services,ISP
 f5.com,F5,Technology
 faa.gov,Federal Aviation Administration,Government
 facebook.com,Meta,Social Media
@@ -1829,12 +2278,18 @@ fahrenheit88.com,fahrenheit88,Retail
 faiba.co.ke,Jamii Telecommunications,ISP
 fairfax.va.us,"Fairfax County, Virginia",Government
 fairview.org,Fairview Health Services,Healthcare
+famu.edu,Florida A and M University,Education
 fanaptelecom.ir,Fanap Telecom,ISP
+fanava.net,Fanava Group,ISP
 fao.org,Food and Agriculture Organization of the United Nations,Government
 fap.mil.pe,La Fuerza Aérea del Perú (FAP),Government
+fapesc.sc.gov.br,FAPESC Santa Catarina Research Foundation,Government
 fareastone.com.tw,FarEasTone,ISP
 farlep.net,Farlep-Invest,ISP
+farmerstel.com,Farmers Telecommunications Cooperative,ISP
 farmerstelcom.com,Farmers Telephone (FTI),ISP
+farmingdale.edu,Farmingdale State College,Education
+farmside.co.nz,Farmside,ISP
 fast.net.id,Linknet-Fastnet,ISP
 fast.net.kg,Skynet Telecom,ISP
 fast.net.uk,FASTNET,ISP
@@ -1845,18 +2300,24 @@ fastly.com,Fastly,SaaS
 fastlylb.net,Fastly,Technology
 fastmail.com,Fastmail,Email Provider
 fastnet.kg,FastNet,ISP
+fastnetdata.com,FASTNET DATA,Web Host
 fastspeed.dk,Fastspeed,ISP
 fasttelco.com,FASTtelco,ISP
+fasttrackcomm.net,FastTrack Communications,ISP
 fastvps-server.com,P.A.G.M. OU,Web Host
 fastweb.it,Fastweb,ISP
+fatbeam.com,Fatbeam Fiber,ISP
 fatum.ru,Fatum,ISP
 fau.edu,Florida Atlantic University,Education
 faxpipe.com,FaxPipe (Formerly AirCom USA),SaaS
+fbi.gov,FBI,Government
 fbi.ie,Future Business,Technology
 fbnet.com.br,FB Net,ISP
 fc-net.fr,fcnet,ISP
 fccn.pt,FCCN,Education
+fcconnexion.com,Fort Collins Connexion,ISP
 fcnet.fr,fcnet,ISP
+fcps.edu,Fairfax County Public Schools,Education
 fdcservers.net,FDC Servers,Web Host
 fdu.edu,Fairleigh Dickinson University,Education
 fea.net,West Coast Internet (WCI),ISP
@@ -1864,12 +2325,17 @@ feasa.ie,Feasa,Industrial
 federalreserve.gov,Federal Reserve,Government
 fedex.com,FedEx,Logistics
 ferreterialindavista.com,Somos Ferreteria Lindavista,Retail
+ferris.edu,Ferris State University,Education
 feslegen.com.tr,Feslegen Catering,Food
+festo.com,Festo,Manufacturing
 fetnet.net,FETNet,ISP
 fgl.com.mx,Francisco Garcia Lopez,Healthcare
 fhcrc.org,Fred Hutchinson Cancer Research Center,Healthcare
 fhptelecom.com.br,FHP Telecom,ISP
+fiber.net,Fibernet Utah,Web Host
 fiber.net.id,Fiber Networks Indonesia,ISP
+fibercop.it,FiberCop,ISP
+fibergrid.net,Fiber Grid,ISP
 fiberhub.com,FiberHub,ISP
 fiberinternet.com.br,SpeedNet Telecom,ISP
 fibernetics.ca,Fibernetics,ISP
@@ -1886,6 +2352,7 @@ fibranetdqx.com.br,Fibranet Telecom,ISP
 fibranett.net.br,Fibranett,ISP
 fibrativainternet.com.br,FibrAtiva,ISP
 fibrenoire.ca,fibrenorie,ISP
+fibrlink.com,Beijing FibrLINK Networks,ISP
 fibron.com.br,Fibron Telecom,ISP
 fidelitycommunications.com,Fidelity Communications,ISP
 fidium.com,Fidium Fiber,ISP
@@ -1893,12 +2360,16 @@ fidiumfiber.com,Fidium Fiber,ISP
 figma.com,Figma,SaaS
 figma.site,Figma,SaaS
 figueiredoprovedores.com.br,COMNET,ISP
+filanco.ru,Citytelecom (Filanco),ISP
 finanzaworld.it,FinanzaWorld,Finance
 finanzaworld.net,FinanzaWorld,Finance
+fiocruz.br,Fiocruz Oswaldo Cruz Foundation,Education
 firebaseapp.com,Google,PaaS
 fireeyecloud.com,FireEye,Email Security
 fireeyegov.com,FireEye (Government),Email Security
 firenettelecom.com.br,FireNet Telecom,ISP
+firmenich.com,dsm-firmenich,Manufacturing
+first-server.net,FirstServer,Web Host
 firstcloudsecurity.net,CyberCision,Email Security
 firstcolo.net,firstcolo,Web Host
 firstcomm.com,FirstComm,ISP
@@ -1914,8 +2385,12 @@ fiserv.com,Fiserv,Finance
 fisherpaykel.com,Fisher & Paykel,Retail
 fisquare.com,Infince,SaaS
 fit.edu,Florida Institute of Technology,Education
+fittelecom.com.br,FIT Telecom (Vero),ISP
+fiu.edu,Florida International University,Education
 fixnet.com.tr,FixNet,ISP
+fiz-karlsruhe.de,FIZ Karlsruhe,Science
 fl.gov,State of Florida,Government
+flagtel.com,Flag Telecom,ISP
 flashmaistelecom.com.br,Flash + Telecom,ISP
 flashnete.com.br,Flash Net,ISP
 flashnetprovedor.com.br,Flashnet,ISP
@@ -1929,6 +2404,8 @@ flinnsci.com,Flinn Scientific,Healthcare
 floridablue.com,Florida Blue,Finance
 floridaurologypartners.com,Florida Urology Partners,Healthcare
 flroofingcompany.com,Florida Roofing Company,Construction
+fluidone.com,FluidOne,ISP
+fluke.com,Fluke,Manufacturing
 flutech.co.th,Flu Tech,Manufacturing
 fly.dev,fly.io,PaaS
 fly.io,fly.io,PaaS
@@ -1936,17 +2413,25 @@ flychicago.com,Chicago Department of Aviation,Government
 flyfrontier.com,Frontier Airlines,Travel
 flytectelecom.com.py,Flytec Telecom,ISP
 flywheelsites.com,Flywheel,Web Host
+fm.com,FM Global,Finance
 fmc-na.com,Fresenius Medical Care,Healthcare
 fmcna.com,Fresenius Medical Care,Healthcare
 fmu.ac.jp,Fukushima Medical University,Education
+fmv.se,FMV / Forsvarets Materielverk,Defense
+fnal.gov,Fermi National Accelerator Laboratory,Government
 fnb.co.za,First National Bank,Finance
 fnetpe.com.br,FNET,ISP
+fnj.co.jp,Family Net Japan,ISP
+fns-holdings.com,F.N.S. Holdings,Web Host
+foaaa.com,Federal Online Group,Web Host
 foconet.net.br,Foconet Telecom,ISP
 focusbroadband.com,FOCUS Broadband,ISP
 fogel-group.cr,Fogel Group,Industrial
 fonabosque.gob.bo,FONABOSQUE,Government
 fonacit.gob.ve,Fonacit,Government
 foodtecsolutions.com,FoodTec Solutions,SaaS
+forcepoint.com,Forcepoint,Email Security
+fordham.edu,Fordham University,Education
 fordperformanceracingschool.com,The Ford Performance Racing School,Automotive
 foreupwebsites.com,foreUP,SaaS
 formassembly.com,FormAssembly,SaaS
@@ -1954,10 +2439,12 @@ format24.ua,Format 24,ISP
 forpsi.com,Forpsi,Web Host
 forsakringskassan.se,Forsakringskassan,Government
 fortetelecom.com.br,Forte Telecom,ISP
+forth.gr,Foundation for Research and Technology Hellas,Science
 forthnet.gr,Nova,ISP
 fortimail.com,Fortinet FortiMail,Email Security
 fortimailcloud.com,Fortinet FortiMail Cloud,Email Security
 fortinet.com,Fortinet,Email Security
+fortressitx.com,FortressITX,Web Host
 forwardemail.net,ForwardEmail.net,Email Provider
 fourseasonspediatrics.com,Four Seasons Pediatrics,Healthcare
 foxconn.com.cn,Foxconn,Manufacturing
@@ -1966,6 +2453,7 @@ foxnetbrasil.com.br,FoxNet Brasil,ISP
 foxtelecominformatica.com.br,Grupo Fox Telecom,ISP
 foxtrothosting.com,Foxtrot Media,Web Host
 foxtrotmedia.com,Foxtrot Media,Web Host
+fpb.cc,Frankfort Plant Board,Utilities
 fphonline.com,Family Pet Hospital,Healthcare
 fpl.com,Florida Power & Light,Utilities
 fpt.vn,FPT Telecom,ISP
@@ -1973,13 +2461,18 @@ fr.ch,Canton of Fribourg,Government
 francedns.com,Eurofiber France,ISP
 franchisemail.net,FranConnect,SaaS
 franet.com.br,Franet Telecom,ISP
+frantech.ca,FranTech Solutions,Web Host
 franweb.net.br,FRAN WEB,ISP
+fraport.de,Fraport,Travel
 fraunhofer.de,Fraunhofer,Science
 frazmtn.com,Frazier Mountain Internet,ISP
+fredonia.edu,SUNY Fredonia,Education
 free.fr,Free,ISP
 free.org,Free,ISP
+free.re,Free Reunion,ISP
 freebit.com,FreeBit,ISP
 freeddns.us,Now-DNS,Web Host
+freedom-vrn.ru,Freedom (Informsvyaz Chernozemye),ISP
 freedom1.ru,Freedom,ISP
 freehostia.com,Freehostia,Web Host
 freehosting.com,FreeHosting.com,Web Host
@@ -1987,28 +2480,37 @@ freemail.hu,Freemail bejelentkezés,Email Provider
 freemediainternet.com,freemediainternet.com,Web Host
 freemyip.com,freemyip,Web Host
 freepro.com,Free Pro,ISP
+freerangecloud.com,Free Range Cloud,Web Host
 freetls.fastly.net,Fastly,Technology
 fregat.com,Fregat,ISP
 freseniusmedicalcare.com,Fresenius Medical Care,Healthcare
 frgp.net,Front Range GigaPoP,Education
 frinet.com.br,Frinet,ISP
 frionline.com.br,FriOnline,ISP
+frogfoot.com,Frogfoot Networks,ISP
 fronteirainternet.com.br,Fronteira Internet,ISP
 frontier.com,Frontier,ISP
 frontiernetworks.ca,Frontier Networks Inc,Web Host
 frontiir.com,FRONTiiR,MSP
 fsu.edu,Florida State University,Education
+ft.fo,Faroese Telecom,ISP
+ftc-i.net,Farmers Telephone Cooperative,ISP
+ftc.gov,Federal Trade Commission,Government
 ftiwifi.com,Farmers Telephone (FTI),ISP
 fuertehoteles.com,Fuerte Group Hotels,Travel
 fujibake.co.jp,Fuji Bakelite,Industrial
 fujinohsan.com,Fujinohsan,Manufacturing
 fujita-hu.ac.jp,Fujita Health University,Healthcare
+fujitsu,Fujitsu,Manufacturing
 fujitsu.com,Fujitsu,Technology
+fukuoka-u.ac.jp,Fukuoka University,Education
 fulcrumcorp.com,Fulcrum Software,SaaS
 fulldata.com.ve,Fulldata,ISP
 fullnet.com.br,Fullnet,ISP
 fullnetfibra.com.br,Full Net Fibra,ISP
+fundaments.nl,Fundaments,Web Host
 funeralone.net,funeralOne,SaaS
+furman.edu,Furman University,Education
 furrera.ps,Furrera,ISP
 fuse.net,Altafiber (Formerly Cincinnati Bell),ISP
 fusionconnect.com,Fusion Connect,MSP
@@ -2018,10 +2520,14 @@ future-bridge.eu,Future Bridge Events,Marketing
 fxclickinsight.co.za,FXClick Insight,Finance
 fyfeweb.com,FyfeWeb,Web Host
 fyfeweb.uk.net,FyfeWeb,Web Host
+fzi.de,FZI Forschungszentrum Informatik,Science
+g.network,G.Network Communications,ISP
 g2netsul.com.br,G2NetSul,ISP
 g6internet.com.br,G6 Internet,ISP
+g8.net.br,SAMM,ISP
 ga.com,General Atomics,Defense
 ga.gov,State of Georgia,Government
+gabia.com,Gabia,Web Host
 gabontelecom.ga,Gabon Telecom,ISP
 gacaradio.com,Georgia-Carolina Radiocasting,Entertainment
 gaggle.net,Gaggle,SaaS
@@ -2032,13 +2538,20 @@ galls.com,Galls,Retail
 gamma.co.uk,Gamma,ISP
 gammagroup.co,Gamma,ISP
 gandi.net,Gandi.net,Web Host
+gaoland.net,SFR,ISP
+garantia.tv,Kolomna-Sviaz TV,ISP
 gardentelecom.com.br,Garden Telecom,ISP
 garr.it,GARR,Education
 garratelecom.net.br,Garra Fibra,ISP
 gastrogainesville.com,Gastroenterology Associates of Gainesville,Healthcare
 gatech.edu,Georgia Institute of Technology,Education
+gatespeed.com,Cruzio,ISP
+gatewayfiber.com,Gateway Fiber,ISP
 gatormail.co.uk,Spotler,Marketing
+gavleenergi.se,Gavle Energi,Utilities
+gawex.pl,Gawex Media,ISP
 gazella.es,Orix Systems,MSP
+gba.gob.ar,Provincia de Buenos Aires,Government
 gbic.mx,GBIC Comunicaciones,ISP
 gblnet.net,Global Network Management,MSP
 gbsn.com.br,GbsNet,ISP
@@ -2046,14 +2559,18 @@ gci.com,GCI,ISP
 gci.net,GCI,ISP
 gci.net.br,GCI Net,ISP
 gcicom.net,Nasstar,MSP
+gciservicios.com.ar,Merco Comunicaciones,ISP
 gcmcomputers.com,GCM Computers,MSP
 gcore.com,Gcore,Web Host
 gcrcompany.com,GCR Company,MSP
+gcs.co.kr,Green Cable Television Station,ISP
 gctrials.com,GCT,Healthcare
+gcu.edu,Grand Canyon University,Education
 gd.gov.cn,Government of Guangdong Province,Government
 gda.pl,TASK (Gdansk Tech),Education
 gdnetfibra.com.br,GD Net Fibra,ISP
 ge.ch,Canton of Geneva,Government
+gearheart.com,Gearheart Communications,ISP
 gearhost.com,GearHost,Web Host
 geckonet.pl,Geckonet,ISP
 gegnet.com.br,GGNet Telecomunicações,ISP
@@ -2062,31 +2579,45 @@ geisinger.org,Geisinger,Healthcare
 gen2fund.com,Gen II,Finance
 gencat.cat,Generalitat de Catalunya,Government
 gene.com,Genentech,Healthcare
+generali.de,Generali Deutschland,Finance
 generalinformatix.net,General Informatix,Technology
 generalmills.com,General Mills,Food
+geneseo.edu,SUNY Geneseo,Education
 genie-networks.com,Genie Networks,Technology
 genoray.com,GENORAY,Healthcare
 genstarnetcable.com,Gennstar Network Solutions,ISP
 geolinks.com,GeoLinks,ISP
+georgetown.edu,Georgetown University,Education
 georgia.gov,State of Georgia,Government
 georgiasouthern.edu,Georgia Southern University,Education
 gerberlife.com,Gerber Life Insurance,Finance
 getkeepsafe.com,Keepsafe Software,SaaS
 getordained.org,Universal Life Church,Religion
 getresponse.com,GetResponse,Marketing
+getty.edu,J. Paul Getty Trust,Education
+gettysburg.edu,Gettysburg College,Education
 getunwired.com,unWired Broadband,ISP
 gfiber.com,Google Fiber,ISP
+gga.ch,GGA Maur,ISP
 ggsv.jp,Techorus,Web Host
 ghm-grenoble.fr,Groupe hospitalier mutualiste de Grenoble,Healthcare
 ghnet.com.br,GHNet,ISP
 ghostnet.de,GHOSTnet,Web Host
 giantpartners.com,Giant Partners,Marketing
+gib-solutions.ch,GIB Solutions,ISP
+gibsonemc.com,Gibson Connect (Gibson EMC),Utilities
+gifu-u.ac.jp,Gifu University,Education
 gigabytetelecom.com.br,Gigabyte Telecom,ISP
 gigaclear.com,Gigaclear,ISP
 gigahost.dk,GigaHost,Web Host
 gigahost.no,Gigahost,Web Host
+gigalink.com.br,Gigalink,ISP
 gigamaisempresas.com.br,Giga+ Fibra,ISP
 gigared.com.ar,Gigared,ISP
+gigas.com,Gigas Hosting,Web Host
+gigatel.com.ua,Lanet (Gigatel),ISP
+gigenet.com,GigeNET,Web Host
+gilat.net,Gilat Telecom,ISP
 git-repos.de,LCube,Web Host
 github.com,GitHub,SaaS
 github.io,GitHub,SaaS
@@ -2095,11 +2626,15 @@ gitlab.com,GitLab,SaaS
 gitlab.io,GitLab,SaaS
 glasgow-ky.com,Glasgow EPB,ISP
 glasgowepb.com,Glasgow EPB,ISP
+glbb.jp,GLBB Japan,ISP
+glcom.net,Great Lakes Comnet,ISP
 glesys.com,Glesys,Web Host
 glesys.net,GleSYS,Web Host
 glidegroup.co.uk,Glide,ISP
 glink.inf.br,Glink,Web Host
 gln.net.br,Global Lines,ISP
+global-layer.com,Global Layer,ISP
+global.fujitsu,Fujitsu,Manufacturing
 global.ntt,NTT,ISP
 globalcombasilicata.it,GlobalCom Basilicata,ISP
 globalconecta.com.br,Global Conecta,ISP
@@ -2110,10 +2645,13 @@ globalconnectgroup.com,GlobalConnect,ISP
 globalhealthcareresearch.com,Global Healthcare Research,Healthcare
 globalipexchange.net,Angelnet,ISP
 globalit.com,Global IT,MSP
+globalnoc.net,equada network,ISP
 globalsecurelayer.com,Global Secure Layer,ISP
 globaltelecom-mt.com.br,Global Telecom,ISP
+globalways.net,Globalways,ISP
 globconnex.com,Global Connectivity Solutions,ISP
 globe.com.ph,Globe Telecom,ISP
+gm.com,General Motors,Automotive
 gmailify.com,Gmailify,Email Provider
 gmdp.net.id,GMDP,ISP
 gmntelecom.com.br,GMN Telecom,ISP
@@ -2125,64 +2663,86 @@ gmx.com,GMX,ISP
 gmx.net,GMX,ISP
 gn-server.de,Greatnet.de,Web Host
 gnb.ca,Government of New Brunswick,Government
+gnc.am,GNC-Alfa,ISP
 gnet.cc,GNET,Web Host
 gnetworkve.com,G-Network,ISP
 gnomen.co.uk,Gnomen,Real Estate
+gnu.ac.kr,Gyeongsang National University,Education
 go.com.jo,Orange Jordan,ISP
 go.com.mt,GO p.l.c.,ISP
 go.com.sa,GO Telecom,ISP
+gobertram.com,Bertram Communications,ISP
 goco.ca,TELUS,ISP
 godaddy.com,GoDaddy,Web Host
 goip.de,GoIP,Web Host
 goknet.com.tr,GÖKNET,ISP
 gol.com,Gol,Travel
+goldenwest.com,Golden West Telecommunications,ISP
 goldmedimport.com.br,Goldmed import,Healthcare
 gom.co.za,Graytown Office Machines,MSP
 gomailify.net,Gmailify,Email Provider
+gondtc.com,NDTC North Dakota Telephone,ISP
 gonetspeed.com,GoNetSpeed,ISP
+gonzaga.edu,Gonzaga University,Education
 gonzagatelecom.com.br,Gonzaga Telecom,ISP
 goodline.info,Good Line,ISP
 google.com,Google (Including Gmail and Google Workspace),Email Provider
 googlefiber.net,Google Fiber,ISP
 googleusercontent.com,Google Cloud Platform (GCP),PaaS
+gore.com,W. L. Gore and Associates,Manufacturing
 gorgiphoto.com,Gabriel Gorgi,Photography
+gorillaservers.com,GorillaServers,Web Host
 gosecure.ai,GoSecure,Email Security
 gosecure.net,GoSecure,Email Security
 goskope.com,Netskope,Email Security
 gospellight.sg,Gospel Light Christian Church,Religion
 gotdns.com,DynDNS,Web Host
 gotdns.org,DynDNS,Web Host
+goteborg.se,City of Gothenburg,Government
 gotpantheon.com,Pantheon,Web Host
+gouv.qc.ca,Government of Quebec,Government
 gov-dooray.com,Dooray,SaaS
 gov.bc.ca,Province of British Columbia,Government
 gov.hu,Government of Hungary,Government
 gov.in,Indian government,Government
+gov.nt.ca,Government of Northwest Territories,Government
 gov.pf,The Government of French Polynesia,Government
+gov.si,Slovenia Government Portal,Government
 govdelivery.com,Granicus,SaaS
+govst.edu,Governors State University,Education
 govstack.com,Govstack (eSolutions Group),Technology
 gpcom.com,Great Plains Communications,ISP
+gpo.gov,US Government Publishing Office,Government
 gpphosted.com,Proofpoint (Government),Email Security
 grainger.ca,Grainger Industrial Supply,Industrial
 grainger.com,Grainger Industrial Supply,Industrial
 granicus.com,Granicus,SaaS
 granitenet.com,Granite Telecommunications,ISP
 graysmark.net,Graysmark Business Systems,MSP
+greatforti.com,Anpple Tech,Web Host
 greatmail.com,Greatmail,Email Provider
 green.ch,green.ch,ISP
 greenarrowemail.com,GreenArrow,SaaS
 greenarrowmail.com,GreenArrow,SaaS
 greenconsulting.it,Green Consulting,MSP
+greendotgroup.co,Green Dot,ISP
 greenecountyny.gov,"Greene County, New York",Government
 greenfloid.com,Green Floid,Web Host
 greengeeks.com,GreenGeeks,Web Host
 greengeeks.net,GreenGeeks,Web Host
+greenhousedata.com,Lunavi (Greenhouse Data),Web Host
+greenlightnetworks.com,Greenlight Networks,ISP
+greenmountainpower.com,Green Mountain Power,Utilities
 greentelecom.net.br,Green Telecom,ISP
 greenviewdata.com,Greenview Data,Email Security
+grinnell.edu,Grinnell College,Education
 grnet.gr,GRNET,Education
 group.bnpparibas,BNP Paribas,Finance
+group.ntt,NTT Group,ISP
 groupe-asten.fr,Groupe Asten,MSP
 groupon.com,Groupon,Retail
 grsolucoestelecom.com.br,GR Soluções Telecom,ISP
+gru.com,Gainesville Regional Utilities,Utilities
 grupocybernet.com.br,Grupo Cybernet,ISP
 grupoice.com,ICE,ISP
 grupoip2.com.br,IP2 Internet,ISP
@@ -2191,12 +2751,16 @@ grupojet.com.br,RD Telecom,ISP
 gruposalinas.com,Groupo Salinas,Conglomerate
 gruposalinas.com.mx,Groupo Salinas,Conglomerate
 grupotelecompe.com.br,Grupo Telecom,ISP
+gruppoiren.it,Iren Group,Utilities
 grvfibra.com.br,GRV Fibra,ISP
 gsbridge.com,Golden State Bridge,Industrial
 gsi.de,GSI Helmholtzzentrum für Schwerionenforschung,Education
 gss-security.ca,GSS Security,Physical Security
 gsu.edu,Georgia State University,Education
+gta.net,GTA Teleguam,ISP
 gtd.cl,Gtd,ISP
+gtdcolombia.com,GTD Colombia,ISP
+gtdmanquehue.com,Gtd,ISP
 gthost.com,GTHost,Web Host
 gtnexus.com,Infor Nexus (Formerly GT Nexus),SaaS
 gtpl.net,GTPL,ISP
@@ -2207,27 +2771,42 @@ gturbo.com.br,G Turbo Telecom,ISP
 gtxnet.com.br,GTXNET,ISP
 gu.se,University of Gothenburg,Education
 guardedhost.com,Omnis Network,Web Host
+gulfstreamaircraft.com,Gulfstream Aerospace,Manufacturing
 gunma-u.ac.jp,Gunma University,Education
+gustavus.edu,Gustavus Adolphus College,Education
 gva.africa,GVA (Canal+),ISP
 gva.es,Generalitat Valenciana,Government
+gvec.net,GVEC Internet Services,ISP
 gvt.net.br,Telefônica Brasil,ISP
 gvtc.com,GVTC,ISP
 gwblawfirm.com,Gallivan White and Boyd,Legal
 gwdg.de,GWDG,Education
+gwi.net,GWI,ISP
 gwt.net.br,Gateway Telecom,ISP
 gwu.edu,The George Washington University,Education
 h-isac.org,H-ISAC,Healthcare
 h4ahosting.com,H4A Hosting,Web Host
+h4y.us,H4Y Technologies,Web Host
+ha-vel.cz,ha-vel internet,ISP
 hab-inc.com,Berkheimer,Finance
+hackney.gov.uk,London Borough of Hackney,Government
+hallmark.com,Hallmark,Retail
+halservice.it,WiC (HAL Service),ISP
+hamilton.edu,Hamilton College,Education
+hamline.edu,Hamline University,Education
 hammacher.com,Hammacher Schlemmer,Retail
 hamwan.org,HamWAN,Nonprofit
 han-solo.net,hostNET,Web Host
 hanami.run,Mailwip (Formerly Hanami),Email Provider
 hanastar.net.id,HSnet,ISP
+handynetworks.com,Summit Hosting (Handy Networks),Web Host
 hankyu-hanshin.co.jp,Hankyu Hanshin,Conglomerate
+hanyang.ac.kr,Hanyang University,Education
 hap.be,CHU Ambroise Paré,Healthcare
 hargray.com,Hargray,ISP
+harper.cc.il.us,Harper College,Education
 harrishealth.org,Harris Health System,Healthcare
+hartford.edu,University of Hartford,Education
 harvard.edu,Harvard University,Education
 hasura-app.io,Hasura,PaaS
 hasura.app,Hasura,PaaS
@@ -2240,11 +2819,19 @@ hatenadiary.jp,Hatena,SaaS
 hatenadiary.org,Hatena,SaaS
 hathway.com,Hatchway,ISP
 hathway.net,Hathway,ISP
+haverford.edu,Haverford College,Education
 hawaii.edu,University of Hawaii,Education
 hawaiiantel.com,Hawaiian Telcom,ISP
+hawetelekom.com,Hawe Telekom,ISP
 hay.net,Hay Communications,ISP
+haynesboone.com,Haynes and Boone,Legal
+hbci.com,Hiawatha Broadband Communications,ISP
 hccl.net,HCCL,MSP
+hccs.edu,Houston Community College,Education
 hcg.gr,Greek Coast Guard,Government
+hchdfoundation.org,Harris Health System,Healthcare
+hcinet.net,Hanson Communications,ISP
+hcltechnologies.com,HCL Technologies,MSP
 hcn.co.kr,Hyundai HCN,ISP
 hctc.net,Hill County Telephone Cooperative (HXTC),ISP
 hdems.com,HENNGE Mail Archive,SaaS
@@ -2253,11 +2840,14 @@ he.net,Hurricane Electric,ISP
 health-isac.org,H-ISAC,Healthcare
 healthall.com,UC Health,Healthcare
 healthcaresupplypros.com,Healthcare Supply Pros,Healthcare
+healthplan.com,HealthPlan Services,Healthcare
 healthproductsforyou.com,Health Products For You,Healthcare
 healthtouch.com,Cardinal Health,Healthcare
 healthyvision.org,Healthy Vision Institute,Healthcare
+heartinternet.uk,Heart Internet,Web Host
 hebergementadn.ca,ADN Communications,Web Host
 hehe.si,Hehe,Web Host
+hel.fi,City of Helsinki,Government
 helinet.de,HeLi NET Telekommunikation,ISP
 helioho.st,HelioHost,Web Host
 heliohost.org,HelioHost,Web Host
@@ -2271,10 +2861,12 @@ helpscout.net,Help Scout,SaaS
 helse-vest-ikt.no,Helse Vest IKT,Healthcare
 henet.com.br,He-Net,ISP
 henkel.cn,Henkel,Manufacturing
+hennepincounty.gov,Hennepin County,Government
 henryind.com,Henry Industries,Industrial
 heptanet.com.br,Heptanet,ISP
 herbion.com,Herbion,Healthcare
 herbion.us,Herbion,Healthcare
+here.com,HERE Technologies,PaaS
 herefordshire.gov.uk,Herefordshire Council,Government
 herokuapp.com,Heroku,PaaS
 herotel.com,Herotel,ISP
@@ -2289,6 +2881,7 @@ hgc-intl.com,HGC,ISP
 hh.nm.cn,China Unicom,ISP
 hhs.gov,U.S. Department of Health & Human Services,Government
 hhsys.org,Huntsville Hospital,Healthcare
+hiab.com,Hiab,Manufacturing
 hickorytech.net,Consolidated Communications,ISP
 highlinefast.com,Highline,ISP
 highmark.com,Highmark,Healthcare
@@ -2299,30 +2892,40 @@ hightechbroadband.net,Hightech Broadband,ISP
 highwire.org,HighWire,SaaS
 highwirepress.com,HighWire,SaaS
 hinet.net,HiNet,ISP
+hip-hosting.com,HIP-Hosting,Web Host
 hiper.dk,Hiper,ISP
+hiss.co.jp,HISS Hokuden Information System Service,MSP
 hissm.com,Hiss Media,Marketing
 hit.ac.kr,Daejon Health Sciences College,Education
+hitachi-pt.co.jp,Hitachi,Conglomerate
 hitmedios.com,HT Medios,MSP
 hivelocity.net,Hivelocity,Web Host
 hiwaay.net,HuWAAY,ISP
 hiworks.co.kr,hiworks,SaaS
+hkbn.com.hk,HKBN,ISP
 hkbn.net,HKBN,ISP
 hkbnes.com,HKBN Enterprise,ISP
 hkbnes.net,HKBN Enterprise,ISP
 hkbu.edu.hk,Hong Kong Baptist University,Education
+hkcsl.com,csl HKCSL,ISP
+hkglobalnetwork.com,Global Communication Network,ISP
 hkn.de,HKN,ISP
 hkt-enterprise.com,HKT Enterprise,ISP
+hkt.cc,Forewin Telecom Group,ISP
 hku.hk,The University of Hong Kong,Education
 hmall.com,Hyundai Home Shopping,Retail
 hmcaguas.com,Puerto Rico Telephone Company,ISP
 hmu.gr,Hellenic Mediterranean University,Education
 hoaspace.com,HOA Space,SaaS
+hofstra.edu,Hofstra University,Education
 hokudai.ac.jp,Hokkaido University,Education
 hol.gr,Vodafone,ISP
 holistictech.net,Holistic Technologies,MSP
+hollandc.pe.ca,Holland College,Education
 holz.net.br,Holz Network,ISP
 home-webserver.de,DDNSS,Web Host
 home.cern,CERN,Science
+home.kpmg,KPMG,Consulting
 home.pl,home.pl,Web Host
 homedepot.com,The Home Depot,Retail
 homedepot.com.mx,The Home Depot,Retail
@@ -2331,7 +2934,9 @@ homeftp.org,DynDNS,Web Host
 homeip.net,DynDNS,Web Host
 homelinux.net,DynDNS,Web Host
 homelinux.org,DynDNS,Web Host
+homeoffice.gov.uk,UK Home Office,Government
 homeplus.net.tw,Hoshin Multimedia,ISP
+homesc.com,Home Telecom,ISP
 homesklep.pl,home.pl,Web Host
 homesteadhealthcareservices.com,Homestead Health Care Services,Healthcare
 homeunix.net,DynDNS,Web Host
@@ -2340,11 +2945,15 @@ honda.com,Honda,Automotive
 hondutel.hn,Hondutel,ISP
 honeycrm.com,HoneyCRM,SaaS
 hongkongserver.net,Hong Kong Server,Web Host
+hood.edu,Hood College,Education
 hopitaleuropeendeparis.fr,Hôpital Européen de Paris,Healthcare
+hopone.net,HopOne Internet,Web Host
 hopto.me,No-IP,Web Host
 hopto.org,No-IP,Web Host
+horizonstelecom.com,Horizons Telecom,ISP
 horizontes.net.br,Horizontes Fibra,ISP
 hornetsecurity.com,Hornetsecurity,MSSP
+hosei.ac.jp,Hosei University,Education
 hosp.kaizuka.osaka.jp,Kaizuka City Hospital,Healthcare
 hospedagemweb.com.br,Central Server,Web Host
 host-it.co.uk,Host-IT,Web Host
@@ -2364,6 +2973,7 @@ hostgate.ro,Hostgate.ro,Web Host
 hostglobal.plus,HOSTGLOBAL.PLUS,Web Host
 hostgo.com,HostGo,Web Host
 hostguy.com,hosting.india.to,Web Host
+hosthatch.com,HostHatch,Web Host
 hostico.ro,HOSTICO,Web Host
 hosting-advantage.com,Hosting Advantage,Web Host
 hosting-cluster.nl,Combell,Web Host
@@ -2389,7 +2999,9 @@ hostmonster.com,Hostmonster,Web Host
 hostnet-vps.nl,Hostnet,Web Host
 hostnet.nl,Hostnet,Web Host
 hostneverdie.com,Hostneverdie,Web Host
+hostopia.com,Hostopia,Web Host
 hostpacific.com,HostPacific.com,Web Host
+hostpapa.com,HostPapa,Web Host
 hostpapavps.net,HostPapa,Web Host
 hostpoint.ch,Hostpoint,Web Host
 hostresolver.net,Stack Harbor,Web Host
@@ -2401,16 +3013,22 @@ hostsevenplus.com,HostSevenPlus,Web Host
 hostsg.com,HostSG,Web Host
 hostspeedy.com,Host Speedy,Web Host
 hosttook.com,Hosttook,Web Host
+hostvds.com,HostVDS,Web Host
+hostway.co.kr,Hostway IDC,Web Host
 hostway.com,Hostway,Web Host
 hostwinds.com,Hostwinds,Web Host
 hostwindsdns.com,Hostwinds,Web Host
 hostyhosting.io,HostyHosting,Web Host
+hostzealot.com,HostZealot,Web Host
 hotel-icon.com,Hotel ICON,Travel
 hotelhugony.com,Hotel Hugo New York,Travel
+hotnet.co.jp,HOTnet Hokkaido Telecommunications,ISP
 hotnet.net.il,Hot Net Internet Services,ISP
 hotwirecommunication.com,Hotwire Communications,ISP
 hotwirecommunications.com,Hotwire Communications,ISP
 house.gov,U.S. House of Representatives,Government
+houstonisd.org,Houston Independent School District,Education
+howard.edu,Howard University,Education
 howchin.com.my,How Chin Engineering,Industrial
 hp.com,HP,Technology
 hpe.com,Hewlett Packard Enterprise,Technology
@@ -2425,20 +3043,29 @@ hstgr.cloud,Hostinger,Web Host
 ht.hr,Hrvatski Telekom,ISP
 htc.net,HTC,ISP
 htcinc.net,HTC,ISP
+htdc.org,HTDC Hawaii Technology Development Corporation,Government
 htmlservices.it,HTMLServices.it,MSP
 htp.net,htp,ISP
+htuidc.com,Dianliantongxin,Web Host
 huaweicloud.com,Huawei Cloud,IaaS
 hubspotemail.net,HubSpot,Marketing
 hugel-inc.com,Hugel,Healthcare
+hugetns.com,Huge TNS,ISP
 hughes.com,Hughes,ISP
 hughes.net,Hughes Network Systems,ISP
 hughston.com,Hughston Clinic,Healthcare
 hugstelecom.com,Hugs Telecom,ISP
+hull.ac.uk,University of Hull,Education
 hulum.iq,Hulum Almustakbal,ISP
+huntington.com,Huntington Bancshares,Finance
 huntsvillehospital.org,Huntsville Hospital,Healthcare
 hushmail.com,Hushmail,Email Provider
+hut8.com,Hut 8,IaaS
+hut8mining.com,Hut 8,IaaS
 hvacwebsites.com,Online Access,Marketing
+hvcc.edu,Hudson Valley Community College,Education
 hvvc.us,Hivelocity,Web Host
+hya.com.tw,Taiwan Optical Platform,ISP
 hydro.com,Norsk Hydro,Industrial
 hyonix.com,Hyonix,Web Host
 hyosung.com,Hyosung,Conglomerate
@@ -2456,7 +3083,9 @@ iam.ma,Maroc Telecom,ISP
 iastate.edu,Iowa State University,Education
 ibindley.com,Cardinal Health,Healthcare
 ibm.com,IBM,Technology
+iboss.com,iboss,SaaS
 ibx.com,Independence Blue Cross,Healthcare
+icc-media.co.jp,ICC Corporation,ISP
 ice.co.cr,Grupo ICE,Industrial
 icehosting.nl,IceHosting,Web Host
 icertis.com,Icertis,SaaS
@@ -2465,7 +3094,9 @@ icfre.org,Indian Council of Forestry Research and Education,Government
 ici.ro,ICI București,Government
 iclicktelecom.net.br,iClick Telecom,ISP
 icloud.com,Apple iCloud,Email Provider
+icomtex.ru,Intercomtex,ISP
 iconnecttelecom.com.br,Connect Telecom,ISP
+iconz.net,ICONZ,ISP
 icoremail.net,Coremail,Email Provider
 icosnet.com,ICOSNET,ISP
 icostelecom.com.br,ICOS Telecom,ISP
@@ -2477,14 +3108,22 @@ idcf.jp,IDC Frontier,Web Host
 idealinsurancebrokersng.com,Ideal Insurance Brokers,Finance
 idealwebpiaui.com.br,Ideal Web,ISP
 ideaservers.net,Hetzner,Web Host
+ideatek.com,IdeaTek,ISP
 identibitsuisse.ch,identibit suisse,Marketing
 identity.digital,Identity Digital (Afilias),Technology
 idig.net,Canadian Web Hosting,Web Host
+idknet.com,Interdnestrcom,ISP
 idm.net.lb,IncoNet IDM,ISP
 idodns.com,IDO DNS,MSP
 idt.net,IDT Corporation,ISP
+ieee.org,IEEE,Nonprofit
+ientc.com,IENTC Telecom,ISP
+ieso.ca,Independent Electricity System Operator (Ontario),Utilities
 ifeelfree.co.nz,I Feel Free,MSP
 ifibertelecom.com.br,iFiber Telecom,ISP
+iforte.co.id,iForte Global Internet,ISP
+ifremer.fr,IFREMER,Science
+ifsc.edu.br,IFSC Federal Institute of Santa Catarina,Education
 iftnet.com.br,IFTNET Telecom,ISP
 ifxnetworks.com,IFX Networks,MSP
 ifxnw.com.ve,IFX Networks,MSP
@@ -2496,6 +3135,7 @@ ihor-hosting.ru,IHOR Hosting,Web Host
 ihor.online,IHOR Hosting,Web Host
 ihs.gov,Indian Health Service,Government
 ihug.co.nz,ihug,ISP
+iiasa.ac.at,IIASA International Institute for Applied Systems Analysis,Science
 iij.ad.jp,Internet Initiative Japan,ISP
 iij4u.or.jp,Internet Initiative Japan,ISP
 iinet.net.au,iiNet,ISP
@@ -2510,6 +3150,7 @@ ilimnet.ru,Telnet,ISP
 ilink.net,VDC Powerbase,IaaS
 illinois.edu,University of Illinois,Education
 illinois.net,Illinois Century Network,Education
+illinoisstate.edu,Illinois State University,Education
 ilpt.com,Independence Light & Power Telecommunications,ISP
 im3.id,IM3,ISP
 imageonline.co.in,Image Online,Marketing
@@ -2518,16 +3159,22 @@ imanila.ph,iManila,Marketing
 imcconseil.fr,IMC Conseil,MSP
 imf.org,International Monetary Fund,Government
 imicro.com.br,IMICRO Telecom,ISP
+immedion.com,Immedion (Centersquare),Web Host
 immomeister.com,Immomeister,Real Estate
 imnet.com.br,Imnet,ISP
 imon.net,ImOn Communications,ISP
+imp.ch,ImproWare,ISP
+impa.br,IMPA,Education
 implantartelecom.com.br,Implantar Telecom,ISP
 improvmx.com,ImprovMX,Email Provider
 impulsahosting.com,Impulsa IT Solutions,Web Host
 ims.net.co,IMS,ISP
+imsa.edu,Illinois Mathematics and Science Academy,Education
 imsbiz.com,Hong Kong Telecommunications (HKT),ISP
 imsnetworks.com,IMS Networks,ISP
 in.net.pl,INFO-NET grupa ZICOM,ISP
+in2net.com,In2net Network,ISP
+inalan.gr,Inalan,ISP
 incapsula.com,Imperva,Email Security
 incomcloud.com,InCom,MSP
 incontact.com,NICE CX,SaaS
@@ -2544,12 +3191,18 @@ indosat.com,IM3,ISP
 indosatooredoo.com,IM3,ISP
 indra.com,Indra,Web Host
 indstate.edu,Indiana State University,Education
+indy.gov,City of Indianapolis,Government
 indytel.com,Independence Light & Power Telecommunications,ISP
 inea.pl,INEA,ISP
 ineedbob.com,Computer Solutions,MSP
+ines.co.jp,INES,MSP
+ines.ro,iNES Group Romania,ISP
+inesc.pt,INESC,Science
 inet.co.th,INET,ISP
 inet.vn,INET,Web Host
 inetcom.ru,Inetcom,ISP
+inettech.co.kr,iNet Technologies,ISP
+inetvl.ru,AlianceTelecom,ISP
 inexa.com.br,Inexa,ISP
 inexio.net,inexio,ISP
 inext.co.th,INET,ISP
@@ -2558,13 +3211,16 @@ infinivan.com,InfiniVAN,ISP
 infixnet.com.br,Infix Telecom,ISP
 info-trade.gr,INFO-TRADE,Technology
 infobarranet.com.br,Infobarra,ISP
+infolada.ru,InfoLada,ISP
 infolinebandalarga.com.br,Infoline,ISP
+infolink.com,Infolink Global,ISP
 infolink.ru,Infolink,ISP
 infolinktelecom.com,Infolink Telecom,ISP
 infomaniak.ch,infomaniak,Web Host
 infomaniak.com,Infomaniak,Web Host
 infomir.com.ua,Infomir,ISP
 infonet-isp.com.br,Infonet Telecom,ISP
+infonetdc.com,Infonet,Web Host
 infopact.nl,Infopact,ISP
 infopasa.com.br,Infopasa,ISP
 infor.com,Infor,SaaS
@@ -2574,15 +3230,21 @@ informac.com.br,Informac,ISP
 infornetnetwork.net.br,I3 Telecomunicações,ISP
 infoservic.com.br,InfoServic Telecom,ISP
 infosetetelecom.com.br,Info Sete,ISP
+infosi.gov.ao,INFOSI Angola Information Society,Government
 infotec.psi.br,Infotec,ISP
 infotrade.gr,INFO-TRADE,Technology
+infowest.com,InfoWest,ISP
+infracom.se,InfraCom,ISP
 ing.com,ING,Finance
 ingenuitycloudservices.com,Ingenuity Cloud Services,Web Host
 ingenuityfilms.com,Ingenuity Films,Entertainment
+inha.ac.kr,Inha University,Education
+inidc.net,Beijing ShuJuJia Technology,Web Host
 init.lt,INIT,ISP
 init7.net,Init7,ISP
 inkyphishfence.com,INKY,Email Security
 inl.gov,Idaho National Laboratory,Government
+inmarsat.com,Inmarsat,ISP
 inmicsnebula.fi,Telia,ISP
 inmotionhosting.com,InMotion Hosting,Web Host
 innline.am,innline,SaaS
@@ -2593,6 +3255,9 @@ innova.puglia.it,InnovaPuglia,Government
 innovasur.com,Innovasur,MSP
 inovalon.com,inovalon,Healthcare
 inovanettelecom.net.br,InovaNet,ISP
+inpe.br,INPE Brazilian National Institute for Space Research,Science
+inq.inc,Inq. Digital,ISP
+inria.fr,INRIA,Science
 inspire.net.nz,Inspire Net Limited,ISP
 inspirebroadband.net,Inspire Broadband,ISP
 inspiren.my,Inspiren,Marketing
@@ -2603,6 +3268,8 @@ intechonline.com,Intech Online,ISP
 intechonline.net,Intech Online,ISP
 integra.net.au,integra,MSP
 integratedlifecare.ca,Integrated Life Care,Healthcare
+intel.com,Intel,Manufacturing
+intelbi.ru,IntelBI (TransTeleCom),ISP
 inteliquent.com,Inteliquent,ISP
 intellicentre.net.au,Macquarie Technology,IaaS
 intellisurvey.com,InteliSurvey,SaaS
@@ -2613,15 +3280,19 @@ inter.net.il,Internet Gold,ISP
 inter.net.th,Internet Thailand Company Limited,ISP
 intercolnet.com.br,Intercol,ISP
 interconnect.cz,Interconnect,ISP
+interconnect.nl,Interconnect Netherlands,Web Host
 interdeal.co.il,Interdeal,Finance
 interfibras.net.br,Interfibras Telecomunicações,ISP
 interhost.it,Genesys Informatica Srl,MSP
+interior.gov.cl,Chile Ministry of Interior,Government
 interkam.pl,Interkam,ISP
 interlink.md,Interlink Comunicatii,ISP
 intermax.nl,Intermax,MSP
+intermedia.net,Intermedia,SaaS
 intermetalsa.co.mz,Intermetal,Construction
 intermountainhealthcare.org,Intermountain Health,Healthcare
 internap.com,Internap,Web Host
+international.com,International Truck and Engine,Manufacturing
 internationalpaper.com,International Paper,Industrial
 internet-webhosting.com,iWHOST,Web Host
 internet.co.za,Axxess,ISP
@@ -2631,17 +3302,21 @@ internet10.net.br,Internet 10,ISP
 internetlocal.com.ar,Internet Local,ISP
 internetmailserver.net,Internet Mail Server Networks,Email Provider
 internetnamesforbusiness.com,Internet Names For Business,Web Host
+internetparatodos.com.ar,Internet Para Todos La Rioja,Government
 internetsuper.com.br,Internet Super,ISP
 internetvikings.com,Internet Vikings,Web Host
 internetway.com.br,Internet Way,ISP
 internexa.com,InterNexa,ISP
+internext.cz,Internext,ISP
 internexus.co.uk,Internexus,ISP
 interra.ru,Interra,ISP
 interserver.net,InterServer,Web Host
 intervel.com.br,Intervel Telecom,ISP
+interworks.co.za,Interworks,ISP
 interzet.ru,ER-Telecom,ISP
 inti.net.id,Inti Data Telematika,ISP
 intracom-telecom.com,Intracom Telecom,ISP
+intred.it,Intred,ISP
 invaluement.com,Invaluement,Email Security
 investinmiddlesex.ca,"Middlesex County, Canada",Government
 investpsp.ca,PSP Investments,Finance
@@ -2653,6 +3328,7 @@ ioflood.net,I/O Flood,Web Host
 ioh.co.id,IM3,ISP
 iomart.com,iomart,Web Host
 ionblade.com,IonBLADE,Web Host
+ionnetwork.co.id,ION Network (PT Parsaoran Global Datatrans),ISP
 ionos.com,IONOS,Web Host
 ionos.de,IONOS,Web Host
 iowa.gov,State of Iowa,Government
@@ -2682,7 +3358,9 @@ ip-57-128-192.eu,OVH,Web Host
 ip-87-98-138.eu,OVH,Web Host
 ip-92-204-129.us,OVH,Web Host
 ip-92-204-134.us,OVH,Web Host
+ip-home.net,iP-Home,ISP
 ip-kyoto.ad.jp,Advanced Software Technology & Management Research Institute of Kyoto,Education
+ip-projects.de,IP-Projects,Web Host
 iphmx.com,Cisco Cloud Email Security (CES),Email Security
 iphost.gr,IpHost,Web Host
 iphost.net,IpHost,Web Host
@@ -2692,59 +3370,87 @@ ipko.com,IPKO,ISP
 iplan.com.ar,IPlan,ISP
 ipm.ac.ir,Institute for Research in Fundamental Sciences,Education
 ipm.com,Intelligent Protection Management,Web Host
+ipn.mx,Instituto Politecnico Nacional,Education
 ipnettelecom.com.br,IPNET,ISP
 ipnext.com.ar,IPNEXT,ISP
 ipnxnigeria.net,ipNX Nigeria,ISP
 ipost.com,iPost,Marketing
 ippathways.com,IP Pathways,MSP
 iprimus.com.au,iPrimus,ISP
+ipserverone.com,IP ServerOne,Web Host
+iptp.com,IPTP Networks,ISP
 ipv.net.pl,Promedia,ISP
+ipx.com.au,IP Exchange Australia,ISP
 iqcomputing.com,IQComputing,Web Host
 iqcomputing.net,IQComputing,Web Host
+iqfiber.com,IQ Fiber,ISP
 iqhive.com,IQ Hive,MSP
 iqon-global.com,IQON Global,Web Host
 irbr.ru,ИРБР,Web Host
+irib.ir,IRIB Islamic Republic of Iran Broadcasting,Government Media
 ironmountain.com,Iron Mountain,Technology
 ironwoodcrc.com,Ironwood Cancer & Research Centers,Healthcare
 is.co.za,Internet Solutions,ISP
 is74.ru,Intersvyaz,ISP
+isc.org,Internet Systems Consortium,Nonprofit
 iseek.com.au,iseek Communications,ISP
 isenterprise.com,KPN,ISP
+ishantechnologies.com,Ishan Technologies,ISP
 isid.co.jp,Information Services International-Dentsu,MSP
+isiline.it,Isiline,ISP
 isite.de,iWelt,MSP
 isnet.net.tr,Is Net,ISP
 isomediainc.com,Isomedia,ISP
+isp.net,ISP.net Las Vegas,ISP
+ispalliance.cz,ISP Alliance,ISP
 ispgateway.de,domainfactory GmbH,Web Host
 isplevel.com,ISPLevel,Web Host
 isplevel.pro,ISPLevel,Web Host
 ispn.net,ISPN,MSP
 ispnet.us,Starnova,Web Host
+isppro.de,ISPpro Internet,Web Host
 ispserver.com,ISPServer,Web Host
 issp.at,issp,Web Host
 issr.ru,Mobile TeleSystems,ISP
 istekki.fi,Istekki,MSP
 istitutotumori.mi.it,Istituto Nazionale dei Tumori,Healthcare
 istranet.ru,Istranet,ISP
+isu.edu,Idaho State University,Education
+isu.net.sa,King Abdul Aziz City for Science and Technology,Science
+isvc.vn,Viet Digital Technology,Web Host
 isync.io,iSync.io,SaaS
+it-grad.ru,IT-GRAD,IaaS
 it7.net,IT7,Web Host
 itafiber.com.br,ITAFIBER,ISP
 itainternet.com.br,Ita Internet,ISP
 italiaonline.it,Italiaonline,Web Host
 itanet.psi.br,ITANET,ISP
 itaon.net.br,ITAON,ISP
+itb.ac.id,Institut Teknologi Bandung,Education
 itcen.com,ITCenenTec,ISP
 itcsa.net,Informática y Telecomunicaciones,ISP
+itdz-berlin.de,IT-Dienstleistungszentrum Berlin,Government
+ite.net,IT&E Guam,ISP
+itel.com,iTel Networks,ISP
+iteso.mx,ITESO,Education
+itgate.it,IT.Gate,ISP
+itglobal.com,ITGLOBAL,IaaS
 ithostline.com,IT HOSTLINE,MSP
 iti-e.co.jp,ITI,Healthcare
 itility.co.uk,Itility,Web Host
+itm8.com,itm8,MSP
 itmedia.co.jp,ITmedia,News
 itnorrbotten.se,IT Norrbotten,MSP
 itools.mn,iTools,MSP
 itop.net.br,iTop,ISP
+itrc.net,Internet Technology Research Consortium,Nonprofit
 itri.org.tw,ITRI,Industrial
+itsa.pl,Intelligent Technologies,ISP
+itsbrasil.net,ITS Telecomunicacoes,ISP
 itscom.jp,its communications,ISP
 itscom.net,iTSCOM,ISP
 itstechnologygroup.com,ITS Technology Group,ISP
+itstriangle.com,Triangle Communications,ISP
 itu.edu.tr,Istanbul Technical University,Education
 itu.int,International Telecommunication Union,Government
 itvoice.com,IT Voice,MSP
@@ -2753,15 +3459,19 @@ iucc.ac.il,IUCC,Education
 iuhw.ac.jp,International University of Health and Welfare,Education
 iup.edu,Indiana University of Pennsylvania,Education
 iusecom.com.br,Figueiredo e Silva,ISP
+iv.lt,Interneto vizija,Web Host
 iveco.com,Iveco,Manufacturing
 iveloz.net.br,Iveloz Telecom,ISP
+iver.com,Iver,MSP
 iwashiya-nagai.co.jp,Iwashiya Nagai Co,Healthcare
 iway.ch,iWay,ISP
 iwelt.de,iWelt,MSP
 iwhost.com,iWHOST,Web Host
 iwihost.net,Host Telecom,Web Host
 iworx-host.com,iWorx Host,Web Host
+ixreach.com,IX Reach,ISP
 izzi.mx,Izzi Telecom,ISP
+j-com.co.jp,J-Com Japan Communications,ISP
 j-server.jp,J-Server,Web Host
 jaaikosei.or.jp,Aichiken Kosei Agricultural Cooperative Association,Agriculture
 jabatus.fr,o2switch,Web Host
@@ -2769,10 +3479,14 @@ jabbroadband.com,Rise Internet,ISP
 jablonka.cz,Jablonka.cz,Nonprofit
 jacobs.com,Jacobs Engineering,Construction
 jadecom.or.jp,Japan Association for Development of Community Medicine,Healthcare
+jadeworld.com,Jade Software,SaaS
 jaea.go.jp,Japan Atomic Energy Agency,Government
+jaguarcommunications.com,Jaguar Communications,ISP
 jaist.ac.jp,Japan Advanced Institute of Science and Technology,Education
+jal.co.jp,Japan Airlines,Travel
 jalanet.co.id,JALAnet,ISP
 jamescitycountyva.gov,"James City County, Virginia",Government
+janis.jp,JANIS,ISP
 japan-wirecable.com,Bell Denki,Industrial
 japnet.com.br,Japnet Telecom,ISP
 jaringanlintasartha.com,PT Jaringan Lintas Artha,ISP
@@ -2781,16 +3495,23 @@ jastel.co.th,JasTel,Web Host
 jato64.com.br,Infortel,ISP
 javvara.com,javvara,Marketing
 jawwal.ps,Paltel,ISP
+jaxa.jp,JAXA,Government
+jaxenergy.com,Jackson Energy Authority,Utilities
 jazz.com.pk,Jazz,ISP
 jazztel.com,Jazztel,ISP
 jazztel.es,Jazztel,ISP
+jbnu.ac.kr,Jeonbuk National University,Education
 jccm.es,Junta de Comunidades de Castilla-La Mancha,Government
 jcntv.co.kr,JCN,ISP
 jcom.co.jp,JCOM,ISP
+jcpenney.com,JCPenney,Retail
 jcu.edu.au,James Cook University,Education
 jcwifi.com,JC WiFi,ISP
 jd.com,JD.com,Retail
+jeebr.net,Jeebr Mumbai,ISP
+jefferson.edu,Thomas Jefferson University,Education
 jellyfish.systems,Namecheap,Email Security
+jenny.africa,Jenny Internet,ISP
 jeroenboschziekenhuis.nl,Jeroen Bosch Ziekenhuis,Healthcare
 jetappcloud.com,Jetapp,Web Host
 jetcan.com.my,jetCan,Industrial
@@ -2808,10 +3529,17 @@ jisc.ac.uk,Jisc,Education
 jjexpress.com.my,JJ Express Services,Logistics
 jknet.com.br,JK Telecom,ISP
 jlab.org,Thomas Jefferson National Accelerator Facility,Education
+jm-data.at,JM-DATA,MSP
 jma-c.jp,Japan Medical Alliance Corporation,Healthcare
 jmu.edu,James Madison University,Education
+jnt.fi,JNT Jakobstadsnejdens Telefon,ISP
+jnu.ac.kr,Chonnam National University,Education
+joanneum.at,Joanneum Research,Science
 johnshopkins.edu,Johns Hopkins University,Education
+joink.com,Joink,ISP
 joker-forward.com,Joker.com,Email Provider
+jonesday.com,Jones Day,Legal
+jonkoping.se,City of Jonkoping,Government
 joomlawired.com,Joomla Wired,Web Host
 jotazo.com,Jotazo,ISP
 jotazo.net,Jotazo Telecom,ISP
@@ -2819,13 +3547,19 @@ jote.cloud,Jotelulu,Web Host
 jotelulu.cloud,Jotelulu,Web Host
 jotelulu.com,Jotelulu,Web Host
 jouwweb.site,JouwWeb,Web Host
+joyent.com,Joyent,IaaS
 jpmchase.com,JPMorgan Chase,Finance
 jpmorganchase.com,JPMorgan Chase,Finance
 jprdigital.in,JPR Digital,ISP
 jreast.co.jp,JR East,Logistics
 jrnetdns.net.br,JRNET,ISP
 jrtelecom.com.br,JR Telecom,ISP
+jsafrasarasin.ch,J. Safra Sarasin,Finance
+jst.go.jp,Japan Science and Technology Agency,Government
+jsums.edu,Jackson State University,Education
 jtglobal.com,JT,ISP
+jtsa.edu,Jewish Theological Seminary,Education
+juce.ca,JUCE Communications,ISP
 juicemagazine.com,Juice Magazine,Publishing
 juliusbaer.com,Julius Baer,Finance
 junct.com,The Junction Internet,ISP
@@ -2837,20 +3571,27 @@ jvsnet.com.br,JVS Net,ISP
 jwa.or.jp,Japan Weather Association,Government
 jweiland12.net,domainfactory GmbH,Web Host
 jwtech.co.th,JW TECH,Industrial
+k-state.edu,Kansas State University,Education
 k-telecom.org,K-Telecom,ISP
+k12.hi.us,Hawaii Department of Education,Education
 k20wa.org,Washington K-20 Network,Education
 k2network.com.br,K2 Network,ISP
 kaas.gg,KaasHosting,Web Host
 kaashosting.nl,KaasHosting,Web Host
 kabel-deutschland.de,Vodafone,ISP
 kabelplus.at,kabelplus,ISP
+kabelszat2002.hu,KabelszatNet,ISP
 kaeri.re.kr,Korea Atomic Energy Research Institute,Government
 kagawa-u.ac.jp,Kagawa University,Education
+kages.at,KAGes (Steiermarkische Krankenanstaltengesellschaft),Healthcare
 kagoshima-u.ac.jp,Kagoshima University,Education
+kagoya.com,KAGOYA,Web Host
 kagoya.net,KAGOYA,Web Host
 kai.jp,KAI Group,Manufacturing
 kainosprint.com.au,Kainos Print,Print
+kaisanet.fi,Kaisanet,ISP
 kaist.ac.kr,KAIST,Education
+kakaocorp.com,Kakao,SaaS
 kalittacharters.com,Kalitta Charters,Logistics
 kaluga.ru,CentrTelecom Kaluga,ISP
 kamatera.com,Kamatera,IaaS
@@ -2858,9 +3599,13 @@ kamensktel.ru,KamenskTelecom,ISP
 kamtv.ru,SKTV,ISP
 kanazawa-u.ac.jp,Kanazawa University,Education
 kaneka.co.jp,Kaneka,Industrial
+kangwon.ac.kr,Kangwon National University,Education
 kanren.org,KanREN,Education
+kansai-u.ac.jp,Kansai University,Education
+kansas.gov,State of Kansas,Government
 kansas.net,KansasNwt,MSP
 kaopucloud.com,Kaopu Cloud,IaaS
+kari.re.kr,KARI Korea Aerospace Research Institute,Science
 kartelkomi.ru,Kartel,ISP
 kaspr-privacy.io,Kaspr,Marketing
 kasserver.com,all-inkl.com,Web Host
@@ -2871,8 +3616,10 @@ kattare.com,Kattare,Web Host
 katv1.az,AG Telekom,ISP
 katv1.net,AG Telekom,ISP
 kaunogrudai.lt,Kauno Grūdai,Food
+kaust.edu.sa,KAUST King Abdullah University,Education
 kazintercom.kz,Kaz InterCom,ISP
 kazrena.kz,KazRENA,Education
+kaztranscom.kz,Jusan Mobile,ISP
 kbro.com.tw,kbro,ISP
 kbtelecom.net,Koos Broadband Telecom,ISP
 kcc.com,Kimberly-Clark,Manufacturing
@@ -2885,6 +3632,7 @@ kcn.tv,Keumgang Cable Network,ISP
 kcom.com,KCOM,ISP
 kcs.co.jp,Sakura KCS,MSP
 kct.co.jp,Kurashiki Cable TV,ISP
+kctvjeju.com,KCTV Jeju,ISP
 kcweb.net,KC Web,ISP
 kddi-webcommunications.co.jp,KDDI Web Communications,Web Host
 kddi.com,KDDI,ISP
@@ -2899,9 +3647,12 @@ kenet.or.ke,KENET,Education
 kennesaw.edu,Kennesaw State University,Education
 kennesawtrans.com,Kennesaw Transportation,Logistics
 kennypweb.com,Kenny P Computer Services,Web Host
+kent.edu,Kent State University,Education
 kepco.co.kr,Korea Electric Power Corporation,Utilities
 keralavisionisp.com,Keralavision Broadband,ISP
+kevag-telekom.de,KEVAG Telekom,ISP
 keycorpgroup.com,KeyCorp Financial,Finance
+keyinfo.com,Key Information Systems (Converge),MSP
 keymachine.de,Keyweb,Web Host
 keymail.com,KeyMail,Email Provider
 keyweb.de,Keyweb,Web Host
@@ -2911,6 +3662,7 @@ kg-graphics.net,KG Graphics,Print
 kggroup.eu,Kauno Grūdai,Food
 khalijfarsonline.net,Khalij Fars Online,ISP
 khplay.nl,KaasHosting,Web Host
+khu.ac.kr,Kyung Hee University,Education
 kicks-ass.net,DynDNS,Web Host
 kicks-ass.org,DynDNS,Web Host
 kicktech.com,KickTech,MSP
@@ -2923,8 +3675,10 @@ kinghost.net,KingHost,Web Host
 kingsoft.com,Kingsoft,SaaS
 kingswoodfacadesthailand.com,Kingswood Facades Thailand,Industrial
 kinx.net,KINX,ISP
+kio.tech,KIO Networks,Web Host
 kirchmann-hurry.co.za,Kirchmann-Hurry Construction,Construction
 kirkbrothers.com,Kirk Brothers Supercenter,Automotive
+kist.re.kr,KIST Korea Institute of Science and Technology,Science
 kit.ac.jp,Kyoto Institute of Technology,Education
 kit.edu,Karlsruhe Institute of Technology,Education
 kitano-hp.or.jp,Kitano Hospital,Healthcare
@@ -2936,21 +3690,32 @@ kliniken-es.net,Klinikum Esslingen,Healthcare
 klinikum-esslingen.de,Klinikum Esslingen,Healthcare
 klogixsecurity.com,K logix,MSSP
 kmd.dk,KMD,Consulting
+kmitl.ac.th,King Mongkut's Institute of Technology Ladkrabang,Education
 kmtn.ru,Kostrom City Telephone Network,ISP
 kmu.ac.jp,Kansai Medical University,Education
+kmu.ac.kr,Keimyung University,Education
 kmv.ru,Post LTD,ISP
 knet.kg,Kyrgyztelecom,ISP
+knipp.de,Knipp Medien und Kommunikation,Web Host
 knockdesign.com,Knock Design,Marketing
 knowit.fi,Knowit,MSP
+knu.ac.kr,Kyungpook National University,Education
 kobe-u.ac.jp,Kobe University,Education
+kochi-u.ac.jp,Kochi University,Education
 kodak.com,Kodak,Technology
 kodiaksys.com,ARIOS,SaaS
+koerber.de,Korber,Conglomerate
+koesio.com,Koesio,MSP
+kogakuin.ac.jp,Kogakuin University,Education
 kogite.fr,KoGite,Web Host
 kolsitegroup.com,Kolsite Group,Industrial
 kongkow.com,Kongkow,SaaS
 konicaminolta.us,Konica Minolta,Technology
 korbank.pl,Korbank,ISP
+kordia.co.nz,Kordia,ISP
+korea.ac.kr,Korea University,Education
 korea.kr,Government of South Korea,Government
+kosovotelecom.com,Telekomi i Kosoves (Vala),ISP
 kostroma.net,Kostrom City Telephone Network,ISP
 koumbit.net,Koumbit.org,MSP
 kovacmed.com,KOVAC-MED,Healthcare
@@ -2961,6 +3726,7 @@ kpn.net,KPN,ISP
 kpu-m.ac.jp,Kyoto Prefectural University of Medicine,Education
 kreativemachinez.tech,Kreative Machinez,Marketing
 kreonet.net,KREONET,Education
+kroger.com,The Kroger Co,Retail
 kryptronic.com,Kryptronic,SaaS
 ksc.net,KSC,Web Host
 ksmship.com,Korea Eco Management,Logistics
@@ -2978,16 +3744,23 @@ ktu.edu,Kaunas University of Technology,Education
 ku.ac.th,Kasetsart University,Education
 ku.edu,University of Kansas,Education
 ku.edu.kw,Kuwait University,Education
+kub.org,Knoxville Utilities Board,Utilities
+kumc.edu,University of Kansas Medical Center,Education
 kundenserver.de,domainfactory GmbH,Web Host
 kursktelecom.ru,Kursktelecom,ISP
 kusunoki-hp.com,Kusunoki Hospital,Healthcare
 kutztown.edu,Kutztown University,Education
+kvant-telecom.ru,Kvant-Telecom,ISP
+kvhasia.com,KVH Asia,ISP
+kwaoo.com,K-NET (Kwaoo),ISP
+kyberio.com,Kyberio,Web Host
 kyivstar.ua,Kyivstar,ISP
 kylos.pl,Kylos,Web Host
 kyndryl.com,Kyndryl,MSP
 kyo.tech,KyoTech,Web Host
 kyoei-med.co.jp,Kyoei Medical Instruments,Healthcare
 kyoei-med.jp,Kyoei Medical Instruments,Healthcare
+kyoto-su.ac.jp,Kyoto Sangyo University,Education
 kyoto-u.ac.jp,Kyoto University,Education
 l3harris.com,L3Harris,Defense
 la.net.ua,Lanet,ISP
@@ -2996,14 +3769,18 @@ laca.org,Licking Area Computer Association,Nonprofit
 lacoe.edu,Los Angeles County Office of Education,Education
 lacoste.com,Lacoste,Retail
 lacounty.gov,Los Angeles County,Government
+ladwp.com,LADWP Los Angeles Department of Water and Power,Utilities
 lafayette.edu,Lafayette College,Education
+lagoon.nc,Lagoon New Caledonia,ISP
 lakotanetwork.com,CRST Telephone Authority (Lakota Network),ISP
+lamar.edu,Lamar University,Education
 lamrc.com,Lam Research,Manufacturing
 lancastergeneralhealth.org,Penn Medicine Lancaster General Health,Healthcare
 lane.edu,Eugene School District 4J,Education
 lanet.ua,Lanet,ISP
 lanl.gov,Los Alamos National Laboratory,Government
 lanoptic.ru,LAN-Optic,ISP
+lanta-net.ru,LanTa,ISP
 laptech.com,LapTech Precision,Manufacturing
 larkinhealth.com,Larkin Health System,Healthcare
 larkinhospital.com,Larkin Health System,Healthcare
@@ -3013,22 +3790,29 @@ lasvegas.net,LasVegas.Net,ISP
 latech.edu,Louisiana Tech University,Education
 latineve.co.jp,LATIN EVE,Retail
 latineve.com,LATIN EVE,Retail
+latisys.com,Latisys (Zayo),Web Host
+latisys.net,Latisys,Web Host
 latitude.sh,Latitude.sh,IaaS
 latrobe.edu.au,La Trobe University,Education
+laurentian.ca,Laurentian University,Education
 lauruslabs.com,Lasarus Labs,Healthcare
 lawtendo.com,Lawtendo,Legal
 lazernet.com.br,Lazernet,ISP
 lb.go.gov.br,Government of Goias State Brasil,Government
 lbl.gov,Lawrence Berkeley National Laboratory,Government
+lblesd.k12.or.us,Linn Benton Lincoln Education Service District,Education
 lcmh.com,Lake Charles Memorial Health System,Healthcare
 lcube-server.de,LCube,Web Host
+lcv.jp,LCV,ISP
 lcv.ne.jp,LCV Corporation,ISP
 lds.online,Luganskie Domashnie Seti,ISP
 ldw.com,Last Day of Work,Entertainment
 leaderdrug.com,Cardinal Health,Healthcare
+leadergpu.com,LeaderGPU,IaaS
 leadpages.co,Leadpages,Marketing
 leadsystemsmarketing.com,Lead Systems Marketing,Marketing
 leaguelineup.com,LeagueLineup,Sports
+learn.ac.lk,Lanka Education and Research Network,Education
 learningstream.com,Learning Stream,SaaS
 leaseweb.ca,Leaseweb,Web Host
 leaseweb.com,Leaseweb,Web Host
@@ -3036,15 +3820,21 @@ leftor.ba,Leftor,Web Host
 leftor.com,Leftor,Web Host
 legenditsolutions.com,Legend IT Solutions,Web Host
 legroupeforget.com,Le Groupe Forget,Healthcare
+lehigh.edu,Lehigh University,Education
 leidos.com,Leidos,Defense
+leon.pl,Leon Polish ISP,ISP
 leonardocompany.com,Leonardo,Defense
+leonet.de,LEONET,ISP
+lepida.net,Lepida,ISP
 lestetelecom.com.br,Leste,ISP
 letsrev.com,REV,ISP
 level-7.co.za,Level 7 Internet,ISP
 level3.com,Lumen,ISP
 level3.net,Lumen,ISP
+lewtelnet.de,LEW TelNet,ISP
 lexi.net,Lexicom,MSP
 lexicom.ca,Lexicom,MSP
+lf.net,LF.net Stuttgart,ISP
 lgcns.com,LG CNS,Technology
 lgfl.net,London Grid for Learning,Education
 lghealth.org,Penn Medicine Lancaster General Health,Healthcare
@@ -3053,9 +3843,12 @@ lgnetpb.com.br,LGNET,ISP
 lguplus.co.kr,LG U+,ISP
 lguplus.com,LG U+,ISP
 lh.pl,LH.pl,Web Host
+lhric.org,Lower Hudson Regional Information Center BOCES,Education
+liasail.net,Liasail Global Hongkong (Harbor),Web Host
 liberated.ca,Liberated Networks,Web Host
 liberatednetworks.com,Liberated Networks,Web Host
 liberation.fr,Liberation,News
+liberty.co.za,Liberty Holdings South Africa,Finance
 libertycr.com,Liberty,ISP
 libertyglobal.com,Liberty Global,ISP
 libertyhospital.org,Liberty Hospital,Healthcare
@@ -3066,11 +3859,16 @@ libertypr.com,Liberty,ISP
 libraesva.com,Libraesva,Email Security
 library.on.ca,Ontario Libraries,Nonprofit
 lidernetfibra.com.br,Lidernet,ISP
+lidero.net,Lidero Network,ISP
+life.by,Life Belarus (BeST),ISP
 lifecell.ua,lifecell,ISP
 lifenetworks.com.br,Lifenetworks,ISP
 ligataxi.com,LiguaTaxi,SaaS
 liggatelecom.com.br,Ligga Telecom,ISP
+lightbound.com,LightBound,ISP
 lightedge.com,LightEdge,MSP
+lightningfibre.co.uk,Lightning Fibre,ISP
+lightnode.com,LightNode,Web Host
 lightower.net,Lightower Fiber Networks,ISP
 lightpathfiber.com,Lightpath,ISP
 lightwyse.com,Lumos,ISP
@@ -3079,6 +3877,7 @@ liguriadigitale.it,Liguria Digitale,MSP
 likuid.com,Likuid,Web Host
 lilly.com,Eli Lilly,Healthcare
 limco-logistics.net,Limco Logistics,Logistics
+limes.com.pl,Limes Polska,ISP
 limestonenetworks.com,Limestone Networks,Web Host
 limitis.com,Limitis,Technology
 lindsaymunicipalhospital.com,Lindsay Municipal Hospital,Healthcare
@@ -3094,6 +3893,7 @@ linkedin.com,LinkedIn,Social Media
 linkfire.com.br,Linkfire Telecom,ISP
 linknetms.com.br,Link Net Telecom,ISP
 linknortetelecom.com.br,Link Norte,ISP
+linksecured.net,LinkSecured (Sudjam),Web Host
 linksul.com.br,LinkSul,ISP
 linkt.fr,Linkt,ISP
 linode.com,Linode,Web Host
@@ -3101,6 +3901,7 @@ linodeusercontent.com,Linode,Web Host
 linqtelecom.com.br,LinQ Telecom,ISP
 lintasarta.net,Lintasarta,ISP
 linxtelecom.com,CITIC Telecom CPC,ISP
+linzag-telekom.at,LINZ AG TELEKOM,ISP
 liquid.tech,Liquid Intelligent Technologies,ISP
 liquidnetlimited.com,LiquidNet,Web Host
 liquidtelecom.com,Liquid Intelligent Technologies,ISP
@@ -3109,10 +3910,13 @@ liquidweb.com,Liquid Web,Web Host
 listrak.com,Listrak,Marketing
 liteserverdns.in,The PowerHost,Web Host
 litiumdrift.se,Litium,SaaS
+litnet.lt,LITNET Lithuanian Research and Education Network,Education
+liu.edu,Long Island University,Education
 liu.se,Linköpings universitet,Education
 live-servers.net,Fasthosts Internet Ltd,Web Host
 live-website.com,IONOS,Web Host
 live.com,Outlook (Personal and Microsoft 365),Email Provider
+livedigi.com,Digi Belize / Belize Telemedia,ISP
 livedns.co.il,LiveDNS,Web Host
 livedo.jp,Livedo Corporation,Healthcare
 livemail.co.uk,Fasthosts Internet Ltd,Web Host
@@ -3123,8 +3927,12 @@ llnl.gov,Lawrence Livermore National Laboratory,Government
 lloydsbankinggroup.com,Lloyds Banking Group,Finance
 lluh.org,Loma Linda University Health,Healthcare
 llumc.edu,Loma Linda University Medical Center,Healthcare
+lmco.com,Lockheed Martin,Defense
 lmi.net,LMi.net,ISP
+lmu.edu,Loyola Marymount University,Education
+lncc.br,LNCC Brazilian National Laboratory for Scientific Computing,Science
 loading.es,Loading,Web Host
+loblaw.ca,Loblaw,Retail
 loc.gov,Library of Congress,Government
 localnet.com,LocalNet,ISP
 locaweb.com.br,Locaweb,Web Host
@@ -3134,33 +3942,45 @@ lodestonegroup.com,Loadstone Insurance,Finance
 lodz.pl,Lodz University of Technology,Education
 loftsinc.com,"Lofts, Inc.",Retail
 loga.net.br,Loga,ISP
+logic.ky,Logic Cayman,ISP
 logicweb.com,LogicWeb,Web Host
 logika.ro,Logika IT Solutions,MSP
+loginbusiness.com,Login Inc Tucson,ISP
+logis.org,LOGIS,Government
 logisticintegrators.com,Logistics Integrators,Logistics
 logix.in,Logix InfoSecurity,MSP
+logosoft.ba,Logosoft,ISP
 lokalonline.com.br,Lokal Online Telecom,ISP
 lolipop.jp,Lolipop,Web Host
 lomalindahealth.org,Loma Linda University Health,Healthcare
 london.on.ca,St. Joseph's Health Care London,Healthcare
+longlines.com,Long Lines Broadband,ISP
 loni.org,LONI,Education
 loopia.se,Loopia,Web Host
 losnettos.net,Los Nettos,Education
+lotteinnovate.com,Lotte Innovate,MSP
 louhi.fi,Louhi,Web Host
 louhi.net,Louhi,Web Host
+louisiana.edu,University of Louisiana at Lafayette,Education
 louisiana.gov,Louisiana Government,Government
+louisville.edu,University of Louisville,Education
 lounea.fi,Lounea,ISP
 lowesthosting.com,Lowest Hosting,Web Host
+loyalty.com,LoyaltyOne,SaaS
 lpages.co,Leadpages,Marketing
 lpcgov.org,La Plata County,Government
 lpn.co.th,L.P.N. Development PCL,Real Estate
+lpnet.com.br,Desktop Sigmanet,ISP
 lpusercontent.com,Leadpages,Marketing
 lrnetbandalarga.net.br,L & R Net,ISP
 lrz.de,LRZ,Education
+lsnetworks.net,Lightspeed Networks,ISP
 lss.net.pl,Freshbox,ISP
 lstn.net,Limestone Networks,Web Host
 lstream.org,LifeStream Blood Bank,Nonprofit
 lstrk.net,Listrak,Marketing
 lsu.edu,Louisiana State University,Education
+lsuc.on.ca,Law Society of Ontario,Government
 lt-nn.net,Link Telecom NN,ISP
 ltt.ly,Libya Telecom & Technology,ISP
 ltu.se,Luleå University of Technology,Education
@@ -3168,6 +3988,7 @@ lu.se,Lund University,Education
 lubonet.net.pl,LUBONET,ISP
 lugtel.com,Lugansk Telephone Company,ISP
 lumen.com,Lumen,ISP
+luminabroadband.com,Lumina Broadband,ISP
 lumison.net,Pulsant,Web Host
 lumos.net,Lumos,ISP
 lumosfiber.com,Lumos,ISP
@@ -3178,6 +3999,8 @@ luxsci.com,LuxSci,Email Security
 lwlcom.net,LWLcom,ISP
 lws-hosting.com,LWS,Web Host
 lxcluster.at,LXCluster,Web Host
+lycatel.com,Lyca Group,ISP
+lycorp.co.jp,LY Corporation,SaaS
 lyntia.com,Lyntia,ISP
 lynxoft.ru,LynXoft,Marketing
 lyse.no,Lyse,ISP
@@ -3190,19 +4013,24 @@ m247global.com,M247,Web Host
 m2dtelecom.com.br,M2D Telecom,ISP
 m4w.at,M4W Kreativ,Marketing
 m9network.com,Volico Data Centers,Web Host
+macalester.edu,Macalester College,Education
 machanet.com.br,Grupo Nordeste Telecom,ISP
 macomnet.ru,Macomnet,ISP
 macquariedatacentres.com,Macquarie Data Centres,Web Host
 macquariegovenrmnet.com,Macquarie Government,IaaS
 macrolan.co.za,SEACOM,MSP
 macrx.com,MAC Rx,Healthcare
+macstadium.com,MacStadium,Web Host
 mada.ps,Mada,ISP
 maddock.net,Maddock Films,Entertainment
 maersk.com,Maersk,Logistics
 maestroit.com,Maestro IT Services,MSP
+maffin.ad.jp,"MAFF (Japan Ministry of Agriculture, Forestry and Fisheries)",Government
+mageal.ru,Mageal,ISP
 magenta.at,Magenta,ISP
 magentosite.cloud,Adobe Magento,SaaS
 magnetplus.ie,Magnet Plus,ISP
+magnite.com,Magnite,Marketing
 magnoliarental.com,Magnolia Rental,Retail
 magticom.ge,Magticom,ISP
 mail.baby,Mail Baby,Email Security
@@ -3246,33 +4074,50 @@ maisinternet.net.br,Mais Internet,ISP
 majorcore.com,MajorCore,Web Host
 makeshop.jp,makeshop,SaaS
 maletazul.pt,Maletazul,MSP
+malmo.se,City of Malmo,Government
 mamacheaps.com,Mama Cheaps,Retail
 man-da.de,MANDA Darmstadt,Education
 managedns.org,IBM Cloud,IaaS
+manchetelecom.fr,Manche Telecom,ISP
 mandrillapp.com,Mailchimp Transactional,SaaS
+mango.com.bd,Mango Teleservices Bangladesh,ISP
 manh.com,Manhattan,SaaS
 manhattan.edu,Manhattan University,Education
+manxtelecom.com,Manx Telecom,ISP
 mapheadstart.org,Mississippi Action for Progress,Nonprofit
 mappsoluciones.com,MappS Soluciones,Web Host
 marcatel.com,Marcatel,ISP
+maren.ac.mw,MAREN Malawi Research and Education Network,Education
+maricopa.edu,Maricopa Community Colleges,Education
+maricopa.gov,Maricopa County,Government
+marist.edu,Marist University,Education
 mark-itt.net,Point Internet,ISP
 mark-net.co.jp,Mark Co,Marketing
 mark.ru,OOO NI,ISP
 marlink.com,Marlink,MSP
+marquette.edu,Marquette University,Education
 marriott-service.com,Marriott,Travel
 marriott.com,Marriott,Travel
 mars-inc.com,Mars,Food
+marsh.com,Marsh,Finance
 martinsnet.com.br,Martins.Net,ISP
+marubeni.com,Marubeni,Conglomerate
 maruyamakai.jp,Maruyamakai,Healthcare
 maruyamakai.or.jp,Maruyamakai,Healthcare
+maryland.gov,State of Maryland,Government
 mas-meb.ru,МастерМебель,Retail
 masergy.com,Masergy (Comcast Business),ISP
+maskatel.qc.ca,Maskatel,ISP
 maskworld.com,Maskworld,Retail
 masmovil.com,MásMóvil,ISP
 masmovil.es,MásMóvil,ISP
 masorange.es,MásOrange,ISP
 mass.gov,Massachusetts Government,Government
+massey.ac.nz,Massey University,Education
 massgeneralbrigham.org,Mass General Brigham,Healthcare
+massivenetworks.com,Massive Networks,ISP
+massresponse.com,Mass Response,SaaS
+master.cz,MasterDC,Web Host
 mastercabo.com.br,Master Cabo,ISP
 masterdatanet.com.br,Master Data Net,ISP
 masterdc.com,MasterDC,Web Host
@@ -3280,21 +4125,29 @@ masterhost.ru,Master Host,Web Host
 masterinter.net,MasterDC,Web Host
 masterjaya.com.my,Master Jaya Engineering,Industrial
 masterlinktelecom.net,Master Link Telecom,ISP
+mastertel.ru,Mastertel,ISP
 mastertrg.ru,МастерМебель,Retail
 masterturbonet.com.br,Master Turbonet,ISP
+matc.edu,Milwaukee Area Technical College,Education
 materprivate.ie,Mater Private Network,Healthcare
+mathworks.com,MathWorks,SaaS
 matrixglobal.net.id,Matrixnet,ISP
 matrixnetglobal.com,Matrixnet,ISP
 mauriziano.it,Ordine Mauriziano,Healthcare
 maxaninteirorsystems.com,Maxan Interior Systems,Industrial
 maximtech.com,Maximtech,Web Host
 maximweb.com,Maxim Management Services,Healthcare
+maxindo.net.id,Maxindo Mitra Solusi,ISP
 maxis.com.my,Maxis,ISP
 maxnet.ua,Maxnet,ISP
 maxxsouth.com,MaxxSouth Broadband,ISP
 mayernetworks.com,Mayer Networks,MSP
+mayoclinic.com,Mayo Clinic,Healthcare
 mbari.org,Monterey Bay Aquarium Research Institute,Education
+mbonetworks.com,MBO Networks,ISP
+mc.net.co,Media Commerce Partners,ISP
 mccooknet.com,McCookNet,Web Host
+mccormickplace.com,McCormick Place,Event Planning
 mcdir.me,McHost,Web Host
 mcdir.ru,McHost,Web Host
 mcdlv.net,Intuit Mailchimp,Marketing
@@ -3308,17 +4161,26 @@ mclaut.com,McLaut,ISP
 mcmahonmed.com,McMahon Publishing,Publishing
 mcmaster.ca,McMaster University,Education
 mcmaster.com,McMaster-Crr,Manufacturing
+mcmtelecom.com,MCM Business (Megacable Mexico),ISP
 mcnbd.com,Millennium Computer's & Networking,MSP
 mcnc.org,MCNC,Education
 mcpre.ru,McHost,Web Host
+mcpsmd.org,Montgomery County Public Schools (Maryland),Education
+mcsnet.ca,MCSnet,ISP
 mcsv.net,Intuit Mailchimp,Marketing
+mctv.jp,Matsusaka Cable TV,ISP
+mctvohio.com,MCTV (Massillon Cable),ISP
 mcw.edu,Medical College of Wisconsin,Education
 mdanderson.org,MD Anderson Cancer Center,Healthcare
 mdc-berlin.de,Max Delbruck Center for Molecular Medicine,Education
 mdc.edu,Miami Dade College,Education
 mdcc.gob.pe,Municipalidad Distrital de Cerro Colorado,Government
+mdcourts.gov,Maryland Courts,Government
+mdlink.de,MDlink,MSP
 mdlsx.ca,"Middlesex County, Canada",Government
+mdu.com,MDU Resources,Utilities
 me.com,Apple iCloud,Email Provider
+mecon.gov.ar,Argentina Ministry of Economy,Government
 medallia.com,Medllia,SaaS
 medcity.net,HCA Healthcare,Healthcare
 medi-take.jp,Medi-Take,Healthcare
@@ -3328,16 +4190,21 @@ mediacenter.hu,MediaCenter Hungary,Web Host
 mediacomcable.com,Mediacom,ISP
 mediacommerce.com.co,Media Commerce Partners,ISP
 mediafuze.com,Mediafuze,Marketing
+mediaprint.at,Mediaprint,Publishing
 mediasolutionsco.com,Media Solutions,Marketing
 mediasolutionscorp.com,Media Solutions,Marketing
 mediaticanet.it,Mediatica,Web Host
 medical-surveys.com,Medical Surveys,Healthcare
+medicalcomputersystems.com,Medical Computer Systems,Healthcare
 medicalsurveynews.com,Global Healthcare Research,Healthcare
 medimpact.com,MedImpact,Healthcare
 meditake.jp,Medi-Take,Healthcare
 mediweightloss.com,Medi-Wegihtloss,Healthcare
 mediweightlossclinics.com,Medi-Wegihtloss,Healthcare
 medline.com,Medline,Healthcare
+medtronic.com,Medtronic,Healthcare
+meduniwien.ac.at,Medical University of Vienna,Education
+medweb.net,Medweb,Healthcare
 mega.kg,Maga-Line,ISP
 mega.mx,Megacable,ISP
 megacable.com.ar,MERCO Comunicaciones,ISP
@@ -3355,31 +4222,41 @@ megamailservers.com,MegaMailServers,MSP
 megamailservers.eu,MegaMailServers,MSP
 meganetrj.com.br,Meganet,ISP
 megared.net.mx,Megared,ISP
+megavision.net.id,Megavision,ISP
+meiji.ac.jp,Meiji University,Education
 meinserver.io,Timme Hosting,Web Host
+mekongnet.com.kh,MekongNet,ISP
 melbicom.net,Melbikomas,Web Host
 melita.com,Melita,ISP
 memberleap.com,MemberLeap,Web Host
+memphis.edu,University of Memphis,Education
 mems-exchange.org,MNX,Industrial
 memset.com,Memset,Web Host
 memset.net,Memset,Web Host
 menlosecurity.com,Menlo Security,Email Security
 meo.pt,MEO,ISP
 mercedes-benz.com,Mercedes-Benz,Automotive
+merck.com,Merck,Healthcare
 merckgroup.com,Merck KGaA,Healthcare
 mercranet.com,Mercranet,Web Host
 mercury.co.nz,Mercury NZ,Utilities
 mercurygate.net,MercuryGate,SaaS
+merezha.in.ua,Merezha,ISP
 meric.net.tr,Meriç Hosting,Web Host
 merit.edu,Merit Network,Education
 merl.com,Mitsubishi Electric Research Labs,Education
 merlien.com,Merlien,Event Planning
 merlin.mb.ca,MERLIN,Education
 merula.net,Merula,ISP
+mesd.k12.or.us,Multnomah Education Service District,Education
 meshsecurity.io,Mesh Security,Email Security
+messa.org,Michigan Education Special Services,Nonprofit
 messagelabs.com,Broadcom Enterprise Messaging Security,Email Security
 messagexchange.com,MessageeXchange,SaaS
 messagingengine.com,Fastmail,Email Provider
 mesvr.com,ReadNotify,Email Provider
+metalink.net,MetaLINK Technologies,ISP
+metanet.co.kr,Metanet DT,MSP
 metcal.com.my,Metcal Technologies,Industrial
 meteversecloud.com,Meteverse,IaaS
 metfone.com.kh,Metfone,ISP
@@ -3392,11 +4269,17 @@ metrohealth.org,MetroHealth,Healthcare
 metronet.com,MetroNet,ISP
 metronetinc.net,Metronet,ISP
 metrored.com.mx,Metrored,ISP
+metrored.hn,Metrored Honduras,ISP
 metrored.net.mx,Metrored,ISP
+metrotel.com.ar,Metrotel Argentina,ISP
+metrotel.net.co,Metrotel,ISP
+metsagroup.com,Metsa Group,Manufacturing
 mettel.net,MetTel,ISP
+metu.edu.tr,Middle East Technical University,Education
 mexxus.com,Mexxus Media,Marketing
 mexxusmedia.com,Mexxus Media,Marketing
 mezmotech.com,Mezmo,SaaS
+mf.gov.pl,Polish Ministry of Finance,Government
 mfa-inc.com,MFA,Industrial
 mfeed.ad.jp,Internet Multifeed (JPNAP),ISP
 mgb.org,Mass General Brigham,Healthcare
@@ -3416,11 +4299,16 @@ microchip.com,Microchip Technology,Manufacturing
 microchip.net.pl,Microchip s.c.,ISP
 microfocus-japan.com,Micro Focus,MSP
 micron.com,Micron Technology,Manufacturing
+micron21.com,Micron21 Datacentre,Web Host
 micronet.in,MicroNet Gigafiber,ISP
+microscan.co.in,Microscan,ISP
+microscaninternet.com,Microscan,ISP
 microservizi.com,Microservizi,ISP
 microsoft.com,Microsoft,Technology
+mid-hudson.com,Mid-Hudson Cablevision,ISP
 midcityvet.com,MidCity Veterinary Hospital,Healthcare
 midco.com,Midco,ISP
+middlebury.edu,Middlebury College,Education
 middlesex.ca,"Middlesex County, Canada",Government
 midi-loisirs.com,Midi Loisirs,Entertainment
 mie-u.ac.jp,Mie University,Education
@@ -3432,26 +4320,37 @@ mil.se,Swedish Armed Forces,Defense
 mila.is,Míla,ISP
 milkcratesdirect.com,FARMPLAST,Retail
 milleni.com.tr,Millenicom,ISP
+millerken.com,Milliken,Manufacturing
 millersville.edu,Millersville University of Pennsylvania,Education
 millicom.com,Tigo,ISP
+milliken.com,Milliken,Manufacturing
+millipore.com,Millipore,Healthcare
 milton.ca,Town of Milton,Government
 mimecast-offshore.com,Mimecast,Email Security
 mimecast.com,Mimecast,Email Security
 mindmoviesmail.com,Mind Movies,SaaS
 minebeamitsumi.com,MinebeaMitsumi,Manufacturing
+mines.edu,Colorado School of Mines,Education
 minigraphics.net,Mini Graphics,Print
 miniserver.com,Memset,Web Host
 minnstate.edu,Minnesota State Colleges and Universities,Education
 mir9.co.kr,Mir9,Marketing
+mirai.ne.jp,Mirai NET,ISP
 miralogic.ru,MiraLogic,ISP
+miranda-media.ru,Miranda Media,ISP
 mirohost.net,MiroHost,Web Host
+misd.net,Macomb Intermediate School District,Education
+misshosting.se,Miss Hosting,Web Host
+mississauga.ca,City of Mississauga,Government
 missouri.edu,University of Missouri,Education
+missouri.gov,State of Missouri,Government
 mistral.co.uk,Nasstar,MSP
 mistral.net,Nasstar,MSP
 mit.edu,MIT,Education
 mitec.net,Mitec Solutions,MSP
 mitene.co.jp,Mitene Internet,ISP
 mitre.org,MITRE,Nonprofit
+mitsubishielectric.co.jp,Mitsubishi Electric,Manufacturing
 mittwald.de,Mittwald,Web Host
 mittwald.info,Mittwald,Web Host
 mittwaldserver.info,Mittwald,Web Host
@@ -3462,6 +4361,7 @@ mizban.com,Mizban,Web Host
 mk.de,MK Netzdienste,MSP
 mkc-net.ru,МКС (MKC-Net),ISP
 mknetwork.com.br,MkK Network Telecom,ISP
+mkpnet.ru,Orgtechservice (MKP-Net),ISP
 mksnet.com.br,RazaoInfo,ISP
 mkt2527.com,Acoustic,Marketing
 mktdns.com,Marketo,Marketing
@@ -3474,9 +4374,12 @@ mma.com.br,MMA Fibra,ISP
 mmm.com,3M,Technology
 mmprovedor.com.br,MM Telecom,ISP
 mmrs.jp,Mirai Communication Network Inc.,Web Host
+mnet.bg,MSAT Cable,ISP
 mni.net,MNI,Marketing
 mnsi.net,MNSi Telecom,ISP
 mnzoo.org,Minnesota Zoo,Entertainment
+moack.co.kr,MOACK,Web Host
+mobifone.vn,MobiFone,ISP
 mobilecountypublicworks.net,Mobile County Public Works,Government
 mobilosoft.be,Mobilosoft,Marketing
 mobilosoft.com,Mobilosoft,Marketing
@@ -3488,28 +4391,43 @@ modeldrug.com,Model Health Care,Healthcare
 modenesegastone.com,Modenese Gastone,Retail
 modis.com,AKKODiS,Staffing
 modmc.net,MOD Mission Critical,MSP
+moe.go.th,Ministry of Education Thailand,Government
 moe.gov.tw,Ministry of Education Computer Center,Government
 mogilev.by,Mogilev.by,ISP
+mohawkcollege.ca,Mohawk College,Education
 mojohost.com,MojoHost,Web Host
 molalla.com,Molalla Communications,ISP
 molalla.net,Molalla Communications,ISP
+moldcell.md,Moldcell,ISP
 moldtelecom.md,Moldtelecom,ISP
+molgroup.hu,MOL Group,Industrial
+momentumtelecom.com,Momentum Telecom,ISP
+monaco-telecom.mc,Monaco Telecom,ISP
 monash.edu,Monash University,Education
 monatglobal.com,MONAT Global,Beauty
 mongodb.com,MongoDB,SaaS
 moniker.com,Moniker,Web Host
 monitorsanywhere.com,Monitors AnyWhere,SaaS
+monkeybrains.net,Monkeybrains,ISP
+monroecc.edu,Monroe Community College,Education
 montana.edu,Montana State University,Education
 montanasky.net,MontanaSky,ISP
+montclair.edu,Montclair State University,Education
 montereybaydesign.com,Monterey Bay Design,Web Host
+montgomerycollege.edu,Montgomery College,Education
 montreal.ca,City of Montreal,Government
 moovik.com.ua,MooVik,Retail
+moph.go.th,Thailand Ministry of Public Health,Government
 morarepublic.co.id,Mora Republic,ISP
 moratelindo.net.id,Moratelindo,ISP
 more.net,MOREnet,Education
 moreheadstate.edu,Morehead State University,Education
+morenet.ac.mz,MoRENet,Education
 morespeed.com.br,More Speed Fibra,ISP
+morgan.edu,Morgan State University,Education
+morganstanley.com,Morgan Stanley,Finance
 morganstanleysmithbarney.com,Morgan Stanley Smith Barney,Finance
+morrisville.edu,SUNY Morrisville,Education
 morroonline.com.br,Morro Telecom,ISP
 moselletelecom.fr,Moselle Télécom,ISP
 mostobene.com,Mostobene,Healthcare
@@ -3522,30 +4440,40 @@ movilnet.com.ve,Movilnet,ISP
 movistar.cl,Moivestar Chlie,ISP
 movistar.com.co,Movistar,ISP
 movistar.com.mx,Movistar,ISP
+movistar.com.sv,Movistar El Salvador,ISP
 movistar.com.uy,Tigo,ISP
 movistar.es,Movistar,ISP
 movitel.co.mz,Movitel,ISP
+mpg.de,Max-Planck-Gesellschaft,Science
 mpi-iq.com,Al-Mansour,Healthcare
+mpsaz.org,Mesa Public Schools,Education
+mpy.fi,MPY Telecom,ISP
 mrgdigital.com,MRG Digital,Marketing
 mrhc.org,Magnolia Regional Health Center,Healthcare
 mrhost.biz,MrHost,Web Host
+mrit.gov.pl,Polish Ministry of Development and Technology,Government
 mrse.com.ar,Telefonica de Argentina,ISP
 msd-consulting.co.za,MSD Consulting,Finance
 mserwis.pl,MSERWIS,Web Host
+msfiber.net,Mainstream Fiber Networks,ISP
 msfibra.com.br,MS Fibra,ISP
 msgexch.com,Constant Contact,Marketing
 mskcc.org,Memorial Sloan Kettering Cancer Center,Healthcare
+msoe.edu,Milwaukee School of Engineering,Education
+mssm.edu,Icahn School of Medicine at Mount Sinai,Education
 msstate.edu,Mississippi State University,Education
 mst.edu,Missouri University of Science and Technology,Education
 msu.edu,Michigan State University,Education
 msu.ru,Moscow State University,Education
 mtaroutes.com,N-able,Email Security
+mtasolutions.com,Matanuska Telecom Association,ISP
 mtasv.net,Postmark,SaaS
 mtc.com.na,MTC,ISP
 mtccomm.net,MTC Communications,ISP
 mtdtraining.co.uk,MTD Training Group,SaaS
 mtel.ba,Mtel,ISP
 mtel.me,Mtel,ISP
+mtholyoke.edu,Mount Holyoke College,Education
 mtn.ci,MTN,ISP
 mtn.cm,MTNL,ISP
 mtn.co.rw,MTN Rwanda,ISP
@@ -3558,20 +4486,25 @@ mtnet.hr,Magic Net,ISP
 mtnirancell.ir,MTN Irancell,ISP
 mtnl.net.in,MTNL,ISP
 mtnonline.com,MTN,ISP
+mtnsat.com,MTNSat,ISP
 mtolivethomes.org,Mount Olivet Careview Home,Healthcare
 mts.am,Viva-MTS,ISP
 mts.by,MTS,ISP
 mts.com,MTS Systems,Manufacturing
 mts.rs,MTS,ISP
 mts.ru,MTS,ISP
+mtsac.edu,Mt. San Antonio College,Education
 mtsmail.ca,Bell MTS,ISP
 mtsnet.ru,Mobile TeleSystems PJSC (MTS),ISP
 mtsu.edu,Middle Tennessee State University,Education
 mtsvc.net,GoDaddy,Web Host
 mtu-net.ru,Mobile TeleSystems,ISP
 mtu.edu,Michigan Technological University,Education
+mtw.ru,MTW Mediasoft,Web Host
+muenchen.de,City of Munich,Government
 mufg.jp,MUFG,Finance
 multacom.com,MULTACOM,Web Host
+multi.net.pk,Multinet Pakistan,ISP
 multimedia.pl,Multimedia Polska,ISP
 multipolar.co.id,Multipolar Technology,MSP
 multivelox.com.br,Multivelox,ISP
@@ -3579,9 +4512,12 @@ mun.ca,Memorial University of Newfoundland,Education
 mundivox.com,Mundivox Communications,ISP
 mundocuenca.com.ar,Universidad de la Cuenca del Plata,Education
 mundonetfibra.com.br,Mundo Net Fibra,ISP
+mundopacifico.cl,Mundo Pacifico,ISP
 muni.cz,Masaryk University,Education
+munich-airport.de,Munich Airport,Travel
 musashi-eng.co.jp,Musashi Engineering,Manufacturing
 musc.edu,Medical University of South Carolina,Healthcare
+mutualofomaha.com,Mutual of Omaha,Finance
 muvnet.com.br,Muvnet Telecom,ISP
 mvd.ru,Ministry of Internal Affairs of Russia,Government
 mwainternet.com.br,MWA Internet,ISP
@@ -3624,11 +4560,15 @@ mymanga.co.ke,Mymanga Networks,ISP
 mymedicalsurveys.com,Global Healthcare Research,Healthcare
 mymru.ca,Mount Royal University,Education
 mymts.net,Bell MTS,ISP
+mynet.at,myNET Austria,ISP
 mynet.it,MyNet,ISP
+mynextlight.com,Longmont NextLight,Utilities
+mypremieronline.com,Premier Communications,ISP
 myradweb.net,Rad Web Hosting,Web Host
 myrdbx.io,Raidboxes,Web Host
 myregisteredsite.com,web.com,Web Host
 myrepublic.co.id,MyRepublic,ISP
+myrepublic.net,MyRepublic,ISP
 mysecurecloudhost.com,World Host Group,Web Host
 mysecuritas.com,Securitas,Physical Security
 myshopify.com,Shopify,SaaS
@@ -3654,6 +4594,7 @@ myspreadshop.se,Spreadshop,SaaS
 mytelstar.com,Tel-Star,ISP
 mythic-beasts.com,Mythic Beasts,Web Host
 mywhc.ca,Web Hosting Canada,Web Host
+mywkt.net,WK&T West Ky Networks,ISP
 myworkday.com,Workday,SaaS
 n4telecom.com.br,N4 Telecom,ISP
 na4u.ru,Netangles,Web Host
@@ -3668,6 +4609,7 @@ naist.ac.jp,Nara Institute of Science and Technology,Education
 name.com,Name.com,Web Host
 namecheap.com,Namecheap,Web Host
 namehero.net,NameHero,Web Host
+names.co.uk,names.co.uk (Team Blue),Web Host
 nameserver.sk,Webglobe,Web Host
 namespro.ca,Namespro,Web Host
 nannugroup.com,Nannu Group,Conglomerate
@@ -3676,7 +4618,9 @@ nano.uz,Nano Telecom,ISP
 nao.ac.jp,National Astronomical Observatory of Japan,Education
 nap.net.tw,Taiwan Network Access Point,ISP
 nasa.gov,NASA,Government
+nasboces.org,Nassau BOCES,Education
 nascoeducation.com,Nasco EDucation,Education
+nashville.gov,Nashville Davidson County,Government
 nask.pl,NASK,Education
 nasonline.org,National Academy of Sciences,Education
 nasstar.com,Nasstar,MSP
@@ -3685,16 +4629,24 @@ nationalhha.com,National Home Health,Healthcare
 nationlanka.com,Nation Lanka Finance,Finance
 nationwide.co.uk,Nationwide Building Society,Finance
 nationwide.com,Nationwide,Finance
+natkraftboras.se,Natkraft Boras,Utilities
 nato.int,NATO,Defense
+naturalwireless.com,Natural Wireless,ISP
+natwestmarkets.com,NatWest Markets,Finance
 nau.edu,Northern Arizona University,Education
+naukanet.ru,Nauka-Svyaz,ISP
 navayuga.com,Navayuga,Industrial
+navega.com,Navega Guatemala,ISP
+naver.com,Naver,Search Engine
 navercorp.com,Naver,Technology
 naviexp.jp,NaviExp,MSP
+navigata.ca,Navigata Communications,ISP
 navisite.com,Navisite,MSP
 navy.mil,U.S. Navy,Defense
 nayatel.com,Nayatel,ISP
 nazwa.pl,NetArt Group,Web Host
 nbcb.cn,Bank of Ningbo,Finance
+nbpower.com,New Brunswick Power,Utilities
 nbstelecom.psi.br,NBS Telecom,ISP
 nc.gov,State of North Carolina,Government
 ncbs.res.in,National Centre for Biological Sciences,Education
@@ -3705,10 +4657,16 @@ ncsl.ca,Northern Computer Solutions,MSP
 ncsu.edu,NC State University,Education
 nctc.com,NCTC,ISP
 ncturbi.com.br,NetCom Brasil,ISP
+ncv.co.jp,Newmedia Corporation,ISP
 nd.edu,University of Notre Dame,Education
 nd.gov,North Dakota Government,Government
+ndensan.co.jp,Densan,MSP
 nearlyfreespeech.net,NearlyFreeSpeach.NET,Web Host
+nearoute.io,Nearoute (Ikuuu Network),Web Host
+neas.mr.no,Neas,ISP
 nebraska.edu,University of Nebraska,Education
+nebraska.gov,State of Nebraska,Government
+nebulaglobal.com,Nebula Global,Web Host
 nec.com,NEC,Manufacturing
 nec.com.au,NEC,Technology
 necam.com,NEC,Technology
@@ -3716,16 +4674,22 @@ need-link-eng.co.jp,Need Link Engineering,Technology
 needles.co.kr,Tae Chang Industrial,Healthcare
 neencloud.it,NEEN,MSP
 negabaritika.ru,Negabaritika,Logistics
+neo-fiber.net,NeoFiber Communications,ISP
 neoclan.net,Neoclan Networks,ISP
 neoclan.net.mx,Neoclan Networks,ISP
 neocomisp.com,NeocomISP,ISP
+neosnetworks.com,Neos Networks,ISP
 neotechprovedor.com.br,NeoTech,ISP
 neotel.co.za,Neotel,ISP
+neotel.mk,Neotel North Macedonia,ISP
 neovision.de,NEOVISION,Marketing
 nephronpharm.com,Nephon,Healthcare
+neric.org,Northeastern Regional Information Center,Education
 nersc.gov,National Energy Research Scientific Computing Center,Government
+nessus.at,Nessus GmbH,ISP
 net-rosas.com.br,Net Rosas,ISP
 net-uno.net,Net Uno,ISP
+net.ru,NET.RU Mega ISP,ISP
 net4you.com.br,NET4YOU,ISP
 net92.ru,Sevastopol Telecom,ISP
 netactuate.com,NetActuate,Web Host
@@ -3736,24 +4700,31 @@ netatonce.se,Net at Once,ISP
 netbox.cz,NETBOX,ISP
 netcabo.pt,NOS,ISP
 netcanes.com.br,NetCanes Fibra,ISP
+netcarrier.com,NetCarrier,ISP
 netcentersp.com.br,Netcenter,ISP
 netceu.com.br,TURBO 10 Telecom,ISP
 netcol.com.br,Netcol,ISP
 netcologne.de,NetCologne,ISP
+netcom-bw.de,NetCom BW,ISP
+netcom-r.ru,NetCom-R,ISP
+netcomafrica.com,Netcom Africa,ISP
 netcomet.com.br,Netcomet,ISP
 netcore.co.in,Netcore,Marketing
 netcup.com,netcup,Web Host
 netcup.de,netcup,Web Host
 netdesignhost.com,Netdesign Group,Web Host
 netease.com,NetEase,Email Provider
+neterra.net,Neterra,ISP
 netexpand.com.br,NetExpand,ISP
 netfinn.net,netFinn,Web Host
 netflix.com,Netflix,Entertainment
+netglobalis.net,MCL Internet (Netglobalis),ISP
 netherlandsservers.org,Netherlands Servers,Web Host
 nethinks.com,NETHINKS,MSP
 nethosting.com,NetHosting,Web Host
 netia.pl,Netia,ISP
 netifox.com,NETIFOX,ISP
+netinternet.tr,NetInternet,Web Host
 netiz.net.br,Netiz,ISP
 netlify.app,Netlify,PaaS
 netlify.com,Netlify,PaaS
@@ -3766,22 +4737,26 @@ netnam.com,NetNam,ISP
 netnam.vn,NetNam,ISP
 netnar.com.py,Netnar,ISP
 netnerd.com,NetNerd,Web Host
+netonline.net,Netonline,ISP
 netowl.jp,スターアカウント,ISP
 netpagedns.net,Netpage Internet Services,ISP
 netpeu.com.br,Netpeu,ISP
 netplus.ch,Net+,ISP
 netplus.co.in,Netplus Broadband,ISP
+netpluz.asia,Netpluz Asia,ISP
 netrax.pl,Netrax,ISP
 netregistry.net,Netregistry,Web Host
 netrevolution.com,NetRevolution,ISP
 netrixllc.com,Netrix,MSP
 netroad.ru,Mobile TeleSystems,ISP
+netsat.in,Netsat Communications,ISP
 netservice-jeziorany.pl,Netservice Jeziorany,ISP
 netskope.com,Netskope,SaaS
 netsolus.com,IP Pathways,MSP
 netstore.inf.br,Netstore Telecom,ISP
 netsuitesuiteprojectspro.com,Oracle NetSuite OpenAir,SaaS
 netsulonline.com.br,Netsul Telecom,ISP
+netsurf.bg,Net-Surf Bulgaria,ISP
 netsville.com,Netsville,Marketing
 netsystemcampos.com.br,NETSYSTEM,ISP
 netsystemtelecom.net.br,NetSystem FibraTelecom,ISP
@@ -3790,6 +4765,7 @@ nettoday.co.th,Net Today,Web Host
 nettop.com.br,NetTop,ISP
 nettriangulo.com.br,NetTriânguloTelecom,ISP
 netturbo.com.br,Net Turbo Telecom,ISP
+netuno.net,Net Uno,ISP
 netuse.de,NetUSE,MSP
 netventure.pl,Netventure,MSP
 netvigator.com,HKT,ISP
@@ -3809,6 +4785,7 @@ neubox.com,Neubox,Web Host
 neubox.net,Neubox,Web Host
 neuca.pl,NECUA Group,Healthcare
 neunet.com.ar,Neunet,ISP
+neustarsecurityservices.com,Vercara (Neustar Security Services),Email Security
 nevada.edu,Nevada System of Higher Education,Education
 new-life.com,New Life,Retail
 newfold.com,Newfold Digital,Web Host
@@ -3818,7 +4795,11 @@ newmarket.com,Newmarket,Travel
 newnet.com.br,Newnet,MSP
 newoeste.com.br,New Oeste Telecom,ISP
 newpages.com.my,NEWPAGES,Retail
+newpaltz.edu,SUNY New Paltz,Education
+newroztelecom.com,Newroz Telecom,ISP
 news-gazette.com,News-Gazette,News
+newschool.edu,The New School,Education
+newsltd.com.au,News Corp Australia,News
 newsman.com,NewsMAN,Marketing
 newsmanapp.com,NewsMAN,Marketing
 newsunseo.com,NewSunSEO,Marketing
@@ -3829,25 +4810,34 @@ nexcess.net,Nexcess,Web Host
 nexeon.com,Nexeon,IaaS
 nexg.net,KX NexG,ISP
 nexicom.net,Nexicom,ISP
+nexlinx.net.pk,Nexlinx,ISP
 nexon.com.au,Nexon Asia Pacific,MSP
 nexstar.tv,Nexstar Media,News
 nexsul.net.br,Nexsul Conectividade,ISP
 next-gen.ro,NextGen,ISP
 nexteratech.co,NexTeraTech,MSP
+nextgen.net,NextGen.Net,SaaS
 nextgentel.no,NextGenTel,ISP
+nexthop.no,Nexthop,Web Host
 nextlayer.at,Next Layer,ISP
 nextlinkinternet.com,Nextlink,ISP
+nextnet.pe,Nextnet Peru,ISP
 nextnetworks.net,NextNetworks,MSP
 nextpertise.nl,Nextpertise,ISP
 nexttelecom.net.br,Next Internet,ISP
+nforce.com,NForce Entertainment,Web Host
 nfshost.com,NearlyFreeSpeech.NET,Web Host
+ngblunetworks.nl,NGBLU Networks,ISP
 ngloba.com,Ngloba Devices,MSP
 ngpweb.com,Bonterra,Marketing
+ngren.edu.ng,NgREN Nigerian Research and Education Network,Education
 nh-serv.co.uk,Nimbus Hosting,Web Host
 nhisac.org,H-ISAC,Healthcare
 nhn-techorus.com,NHN Techorus,MSP
 nhncloud.com,NHN Cloud,IaaS
 nhs.net,NHSmail,MSP
+ni.ac.rs,University of Nis,Education
+nibtv.co.kr,Namincheon Broadcasting,ISP
 nic.ad.jp,JPNIC,Nonprofit
 nice.com,NICE CX,SaaS
 nicknetwork.com.br,NickNetwork,ISP
@@ -3858,27 +4848,36 @@ niels-stensen-kliniken.de,Marienhospital Osnabrück,Healthcare
 nifs.ac.jp,National Institute for Fusion Science,Education
 nifty.com,@nifty,Web Host
 nih.gov,National Institutes of Health,Government
+nihon-u.ac.jp,Nihon University,Education
 niigata-u.ac.jp,Niigata University,Education
+nikhef.nl,Nikhef,Science
+nikkei.co.jp,Nikkei,News
 nimsite.uk,Nimbus Hosting,Web Host
 nineweb.net,Nine Web,Web Host
 niosh.com.my,Malaysian National Institute of Occupational Safety and Health,Government
 nip.io,nip.io,SaaS
 nipbr.com,NipBr Telecom,ISP
 nir-telecom.ru,NIR-Telecom,ISP
+nissan.co.jp,Nissan,Automotive
 nist.gov,National Institute of Standards and Technology,Government
 nisz.hu,National Infocommunications Service Company,Government
 nitelusa.com,Comcast,ISP
 nititancommercial.com,Niti Tan Commercial,Industrial
+nitrado.net,Nitrado (marbis),Web Host
 niu.edu,Northern Illinois University,Education
 nixihost.com,NixiHost,Web Host
 njedge.net,Edge,Nonprofit
 njit.edu,New Jersey Institute of Technology,Education
+nkh.com.tw,New Kaohsiung Broadband,ISP
 nkn.gov.in,National Knowledge Network,Education
 nktelco.com,NKTELCO,ISP
 nktelco.net,NKTELCO,ISP
 nktele.com,NkTelecom,Web Host
+nls.kz,NLS Kazakhstan,ISP
+nmsu.edu,New Mexico State University,Education
 nmt.edu,New Mexico Tech,Education
 nmtrucking.com,TRC Solutions,Logistics
+nns.ne.jp,Nihon Network Service,ISP
 no-ip.biz,No-IP,Web Host
 no-ip.ca,No-IP,Web Host
 no-ip.co.uk,No-IP,Web Host
@@ -3887,14 +4886,18 @@ no-ip.info,No-IP,Web Host
 no-ip.net,No-IP,Web Host
 no-ip.org,No-IP,Web Host
 noaa.gov,NOAA,Government
+noanet.net,Northwest Open Access Network (NoaNet),ISP
 nobreinternet.com.br,Nobre Telecom,ISP
 nobretelecom.com.br,Nobre Telecom,ISP
 nocdirect.com,JaguarPC,Web Host
+nocix.net,Nocix,Web Host
 nocworldwifi.com.br,World Wifi,ISP
 node4.co.uk,Node4,MSP
+nodesdirect.com,Nodes Direct,Web Host
 nodosoft.com.ar,Nodosoft,ISP
 noip.me,No-IP,Web Host
 noip.us,No-IP,Web Host
+noirlab.edu,NSF NOIRLab,Science
 nokia.com,Nokia,Technology
 nolegia.net,Nolegia,Web Host
 nomaden.tv,Nomaden TV,Travel
@@ -3911,8 +4914,10 @@ norlys.dk,Norlys,ISP
 noroestenet.com,NoroesteNet,ISP
 norrnod.se,UMDAC (Umeå University),Education
 nortetelecom.net.br,Norte Telecom,ISP
+northcdatacenters.ch,NorthC Datacenters,Web Host
 northcdatacenters.com,NorthC Datacenters,Web Host
 northeastern.edu,Northeastern University,Education
+northlandcable.com,Vyve Broadband (Northland Cable),ISP
 northropgrumman.com,Northrop Grumman,Defense
 northshore.org,NorthShore University HealthSystem,Healthcare
 northwestern.edu,Northwestern University,Education
@@ -3920,9 +4925,14 @@ nos.pt,NOS,ISP
 noticiasnrt.com,Corporativo Núcleo Radio Televisión,News
 notion.com,Notion,SaaS
 notion.site,Notion,SaaS
+nour.net.sa,NourNet,ISP
+nova.edu,Nova Southeastern University,Education
 nova.gr,Nova Greece,ISP
+nova.is,Nova Iceland,ISP
+novafibratelecom.com.br,NovaFibra (Ligga),ISP
 novaredenet.com.br,NovaRedeNet,ISP
 novascotia.ca,Government of Nova Scotia,Government
+novatel.bg,Novatel Bulgaria,ISP
 novelltelecom.com.br,Novell Internet,ISP
 novis.pt,NOS,ISP
 novoserve.com,NovoServe,Web Host
@@ -3934,30 +4944,41 @@ now.sh,Vercel,PaaS
 nowasucha.pl,Urząd Gminy Nowa Sucha,Government
 nowo.pt,NOWO,ISP
 noxlink.com.br,NoxLink,ISP
+np.edu.sg,Ngee Ann Polytechnic,Education
 npcma.ru,Nizhnekamsk Enterprise,Industrial
 npl.co.uk,National Physical Laboratory,Education
+npo.nl,NPO Dutch Public Broadcasting,Government Media
 npsin.com,NP Foods Singapore,Food
+nr.no,Norsk Regnesentral,Science
 nrcki.ru,Kurchatov Institute,Government
 nrconexoes.com.br,NR Conexões,ISP
 nreca.coop,NRECA,Nonprofit
+nri-secure.co.jp,NRI SecureTechnologies,MSP
 nrk.no,NRK,Government Media
 nrtmexico.mx,Corporativo Núcleo Radio Televisión,News
+nscorp.com,Norfolk Southern,Logistics
 nsf.gov,National Science Foundation,Government
 nsighttel.com,Nsight,ISP
+nsk-kk.com,NSK,Manufacturing
 nsmailserv.com,Netcore,Marketing
 nsnparts.com,NSNParts,Defense
 nstplnet.com,Navkar Supertech,ISP
 nsupdate.info,nsupdate.info,Web Host
+nsw.gov.au,State of New South Wales,Government
 nt.gov.au,Northern Territory Government,Government
 nt.tas.gov.au,Networking Tasmania,Government
 ntc.net.np,Nepal Telecom,ISP
+ntdatacenter.net,NT Data Center,Web Host
 nte.no,NTE,ISP
 ntelecom.com.br,Vero,ISP
 ntelos.net,Lumos,ISP
+nthu.edu.tw,National Tsing Hua University,Education
 ntirety.com,Ntirety,MSP
 ntplc.co.th,National Telecom (Thailand),ISP
+nts.ch,NTS Workspace,MSP
 ntt-east.co.jp,NTT East,ISP
 ntt-me.co.jp,NTT-ME,ISP
+ntt.co.jp,NTT,ISP
 ntt.com,NTT Communications,ISP
 nttdata.com,NTT DATA,Consulting
 nttdocomo.co.jp,NTT DOCMO,ISP
@@ -3965,11 +4986,17 @@ nttdocomo.com,NTT DOCOMO,ISP
 nttglobal.net,NTT Communications,ISP
 nttpc.co.jp,NTT PC Communications,ISP
 nttsmc.com,NTT SmartConnect,ISP
+ntu.edu.sg,Nanyang Technological University,Education
 ntu.edu.tw,National Taiwan University,Education
+ntua.gr,National Technical University of Athens,Education
+nucleus.com,Nucleus AI (Fibernetics),SaaS
 nuevaamerica.ec,Nueva America,Retail
+nuoz.com,NuOz,ISP
 nuro.jp,NURO Biz,ISP
+nus.edu.sg,National University of Singapore,Education
 nusa.net.id,Nusanet,ISP
 nusanet.id,Nusanet,ISP
+nuvancehealth.org,Nuvance Health,Healthcare
 nuvera.net,Nuvera Communications,ISP
 nuveramail.net,Nuvera,Email Provider
 nvc.net,Northern Valley Communications,ISP
@@ -3985,16 +5012,22 @@ nychealthandhospitals.org,NYC Health + Hospitals,Healthcare
 nychhc.org,NYC Health + Hospitals,Healthcare
 nycm.com,NYCM Insurance,Finance
 nycu.edu.tw,National Yang Ming Chiao Tung University,Education
+nyi.net,NYI,Web Host
 nyp.org,NewYork-Presbyterian,Healthcare
+nysed.gov,New York State Education Department,Government
+nysif.com,New York State Insurance Fund,Government
 nyspta.org,New York State PTA,Nonprofit
 nyu.edu,New York University,Education
 nyx.net,Nyx.net,ISP
 o-mx.com,Omedia,Marketing
 o2.co.uk,O2 (Telefónica UK),ISP
 o2.cz,O2,ISP
+o2bs.sk,O2 Business Services Slovakia,ISP
 oakland.k12.mi.us,Oakland Schools,Education
 oakwood.org,Oakwood Healthcare,Healthcare
+oauife.edu.ng,Obafemi Awolowo University,Education
 oaxaca.gob.mx,Government of Oaxaca,Government
+obe.net,Obenet (Obehosting),ISP
 oberlausitz-kliniken.de,Oberlausitz-Kliniken,Healthcare
 oberlin.edu,Oberlin College,Education
 obird.ca,obid.ca,MSP
@@ -4003,8 +5036,12 @@ obit.ru,OBIT,ISP
 oblak.host,Oblak Host,Web Host
 obninsk.com,CentrTelecom Kaluga,ISP
 oboi1.ru,Oboi no1,Retail
+obosnett.no,OBOS Nett,ISP
 occtoplus.com.br,Occtoplus,SaaS
+oce.ne.jp,Osaki Computer Engineering,ISP
 oceanviewfunding.com,Ocean View Funding,Finance
+ociris.com,Ociris (G-Portal),Web Host
+ocmboces.org,OCM BOCES,Education
 ocn.ad.jp,NTT,ISP
 ocn.ne.jp,OCN,ISP
 ocn.net.cn,Oriental Cable Network,ISP
@@ -4013,16 +5050,25 @@ oct-net.ne.jp,Oita Cable Telecom,ISP
 octacom.ca,Octacom,MSP
 octantis.ca,Octantis,Marketing
 oderland.com,Oderland,Web Host
+odessa.tv,Sana Plus (Renome-Service),ISP
 odido.nl,Odido,ISP
+odn.ad.jp,ODN Asahi Kasei Networks,ISP
 odoo.com,Odoo,SaaS
 odu.edu,Ohio Dominican University,Education
 oecfiber.com,OEC Fiber,ISP
+oekb.at,Oesterreichische Kontrollbank,Government
+ofnl.co.uk,Open Fibre Networks,ISP
+ogaki-tv.co.jp,Ogaki Cable Television,ISP
 ogero.gov.lb,Ogero,ISP
+ohea.org,Ohio Education Association,Nonprofit
 ohio.edu,Ohio University,Education
+ohio.gov,State of Ohio,Government
 ohsu.edu,Oregon Health & Science University,Education
+oja.at,oja.at,ISP
 ojt.kz,ntustik Zharyk Transit,Industrial
 okanagan.net,Okanagan.net,Web Host
 okayama-u.ac.jp,Okayama University,Education
+okstate.edu,Oklahoma State University,Education
 okta.com,Okta,SaaS
 okvirtual.com.br,Ok Virtual,ISP
 oleane.fr,Oleane,ISP
@@ -4035,6 +5081,7 @@ ometria.com,Ometria,Marketing
 ometria.email,Ometria,Marketing
 omkc.ru,Omskie Kabelnye Seti,ISP
 omni.lt,Omnitel,ISP
+omnicare.com,Omnicare (CVS),Healthcare
 omnicity.net,Watch Communications,ISP
 omnifiber.com,Omni Fiber,ISP
 omninet.co.nz,OmniNet,ISP
@@ -4044,6 +5091,7 @@ omnistep.com,OmniStep Incorporated,ISP
 on-web.fr,Planet-Work,Web Host
 onamae.ne.jp,GMO Internet,Web Host
 onastra.fr,SES Astra,ISP
+onati.pf,Onati,ISP
 ondal.com,Ondal Medical Systems,Healthcare
 ondigitalocean.app,DigitalOcean,PaaS
 one-email.co.th,One Email,Email Provider
@@ -4053,16 +5101,22 @@ one.com,One.com,Web Host
 one.hu,One,ISP
 one.nz,One New Zealand,ISP
 one.th,One Platform,Email Provider
+onebroadband.in,One Broadband (Oneott Intertainment),ISP
 onec1.com,C1,MSP
 onecallnow.com,One Call Now,SaaS
+onecleveland.org,OneCommunity Cleveland,Nonprofit
+onecomm.bm,One Communications Bermuda,ISP
+onecomm.gy,GTT Guyana Telephone,ISP
 onedaysign.com,One Day Signs,Retail
 onenationuk.org,One Nation,Nonprofit
 onenet.net,OneNet,ISP
 oneoffice.jp,OneOffice,SaaS
+oneonta.edu,SUNY Oneonta,Education
 oneringnetworks.com,One Ring Networks,ISP
 onetechtelecom.net.br,Onetech Telecom,ISP
 oni.pt,ONI,ISP
 onice.io,IceWrap,Email Provider
+oninet.ne.jp,Okayama Network,ISP
 onitel.com.br,Onitel,ISP
 onitelecom.com.br,Oni Telecom,ISP
 online-access.com,Online Access,Marketing
@@ -4087,10 +5141,12 @@ onvif.org,Onvif,Technology
 ooma.com,Ooma,ISP
 oops.net.br,Oops Telecom,ISP
 ooredoo.com.kw,Ooredoo,ISP
+ooredoo.dz,Ooredoo Algeria,ISP
 ooredoo.om,Ooredoo,ISP
 ooredoo.qa,Ooredoo,ISP
 ooredoo.tn,Ooredoo,ISP
 opalstack.com,Opalstack,Web Host
+opcnet.hu,OPC Networks,ISP
 openair.com,Oracle NetSuite OpenAir,SaaS
 opendns.com,Cisco OpenDNS,Email Security
 openfiber.it,Open Fiber,ISP
@@ -4099,7 +5155,10 @@ opentransit.net,Orange,ISP
 openwave.ai,Openwave Messaging,Email Provider
 opnet.it,OpNet (WindTre),ISP
 oppd.com,Omaha Public Power District,Utilities
+opt.nc,OPT-NC New Caledonia,ISP
 optage.co.jp,Optage,ISP
+opticaltel.com,Fibernow (Opticaltel),ISP
+opticomm.com.au,Opticomm,ISP
 optimantra.com,OptiMantra,SaaS
 optimum.com,Optimum,ISP
 optimum.net,Optimum,ISP
@@ -4117,12 +5176,14 @@ orange-business.ru,Orange Business,ISP
 orange.be,Orange,ISP
 orange.bf,Orange,ISP
 orange.ci,Orange,ISP
+orange.cm,Orange Cameroun,ISP
 orange.co.il,Partner,ISP
 orange.com,Orange,ISP
 orange.es,Orange,ISP
 orange.fr,Orange,Email Provider
 orange.ma,Orange,ISP
 orange.md,Orange,ISP
+orange.mg,Orange Madagascar,ISP
 orange.net.il,Orange,ISP
 orange.pl,Orange,ISP
 orange.ro,Orange,ISP
@@ -4130,42 +5191,53 @@ orange.sk,Orange,ISP
 orange.tn,Orange,ISP
 orangecustomers.net,Orange,ISP
 orangehost.com,OrangeHost,Web Host
+orangemali.com,Orange Mali,ISP
 oratelecom.com.br,ORA Telecom,ISP
 orbetelecom.com.br,Orbe Telecom,ISP
 orbital.net,Orbital Net,ISP
 oregon.gov,Oregon Government,Government
 oregonstate.edu,Oregon State University,Education
 ori.net,ORI,ISP
+oricom.ca,Oricom Internet,ISP
 orionnet.ru,Orion Telecom,ISP
 oriontelekom.rs,Orion Telekom,ISP
 oristelekom.com,ORIS Telekom,ISP
 orlandodiocese.org,Diocese of Orlando,Nonprofit
 ornl.gov,Oak Ridge National Laboratory,Government
 orthodoxws.com,Orthodox Web Solutions,Web Host
+osaka-sandai.ac.jp,Osaka Sangyo University,Education
 osaka-u.ac.jp,Osaka University,Education
 osc.edu,OARnet,Education
 osconnect.com.br,OS Connect,ISP
+ose.gov.pl,OSE Polish National Education Network,Government
 oser.com,Oser Comunications Group,Marketing
 oshean.org,OSHEAN,Education
 osir.net.br,Osirnet,ISP
+oslo.kommune.no,City of Oslo,Government
+osnetpr.net,Osnet Wireless Puerto Rico,ISP
 osnova.tv,Osnova,ISP
 osogrande.net,Oso Grande Technologies,ISP
 osorio.rs.gov.br,Prefeitura Municipal de Osório,Government
 osu.edu,The Ohio State University,Education
+oswego.edu,SUNY Oswego,Education
 otago.ac.nz,University of Otago,Education
 otava.com,Otava,MSP
 ote.gr,OTE,ISP
 otelco.net,GoNetSpeed,ISP
 otenet.gr,Cosmote,ISP
 oticasmarilia.com.br,Óticas Marília,Healthcare
+otnet.co.jp,OTNet,ISP
 otsuka-shokai.co.jp,Otsuka Shokai,MSP
 ottcmail.com,Ontario & Trumansburg Telephone Companies,ISP
 ou.edu,University of Oklahoma,Education
+ourcommons.ca,Parliament of Canada House of Commons,Government
 ourinet.com.br,Ourinet,ISP
+ous.ac.jp,Okayama University of Science,Education
 outboundrelay.com,ForwardMX,SaaS
 outlook.cn,Outlook (China),Email Provider
 outlook.com,Outlook (Personal and Microsoft 365),Email Provider
 outreachratio.com,Outreach,SaaS
+outremer-telecom.fr,Outremer Telecom,ISP
 outscale.com,Outscale,IaaS
 oversight.com,Oversight,SaaS
 oversightsystems.com,Oversight,SaaS
@@ -4174,6 +5246,7 @@ ovh.fr,OVH,Web Host
 ovh.net,OVH,Web Host
 ovh.us,OVH,Web Host
 ovhcloud.com,OVH,Web Host
+ovintiv.com,Ovintiv,Industrial
 own.pm,OwnProvider,Web Host
 owncloud-dav-hamburg.de,ownCloud,SaaS
 ownip.net,Now-DNS,Web Host
@@ -4191,11 +5264,17 @@ p4net.com.br,P4NET,ISP
 p4net.net.br,P4NET Telecom,ISP
 pa.gov,Commonwealth of Pennsylvania,Government
 pa.net.py,P.A. Networks,ISP
+pacific.edu,University of the Pacific,Education
+pacific.net.th,Pacific Internet Thailand,ISP
 pacificinternet.com,Pacific Internet,ISP
 pacificored.cl,Pacifico Cable,ISP
 pacificsource.com,PacificSource,Healthcare
+packet.com,Equinix Metal (Packet Host),IaaS
 packetexchange.eu,Packet Exchange,Web Host
+packetfabric.co.jp,PacketFabric Japan,ISP
+packetfabric.com,PacketFabric,ISP
 packethub.net,PacketHub,IaaS
+pactiv.com,Novolex (Pactiv),Manufacturing
 pahsco.com.tw,Pacific Hospital Supply,Healthcare
 pair.com,Pair Networks,Web Host
 pair.net,Pair Networks,Web Host
@@ -4221,7 +5300,9 @@ papaki.gr,Papaki,Web Host
 paperworks.com,Paperworks,Retail
 paragould.com,Paragould Municipal Utilities,ISP
 paragould.net,Paragould Municipal Utilities,ISP
+paratus.africa,Paratus Telecom,ISP
 parkerinstitute.org,Parker Jewish Institute for Healthcare & Rehabilitation,Healthcare
+parlament.gv.at,Austrian Parliament,Government
 parliament.gh,Parliament of Ghana,Government
 parsleysage.net,.ParsleySage Guest House,Travel
 parsonline.com,ParsOnline,ISP
@@ -4229,76 +5310,121 @@ partnerlinks.com.my,Partner Links,Marketing
 partteam.pt,PARTTEAM & OEMKIOSKS,Manufacturing
 partteams.com,PARTTEAM & OEMKIOSKS,Manufacturing
 pasargadservices.com,Pasargad Services,Web Host
+pasenate.com,Pennsylvania Senate,Government
+pasteur.fr,Institut Pasteur,Science
+patagoniaip.cl,Patagonia IP,ISP
+pathcom.com,Pathway Communications,MSP
+patmos.tech,Patmos,Web Host
 paubox.com,Paubox,Email Security
+paulbunyan.net,Paul Bunyan Communications,ISP
+pausd.org,Palo Alto Unified School District,Education
 pavlovmedia.com,Pavlov Media,ISP
+paxio.com,Paxio,ISP
 paycom.com,Paycom,SaaS
 paycomonline.com,Paycom,SaaS
 paylodegrowth.com,Paylode,SaaS
 paylodeperk.com,Paylode,SaaS
 paypal.com,PayPal,Finance
+pbcgov.com,Palm Beach County,Government
 pbiaas.com,INOS,Web Host
+pbs.edu.pl,Politechnika Bydgoska,Education
 pca.az,PASHA Capital,Finance
 pcc.in.th,President Chemical,Manufacturing
+pccw.com,PCCW,ISP
 pccwglobal.com,PCCW Global,ISP
 pccwglobalinc.com,PCCW Global,ISP
+pch.net,Packet Clearing House,Nonprofit
 pchosp.org,Putnam County Hospital,Healthcare
 pci.com,PCI Pharma Services,Healthcare
 pcinfo.net.br,PC Info Telecom,ISP
 pciservices.com,PCI Pharma Services,Healthcare
 pcp.by,Pinsk Central Polyclinic,Healthcare
+pcsb.org,Pinellas County Schools,Education
+pcss.pl,Poznanskie Centrum Superkomputerowo-Sieciowe,Science
 pd25.com,Salesforce Marketing Cloud (Formerly Pardot),Marketing
 pdx.edu,Portland State University,Education
+peacecom.net,Scipio Technologies (Peace Communications),MSP
 peacehealth.org,PeaceHealth,Healthcare
+peakinternet.com,Peak Internet,ISP
 peaknet.net,PeakNet,Industrial
 peapod.com,Peapod,Retail
 pearcebevill.com,"Pearce, Bevill, Leesburg, Moore, P.C.",Finance
+pelephone.co.il,Pelephone,ISP
 penguinwebhosting.com,Penguin Webhosting,Web Host
+penki.lt,Penki,ISP
 pennwest.edu,Pennsylvania Western University,Education
 penteledata.net,PenTeleData,ISP
 peopleanswers.com,Infor,SaaS
+peoplescom.net,Peoples Telephone Cooperative,ISP
 peopleshost.com,PeoplesHost,Web Host
 peopleshostshared.com,PeoplesHost,Web Host
 pepitrans01.com,Netcore (Formerly Pepipost),SaaS
 pepitrans02.com,Netcore (Formerly Pepipost),SaaS
+pepperdine.edu,Pepperdine University,Education
 perception-point.io,Perception Point,Email Security
 perenso.com,Perenso,Marketing
 perfora.net,IONOS,Web Host
 performive.com,CloudFirst,Web Host
 perimeterwatch.com,PerimeterWatch,MSSP
+personal.com.py,Personal Paraguay,ISP
 peteralan.co.uk,Peter Alan,Real Estate
+petrobras.com.br,Petrobras,Industrial
 petroed.com,PetroEd,Education
+petronas.com,Petronas,Industrial
+pfalzkom.de,PFALZKOM,ISP
 pfcloud.io,pfcloud,Web Host
 pfizer.com,Pfizer,Healthcare
 pfmsys.com,Professional Flight Management (PFM),Logistics
+pfnllc.net,Peninsula Fiber Network,ISP
 pg.com,Procter & Gamble,Manufacturing
 pgcps.org,Prince George's County Public Schools,Education
 pge.com,PG&E,Utilities
+ph.net,PHNet Philippine Network Foundation,Education
+phaselayer.com,Private Layer,Web Host
+phila.gov,City of Philadelphia,Government
+philasd.org,School District of Philadelphia,Education
+phmgmt.com,PhMgmt VyprVPN,Web Host
 phoenixnap.com,phoenixNAP,Web Host
+phpoy.fi,Elmonet (PHP Oy),ISP
 phpwebhosting.com,PHPWebHosting,Web Host
 piedmonteye.com,Piedmont Eye Center,Healthcare
 piercecountywa.gov,"Pierce County, Washington",Government
 pif.co.uk,Pinnacle Freight,Logistics
 pilot-ipek.ru,Izhevsk Industrial-Economic College,Education
 pilotfiber.com,Pilot Fiber,ISP
+pima.edu,Pima Community College,Education
+pima.gov,Pima County Arizona,Government
+pindc.ru,Pindc Petersburg Internet Network,ISP
+pinellascounty.org,Pinellas County,Government
 pink.co.rs,Mink Media Group,Marketing
 pinnaclecart.com,PinnacleCart,SaaS
 pinpro.by,PinPro,ISP
+pinspb.ru,Petersburg Internet Network (Pinspb),ISP
+pioneer.co.in,Pioneer Online,ISP
 pioneer.co.th,Pioneer Transportation,Logistics
 pip.com.au,PIP Total IT Solutions,Web Host
 pipefy.com,Pipefy Inc,SaaS
+pirxnet.pl,PirxNet,ISP
 pishgaman.net,Pishgaman,ISP
+pitchile.cl,PIT Chile,ISP
+pitt.edu,University of Pittsburgh,Education
 pius-hospital.de,Pius-Hospital Oldenburg,Healthcare
 pixeledges.com,Pixel Edges Technologies,Marketing
 plala.or.jp,Plala,ISP
+planet.net,Planet Networks,ISP
 planetel.it,Planetel,ISP
 planetfiber.com.br,Planet Fiber,ISP
 planethoster.fr,PlanetHoster,Web Host
 planethoster.net,PlanetHoster,Web Host
 planety.com.br,Planety Internet,ISP
+plateautel.com,Plateau Telecommunications,ISP
 platform.sh,Upsun,PaaS
+plattsburgh.edu,SUNY Plattsburgh,Education
 play-internet.pl,Play,ISP
 play.pl,Play,ISP
 playbackmail.com,PlayBackMail,Email Provider
+playstation.com,Sony PlayStation,Entertainment
+playtech.ee,Playtech,Entertainment
 pldi.net,Pioneer Cellular,ISP
 pldt.com,PLDT,ISP
 pldt.net,PLDT,ISP
@@ -4313,6 +5439,7 @@ plus.hr,Plus Hosting,Web Host
 plus.net,plusnet,ISP
 plus.pl,Plus,ISP
 plusitma.com.br,PLUS MEGA,ISP
+plusline.net,Plus.line,Web Host
 plusnet.de,Plusnet,ISP
 plusnetfoz.com.br,Plusnet Foz,ISP
 plusserver.com,PlusServer,Web Host
@@ -4326,8 +5453,12 @@ pocketinet.com,PocketiNet,ISP
 poda.cz,PODA,ISP
 podzone.net,DynDNS,Web Host
 podzone.org,DynDNS,Web Host
+point-broadband.com,Point Broadband,ISP
 pol-online.com,Bangladesh Online,ISP
 pol.ir,ParsOnline,ISP
+polisen.se,Swedish Police,Government
+politiet.no,Norwegian Police,Government
+polk-fl.net,Polk County Public Schools,Education
 polsatbox.pl,Polsat Box,ISP
 polsl.pl,Silesian University of Technology,Education
 polyclinique-limoges.com,Polyclinique de Limoges,Healthcare
@@ -4339,21 +5470,26 @@ poneytelecom.eu,Pony Telecom,Web Host
 pontenova.com.br,Ponte Nova Online,News
 popsnet.com.br,POP's Net,ISP
 popularelectriccentre.com,Popular Electric Centre,Industrial
+populoos.es,Populoos,ISP
 porar.asia,Porar,Web Host
 porar.com,Porar Web Application,Web Host
 porkbun.com,porkbun.com,ISP
 portalcom.inf.br,Portal.com,ISP
 portative.com,Portative Technologies,ISP
 portative.net,Portative Technologies,ISP
+portlandk12.org,Portland Public Schools,Education
 poscoict.com,POSCO DX,MSP
 positive.sk,Positive,SaaS
 post.ch,Swiss Post,Logistics
 post.lu,POST Luxembourg,ISP
+posta.rs,Pošta Srbije (Serbian Post),Logistics
 postcodesoftware.co.uk,Postcode Software,SaaS
 postdanmark.dk,Post Danmark,Logistics
 postech.edu,Pohang University of Science and Technology,Education
+potsdam.edu,SUNY Potsdam,Education
 poupnet.com.br,Triunfo Fibra (Poupnet),ISP
 power1.com,PowerOne,MSP
+powergrid.in,Powergrid Teleservices India,ISP
 powerline.hk,Power Line Datacenter,IaaS
 powertech.psi.br,Power Tech Telecom,ISP
 pox.com.br,Pox Network Telecomunicações,ISP
@@ -4365,9 +5501,11 @@ pratt.lib.md.us,Enoch Pratt Free Library,Government
 prchost.com,PRC Hosting,Web Host
 precisehotels.com,Precise Hotels and Resorts,Travel
 prempub.com,Premier Publishing,Marketing
+previder.com,Previder,Web Host
 prgmr.com,Tornado VPS,Web Host
 primed-halberstadt.de,Primed Halberstadt,Healthcare
 primetel.com.cy,PrimeTel,ISP
+primetelecom.ro,Prime Telecom Romania,ISP
 primorye.ru,Rostelecom,ISP
 primus.ca,Primus,ISP
 primustel.ca,Primus,ISP
@@ -4383,17 +5521,23 @@ privatelayer.com,Private Layer,Web Host
 privatesystems.net,PrivateSystems.net,Web Host
 prnewswire.com,PR Newswire,Marketing
 pro-komp.pl,home.pl,Web Host
+pro-m.hu,Pro-M,ISP
 pro01.net,Pro01 (Toyu),Marketing
 proagentwebsites.com,ProAgent Websites,Real Estate
+probe-networks.de,Probe Networks,Web Host
 procopa.dk,Procopa IT,MSP
 prodocom.com.au,Prodocom,SaaS
 produccion.gob.ec,Ecuador Ministry of Production,Government
+proen.co.th,PROEN,Web Host
 profitserver.ru,Profitserver,Web Host
 prohosting.com,ProHosting,Web Host
 promax.media.pl,Promax,ISP
 prontomarketing.com,Pronto Marketing,Marketing
 proofhubmail.com,ProofHub,SaaS
+proofpoint.com,Proofpoint,Email Security
+propersupportmedia.com,Proper Support Media,Web Host
 prosites.com,ProSites,Web Host
+prosodie.com,Odigo,SaaS
 prospect.pl,Prospect,ISP
 proton.ch,Proton,Email Provider
 proton.me,Proton,Email Provider
@@ -4418,13 +5562,16 @@ prudential.com.sg,Prudential Singapore,Finance
 prudentpublishing.com,Prudent Publishing,Retail
 prw.net,Puerto Rico Webmasters,Web Host
 psc.edu,Pittsburgh Supercomputing Center,Education
+psdschools.org,Poudre School District,Education
 pserver.space,Profitserver,Web Host
 pskovline.ru,Pskovline,ISP
+psn.co.id,Pasifik Satelit Nusantara,ISP
 pspinc.com,Pacific Software Publishing,Web Host
 psu.edu,Penn State,Education
 psychz.net,Psychz Networks,Web Host
 ptcl.com.pk,PTCL,ISP
 ptd.net,PTD,ISP
+ptisp.com,PTisp,Web Host
 ptp.net.id,Perdana Teknologi Persada,ISP
 ptrcloud.net,GMO GlobalSign,IaaS
 ptspb.ru,Severen-Telecom,ISP
@@ -4434,6 +5581,7 @@ pubnix.net,PubNIX,Web Host
 puc-rio.br,PUC Rio,Education
 pucminas.br,PUC Minas,Education
 pucp.edu.pe,Pontificia Universidad Católica del Perú,Education
+pucv.cl,Pontificia Universidad Catolica de Valparaiso,Education
 pulkco.com,Pulk & Co,ISP
 pulse.in,Pulse Telesystems,SaaS
 pulsetv.com,Pulse TV,Retail
@@ -4441,6 +5589,7 @@ puntonet.ec,Puntonet,ISP
 purbanigroup.com,Purbani Group,Manufacturing
 purdue.edu,Purdue University,Education
 purevoltage.com,PureVoltage Hosting,Web Host
+purplecowinternet.com,Purple Cow Internet,ISP
 purtel.com,PURtel,ISP
 pusan.ac.kr,Pusan National University,Education
 pvamu.edu,Prairie View A&M University,Education
@@ -4452,12 +5601,15 @@ pythonanywhere.com,PythonAnywhere,SaaS
 pyur.com,PŸUR,ISP
 qantas.com,Qantas,Travel
 qantas.com.au,Qantas,Travel
+qbeyond.de,q.beyond,MSP
 qcell.gm,Qcell Gambia,ISP
+qcell.sl,QCell Sierra Leone,ISP
 qemailserver.com,Qualtrics,SaaS
 qf.org.qa,Qatar Foundation,Education
 qhoster.net,QHoster,Web Host
 qindiafund.com,Q India Fund,Finance
 qinetiq.com,QinetiQ,Defense
+qingcloud.com,QingCloud,IaaS
 qlix.com.br,Qlix,Web Host
 qmul.ac.uk,Queen Mary University of London,Education
 qnsal.cn,Qn-Solar,Manufacturing
@@ -4467,6 +5619,7 @@ qsoftweb.com,QSoft,Web Host
 qth.com,QTH.com,Web Host
 qti.com,Quick Technologies,Event Planning
 qtnet.co.jp,QTNet,ISP
+qtsc.com.vn,Quang Trung Software City,IaaS
 qtsdatacenters.com,QTS,IaaS
 quadax.com,Quadax,Healthcare
 quadranet.com,Quadranet,Web Host
@@ -4474,15 +5627,18 @@ qualtrics.com,Qualtrics,SaaS
 quantcom.cz,Quantcom,ISP
 quantum.net.id,Quantum Tera Network,ISP
 quattrocom.mx,QuattroCom,ISP
+queensu.ca,Queen's University,Education
 questforum.org,Telecommunications Industry Association,Industrial
 quick.com.br,Quick Internet,ISP
 quickline.ch,Quickline,ISP
+quickline.co.uk,Quickline Communications,ISP
 quickpacket.com,QuickPacket,Web Host
 quitmancountyms.org,"Quitman County, Mississippi",Government
 quotevalet.com,QuoteValet,SaaS
 quotewerks.com,QuoteWerks,SaaS
 qvidian.com,Qvidian,SaaS
 qwest.net,Quest Communications,ISP
+r-kom.de,R-KOM,ISP
 r2net.in,R2 Net,ISP
 r3zo.net,R3ZO,Web Host
 r4l.com,Register4Less,Web Host
@@ -4496,28 +5652,36 @@ rackmaze.com,Rackmaze,Web Host
 rackmaze.net,Rackmaze,Web Host
 racknation.cr,RsckNation,Web Host
 rackspace.com,Rackspace,Web Host
+racsa.co.cr,RACSA,ISP
 radarinternet.com.br,Radar Internet,ISP
 radford.edu,Radford University,Education
 radiant.net,TELUS,ISP
 radiantsolutions.net,Radient Solutions,Web Host
+radiocom.ro,Radiocom Romania,ISP
 radius-net.com,Radius-NET,ISP
+radore.com,Radore,Web Host
 radware.com,Radware,Email Security
 rafftechnologies.com,Raff Technologies,Web Host
+ragingwire.com,NTT Global Data Centers Americas (RagingWire),Web Host
+railtelindia.com,RailTel Corporation of India,ISP
 rain.co.za,Rain,ISP
 rainbowchemicals.ae,Rainbow Chemicals,Manufacturing
 rainbowisp.in,Rainbow Communications India,ISP
 rainfocus.com,RainFocus,SaaS
+rainierconnect.com,Lightcurve (Rainier Connect),ISP
 raiolanetworks.com,Raiola Networks,Web Host
 raksmart.com,RakSmart,Web Host
 rakuten.co.jp,Rakuten Mobile,ISP
 rakuten.com,Rakuten Mobile,ISP
 raleighortho.com,Raleigh Orthopaedic,Healthcare
+rally.ca,Rally Internet,ISP
 rambler.ru,Rambler,Email Provider
 rampermail.com.br,Ramper,Marketing
 ramsaysante.fr,Ramsay Santé,Healthcare
 randdcomp.com,R&D Computers,MSP
 ranksitt.net,Ranks ITT,MSP
 rapeedo.net.br,Rapeedo,ISP
+rapidscale.net,RapidScale,Web Host
 raschig.de,Raschig,Manufacturing
 ratiokontakt.de,Ratiokontakt,ISP
 raycdjr.com,Ray Chrysler Dodge Jeep RAM,Automotive
@@ -4534,6 +5698,7 @@ rcoe.us,Riverside County Office of Education,Education
 rcom.co.in,Reliance Communications,ISP
 rdp.sh,RDP.sh,SaaS
 rdsnet.ro,Digi Romania,ISP
+rdtc.ru,RDTC Novokuznetsk,ISP
 re-activno.ru,Re:activno,Web Host
 reach10.com,Reach Ten,ISP
 reachmail.com,ReachMail,Marketing
@@ -4542,13 +5707,16 @@ readnotify.com,ReadNotify,Email Provider
 readthedocs-hosted.com,Read the Docs,SaaS
 readthedocs.com,Read the Docs,SaaS
 readthedocs.io,Read the Docs,SaaS
+real-net.pro,Real-net,ISP
 realnet.kg,Realnet,ISP
 rebelnetworks.com,Rebel Networks,Web Host
+reconn.ru,Reconn,ISP
 red-7.net,Red 7 Telecomunicaciones,ISP
 redbird.net,NexGenAccess (Formerly Redbird),ISP
 redcentricplc.com,Redcentric,MSP
 redcondor.net,Red Condor,Email Security
 redcotel.bo,Cotel Ltda.,ISP
+redcross.org,American Red Cross,Nonprofit
 redeatel.com.br,Natel Telecom,ISP
 redebrasil.net.br,Rede Brasil,ISP
 redecompunet.com.br,Rede Compunet,ISP
@@ -4568,14 +5736,17 @@ redirectme.net,No-IP,Web Host
 rediris.es,RedIRIS,Education
 rednesp.br,rednesp,Education
 redtailtechnology.com,Redtail Technology,SaaS
+reed.edu,Reed College,Education
 reef-guardian.com,Reef Guardian,Education
 reevo.it,ReeVo,MSP
+reflected.net,Reflected Networks,Web Host
 reg.ru,Reg.ru,Web Host
 reg365.net,register365,Web Host
 regentbranding.co.uk,Regent Branding,Marketing
 regery.net,Regery,Web Host
 regiomed-kliniken.de,Sana Kliniken Oberfranken,Healthcare
 regionaltelecom.net.br,Regional Telecom,ISP
+regiondemurcia.es,Region de Murcia,Government
 regione.toscana.it,Regione Toscana,Government
 regionstockholm.se,Region Stockholm,Government
 register.it,Register.it,Web Host
@@ -4585,10 +5756,14 @@ registeredsite.com,Web.com,Web Host
 registrar-servers.com,Namecheap,Web Host
 regusnet.com,Regus,Real Estate
 regxa.com,Regxa Cloud,Web Host
+relaix.net,RelAix Networks,ISP
 relativity.one,RelativityOne,SaaS
+reliablehosting.com,Reliable Hosting,Web Host
+reliablesite.net,ReliableSite,Web Host
 relmax.com,Relmax,Web Host
 relmax.net,Relmax,Web Host
 relod.ru,RELOD,Retail
+relx.com,RELX,SaaS
 renal-md.com,Renal-MD,Healthcare
 renater.fr,RENATER,Education
 render.com,Render,PaaS
@@ -4600,24 +5775,35 @@ responselogix.com,Digital Air Strike,Marketing
 restena.lu,RESTENA,Education
 retarus.com,Retarus GmbH,SaaS
 retelit.it,Retelit,ISP
+retn.net,RETN,ISP
+retn.ru,RETN Russia,ISP
 reuna.cl,REUNA,Education
 reverse-mundo-r.com,R Cable y Telecomunicaciones,ISP
+rge.com,Rochester Gas and Electric,Utilities
+rh-tec.de,rh-tec,Web Host
 rhcloud.com,Red Hat OpenShift,PaaS
 rheamedical.org,Rhea Medical Center,ISP
 rhein-it.de,RHEN IT,MSP
 rhnet.is,RHnet,Education
 rhsolutions.ca,RH Solutions,Web Host
+ri.gov,State of Rhode Island,Government
 riberasaludmail.com,Ribera Salud,Healthcare
 rice.edu,Rice University,Education
+richmond.edu,University of Richmond,Education
 ridsa.com.ar,Red Intercable Digital,ISP
 rightel.ir,Rightel,ISP
 rightnowtech.com,Oracle Service Cloud,SaaS
 rightside.ru,Telecoma,ISP
+riiseeznet.ch,Rii Seez Net,ISP
 rijksoverheid.nl,Government of the Netherlands,Government
 rijkswaterstaat.nl,Rijkswaterstaat,Government
+riken.jp,RIKEN,Science
+rikkyo.ac.jp,Rikkyo University,Education
 rima-tde.net,"TELEFONICA, S.A.",ISP
+rimon.net.il,Internet Rimon,ISP
 ringsquared.com,RingSquared,ISP
 ringstad.no,Ringstad Consulting,MSP
+risd.org,Richardson Independent School District,Education
 riseinternet.com,Rise Internet,ISP
 risetelecoms.co.za,Rise Telecoms,ISP
 riskonnectclearsight.com,Riskonnect ClearSight,SaaS
@@ -4625,29 +5811,41 @@ risq.quebec,RISQ,Education
 rit.edu,Rochester Institute of Technology,Education
 ritsumei.jp,Ritsumeikan University,Education
 ritternet.com,Ritter Communications,ISP
+riu.edu.ar,ARIU Argentine University Network,Education
 rm.com,RM Education,Education
 rmc.ca,Royal Military College of Canada,Education
 rminet.com.br,RM Informática,ISP
 rmx.de,Retarus GmbH,SaaS
 rnp.br,RNP,Education
 rnu.tn,Centre de Calcul El Khawarizmi,Education
+roadrunnerwireless.net,Roadrunner Wireless,ISP
 robi.com.mk,Telekabel,ISP
+roblox.com,Roblox,Entertainment
 roche.com,Roche,Healthcare
 rochester.edu,University of Rochester,Education
+rockefeller.edu,The Rockefeller University,Education
+rockenstein.de,Rockenstein,Web Host
 rocketsoftware.com,Attachmate (Rocket Software),Technology
 rockwellcollins.com,Collins Aerospace,Defense
 rodenyc.com,RODE Advertising,Marketing
+roedu.net,RoEduNet,Education
 rogers.com,Rogers,ISP
 roguevalleyurology.com,Rogue Valley Urology,Healthcare
 rootlayer.net,RootLayer LTD.,Web Host
+ropa.de,ropa,Web Host
+rose-hulman.edu,Rose-Hulman Institute of Technology,Education
+rosnet.ru,OJSC Rosnet,ISP
 rossoxweb.it,RossoXweb,MSP
 rostelecom.com.br,ROS Telecom,ISP
 rostelecom.ru,Rostelecom,ISP
 rotundasoftware.com,Rotunda Software,MSP
 router12.net,Router12 Networks,ISP
 routit.nl,RoutIT,ISP
+rowan.edu,Rowan University,Education
+royalehosting.net,RoyaleHosting,Web Host
 rpi.edu,Rensselaer Polytechnic Institute,Education
 rpost.net,RPost,Email Security
+rptu.de,Rheinland-Pfalzische Technische Universitat,Education
 rpworld.co.in,RP World Telecom,ISP
 rqnet.com.br,RqNet,ISP
 rrinternettelecom.com.br,RR Internet Telecom,ISP
@@ -4669,8 +5867,11 @@ ruhr-uni-bochum.de,Ruhr University Bochum,Education
 runbox.com,Runbox,Email Provider
 runhosting.com,RunHosting,Web Host
 ruralroadshealthservices.ca,Alexandra Hospital,Healthcare
+ruraltelephone.com,Nex-Tech (Rural Telephone Service),ISP
+rush.edu,Rush University,Education
 rusonyx.ru,Rysonyx Cloud,Web Host
 rutgers.edu,Rutgers University,Education
+ruukki.com,Ruukki SSAB,Manufacturing
 rvurology.com,Rogue Valley Urology,Healthcare
 rwas.co.uk,Royal Welsh Agricultural Society,Agriculture
 rwth-aachen.de,RWTH Aachen University,Education
@@ -4687,6 +5888,7 @@ sabyr.com,Sabyr Consulting,MSP
 sabyrconsulting.com,Sabyr Consulting,MSP
 saccounty.gov,Sacramento County,Government
 saccounty.net,Sacramento County,Government
+sacredheart.edu,Sacred Heart University,Education
 safari-productions.com,Safari Productions,Event Planning
 safaricom.co.ke,Safaricom,ISP
 safaricombusiness.co.ke,Safaricom,ISP
@@ -4694,58 +5896,85 @@ safeport.com,Safeport Network Services,Web Host
 safescreening.co.uk,The Access Group,SaaS
 safeway.com,Safeway,Retail
 safewebservices.com,NMI,SaaS
+sagenet.com,SageNet,MSP
+sahara.com,Sahara Net,ISP
 sailthru.com,Sailthru,Marketing
 saimanet.kg,Saima Telecom,ISP
 saimatelecom.kg,Saima Telecom,ISP
 saimiya.com,Saiseikai Utsunomiya Hospital,Healthcare
+saint-gobain.com,Saint-Gobain,Manufacturing
 sait.ca,Southern Alberta Institute of Technology,Education
 sakura.ad.jp,Sakura Internet,Web Host
 sakura.ne.jp,SAKURA Internet,ISP
 salam.sa,Salam,ISP
 salary.com,Salary.com,SaaS
 salesforce.com,Salesforce,SaaS
+salkeiz.k12.or.us,Salem-Keizer Public Schools,Education
 salom.uz,Salom Telecom,ISP
+salomon.com,Salomon,Retail
 salonlofts.com,Salon Lofts,Retail
 salt.ch,Salt,ISP
 saltechsystems.com,Saltech Systems,MSP
+salvador.ba.gov.br,City of Salvador (Bahia),Government
 salzburg-ag.at,Salzburg AG,Utilities
 samanage.com,SolarWinds Service Desk,SaaS
 samaralan.ru,SamaraLan,ISP
+samart.co.th,Samart Infonet,ISP
 samil-pharm.com,Samil,Healthcare
 samsa.com,SAMSA,MSP
 samsung.com,Samsung,Technology
 samsungsds.com,Samsung SDS,Technology
 samtel.ru,Samtelecom,ISP
 sana.de,Sana Kliniken Oberfranken,Healthcare
+sanantonio.gov,City of San Antonio,Government
+sandi.net,San Diego Unified School District,Education
 sandia.gov,Sandia National Laboratories,Government
 sandrix.com,Sandrix Technologies,MSP
 sanet.sk,SANET,Education
 sangchaimeter.com,Sangchai Meter,Industrial
+sangoma.com,Sangoma,SaaS
+sanjuan.edu,San Juan Unified School District,Education
 sanofi.fr,Sanofi,Healthcare
+santa-barbara.ca.us,Santa Barbara County,Government
+santandergto.com,Santander Global Technology and Operations,Finance
 santehealth.net,Sante Health System,Healthcare
 sanwa.co.jp,Sanwa Supply,Retail
 sanwakai.jp,Sanwakai Hospital,Healthcare
+saonlinebd.com,Online Computer Library Center / OCLC South Asia,Nonprofit
 sap.com,SAP,Technology
 saplbd.com,Summit Alliance Port,Logistics
 sapmed.ac.jp,Sapporo Medical University,Healthcare
 sapo.pt,SAPO,Email Provider
 saremail.com,SAREnet,ISP
 sarenet.es,Sarenet,ISP
+sargentlundy.com,Sargent and Lundy,Consulting
 sarkor.uz,Sarkor,ISP
+sas.com,SAS Institute,SaaS
+sasag.ch,sasag Kabelkommunikation,ISP
+saskatoon.ca,City of Saskatoon,Government
 sasktel.com,SaskTel,ISP
+satel.net.ua,Satellite (Setilight),ISP
+satfilm.pl,Sat Film,ISP
 satis-tl.ru,Satis,ISP
 satnet.net,Xtrim,ISP
 satorilabs.com,NextGen Healthcare,Healthcare
 sattrakt.com,Sat-Trakt,ISP
+saudi.net.sa,Saudi Telecom Company,ISP
 saunalahti.fi,Elisa,ISP
 savecom.net.tw,SaveCom,ISP
 saveonhosting.com,Save On Hosting,Web Host
 savezone.co.kr,SaveZone,Retail
 savps.ru,SmartApe,Web Host
 sawaisp.sy,Sawa,ISP
+sbac.edu,School Board of Alachua County Florida,Education
 sbaedge.com,SBA Edge,IaaS
 sbb.rs,SBB,ISP
+sbceo.org,Santa Barbara County Education Office,Education
 sbcglobal.net,AT&T,ISP
+sbcss.net,San Bernardino County Superintendent of Schools,Education
+sbin.bj,Celtiis (SBIN Benin),ISP
+sbn.co.th,Super Broadband Network,ISP
+sc.edu,University of South Carolina,Education
 sc.gov,South Carolina Government,Government
 scaladatacenters.com,Scala Data Centers,Web Host
 scalaxy.com,Scalaxy,IaaS
@@ -4753,31 +5982,49 @@ scaledsystems.com,SimpleNet,Web Host
 scaleway.com,Scaleway,Web Host
 scania.com,Scania,Manufacturing
 scatair.com,Scatair,Manufacturing
+scayle.es,Centro de Supercomputacion de Castilla y Leon,Science
+scbroadband.com,SC Broadband,ISP
 sccoast.net,Horry Telephone Cooperative,ISP
 sccoe.org,Santa Clara County Office of Education,Education
 sce.com,Southern California Edison,Utilities
 sch.gr,Greek School Network,Education
+schaeffler.de,Schaeffler,Manufacturing
+schibsted.com,Schibsted Media,News
 schibsted.no,Schibsted Media,News
 schmc.ac.kr,Soon Chun Hyang University Medical Center,Healthcare
+schneider.com,Schneider National,Logistics
+schwab.com,Charles Schwab,Finance
 scinternet.net,South Central Communications,ISP
+scip.es,SCIP Soluciones Corporativas IP,ISP
 scis.gov.az,Special Communication Service of Azerbaijan,Government
+scjohnson.com,S.C. Johnson,Manufacturing
+scn-net.ne.jp,Shonan Cable Network,ISP
 scnet.com.br,SCNet,ISP
 scorm.com,SCORM,SaaS
+scranton.edu,University of Scranton,Education
+screamer.co.za,Screamer Telecoms,ISP
 scrio.com.br,S.C. RIO Telecom,ISP
 scrtc.com,South Central Rural Telecommunications Cooperative,ISP
+scrtc.net,South Central Rural Telecommunications Cooperative,ISP
+scs.co.kr,Seokyung Cable Television,ISP
+scsk.jp,SCSK,MSP
 sctv.com.vn,SCTV,ISP
 scu.edu,Santa Clara University,Education
 scw.cloud,Scaleway,IaaS
 sdldelivery.com,Specialty Delivery & Logistics,Logistics
 sdncommunications.com,SDN Communications,ISP
 sdsc.edu,San Diego Supercomputer Center,Education
+sdsmt.edu,South Dakota Mines,Education
 sdstate.edu,South Dakota State University,Education
 seacom.co.za,SEACOM,MSP
 seacom.com,SEACOM,ISP
 sealbond.co.jp,Nippon Sealbond,Manufacturing
 seanet.com.br,Seanet,ISP
+seaside.ns.ca,Seaside Communications,ISP
 seaspraymta1.com,Cox Communications,ISP
 seaspraymta2.com,Cox Communications,ISP
+seattlechildrens.org,Seattle Children's Hospital,Healthcare
+seciu.edu.uy,SeCIU Uruguay,Education
 secomtrust.net,SECOM Trust Systems,MSP
 sectormail.net,Sectorlink,Web Host
 secure-mailgate.com,Secure Mailgate,Email Provider
@@ -4792,16 +6039,21 @@ securemailserver.ca,securemailserver.ca,Email Provider
 securemx.jp,IIJ SecureMX,Email Security
 securence.com,Securence,Email Security
 secureserver.net,GoDaddy,Web Host
+securian.com,Securian Financial,Finance
 security-mail.net,Secuserve,Email Security
 securitymetrics.com,SecurityMetrics,MSSP
 securitynet.cz,SecurityNet.cz,ISP
+sedmultitel.it,SED Multitel,ISP
 seed.net.tw,Seednet,ISP
 seedshosting.jp,Seeds Hosting,Web Host
 seeweb.it,Seeweb,IaaS
+segasammy.co.jp,Sega Sammy,Entertainment
 segra.com,Segra,ISP
+seinan-gu.ac.jp,Seinan Gakuin University,Education
 sejongtelecom.net,Sejong Telecom,ISP
 selectel.com,Selectel,Web Host
 selectel.ru,Selectel,Web Host
+selenebs.it,A2A Smart City,Utilities
 selfip.com,DynDNS,Web Host
 selfip.net,DynDNS,Web Host
 selfip.org,DynDNS,Web Host
@@ -4809,10 +6061,12 @@ sellfy.com,Sellfy,SaaS
 sellfy.store,Sellfy,SaaS
 selligent.com,Selligent,Marketing
 selnet.az,SelNet,ISP
+selu.edu,Southeastern Louisiana University,Education
 selulargroup.com,Selular,SaaS
 semfronteiras.net.br,Sem Fronteiras,ISP
 sempre.tec.br,Sempre Internet,ISP
 sempreinternet.com.br,Sempre Telecomunicacoes,ISP
+senate.gov,US Senate,Government
 sencinet.com,Sencinet,ISP
 sendcloud.io,Sebdcloud,SaaS
 sendcloud.org,Aurora SendCloud,SaaS
@@ -4844,11 +6098,15 @@ servebolt.com,Servebolt,Web Host
 servebyte.com,Servebyte,Web Host
 servehttp.com,No-IP,Web Host
 serveminecraft.net,No-IP,Web Host
+server24.eu,Server24,Web Host
 servercentral.net,Summit,Web Host
+servercore.com,Servercore,IaaS
 serverdata.net,GoDaddy,Web Host
+serverel.com,Serverel,Web Host
 serverhost.net,Server Host,Web Host
 serverhs.org,WebHS,Web Host
 serverhub.com,ServerHub,Web Host
+serverius.net,Kolo Data Centers (Serverius),Web Host
 servermania.com,ServerMania,Web Host
 servername.us,Rad Web Hosting,Web Host
 serverneubox.com.mx,Neubox,Web Host
@@ -4878,13 +6136,18 @@ sevstar.net,Lancom,ISP
 sevtelecom.ru,Sevastopol Telecom,ISP
 sewan.fr,Sewan,ISP
 sezampro.rs,Orion Telekom,ISP
+sf.gov,City and County of San Francisco,Government
 sfasu.edu,Stephen F. Austin State University,Education
 sfr.fr,SFR,ISP
 sfr.net,SFR,ISP
 sfr.re,SFR,ISP
 sfu.ca,Simon Fraser University,Education
+sfusd.edu,San Francisco Unified School District,Education
 sfwmd.gov,South Florida Water Management District,Government
+sh.cz,SH.cz,Web Host
 sh27.com.br,SunHost,Web Host
+shabakah.com.sa,Shabakah Net,ISP
+shahrad.net,Sefroyek Pardaz,ISP
 shalomnet.com.br,Shalomnet,ISP
 shamrog.com,Shamrog,Web Host
 share-international.us,Share International USA,Nonprofit
@@ -4897,6 +6160,7 @@ shaw.ca,Shaw,ISP
 sheffieldpharma.com,Sheffield Pharmaceuticals,Healthcare
 shell.com,Shell,Industrial
 shentel.com,Shentel,ISP
+sheridancollege.ca,Sheridan College,Education
 sherwin-williams.com,Sherwin-Williams,Retail
 sherwin.com,Sherwin-Williams,Retail
 shield.security,Mailprotector,Email Security
@@ -4904,10 +6168,14 @@ shift4shop.com,Shift4Shop,SaaS
 shinbiro.com,Shinbiro,ISP
 shinpoly.co.jp,Shin-Etsu Polymer,Industrial
 ship.edu,Shippensburg University,Education
+shizuoka.ac.jp,Shizuoka University,Education
 shizuokaseiki.com,Shizuoka Seiki,Industrial
 shmc.jp,Sainokuni Higashiomiya Medical Center,Healthcare
 shoalhaven.net.au,Shoalhaven Internet Services,ISP
+shockhosting.com,Shock Hosting,Web Host
 shockmedia.nl,Shock Media,Web Host
+shomepower.com,Sho-Me Technologies,ISP
+shopee.com,Shopee,Retail
 shopify.com,Shopify,SaaS
 shoplocalpharmacy.com,Cardinal Health,Healthcare
 shopware.com,Shopware,SaaS
@@ -4915,12 +6183,16 @@ shopware.shop,Shopware,SaaS
 shopware.store,Shopware,SaaS
 showakvc.co.jp,"Showa Kasei Kogyo Co., Ltd.",Industrial
 showpad.com,Showpad,Marketing
+shsu.edu,Sam Houston State University,Education
 shtorm.com,Shtorm,ISP
 shtorm.net,Shtorm,ISP
+shudo-u.ac.jp,Hiroshima Shudo University,Education
 shugiin.go.jp,House of Representatives of Japan,Government
 shyamgroup.org,Shyam Group,Conglomerate
 si.edu,Smithsonian Institution,Education
 siac.com,SIAC,Finance
+sibset-team.ru,Sibirskie Seti,ISP
+sibset.ru,Sibirskie Seti,ISP
 sibyl.com,Sibl Design,MSP
 sickkids.ca,The Hospital for Sick Children,Healthcare
 siconect.com.br,Siconect,ISP
@@ -4928,6 +6200,7 @@ siemens.com,Siemens,Industrial
 sierratel.com,Sierra Tel,ISP
 sifycorp.com,Sify,ISP
 sifytechnologies.com,Sify,ISP
+sig.com,Susquehanna International Group,Finance
 signal.no,Signal,ISP
 signalhire.com,SignalHire,SaaS
 signet.nl,Signet,ISP
@@ -4941,6 +6214,8 @@ silicanetworks.com,Silica Networks,ISP
 silknet.com,Silknet,ISP
 silpc.fr,SILPC,Healthcare
 silversky.com,Silversky,Email Security
+silverstar.com,Silver Star Communications,ISP
+simbanet.net,Simbanet Tanzania,ISP
 simcentric.com,Simcentric,Web Host
 simplesite.com,One.com,Web Host
 simplesite.com.br,One.com,Web Host
@@ -4949,7 +6224,9 @@ simplesite.pl,One.com,Web Host
 simplystamps.com,Simply Stamps,Retail
 simplytransit.net,Simply Transit,ISP
 simpro.com.br,Simpro,Healthcare
+simtv.com.br,SIM TV,ISP
 simus.uz,Simus,ISP
+sin.net.cn,Shanghai Information Network,ISP
 sina.com.cn,Sina,Email Provider
 sinal.dk,Norlys,ISP
 sinaldoceu.com.br,Sinal do Céu,ISP
@@ -4963,26 +6240,39 @@ singtel.com,Singtel,ISP
 sinica.edu.tw,Academia Sinica,Education
 sinnet.com.cn,Sinnet,Web Host
 siol.net,Telekom Slovenije,ISP
+sion.com,Sion Argentina,ISP
+sipartech.com,Sipartech,ISP
 siriustelecom.uz,Sirius Telecom,ISP
+sita.aero,SITA,SaaS
 sita.co.za,SITA,Government
 site.rb-hosting.io,Raidboxes,Web Host
 siteground.com,SiteGround,Web Host
 sitehost.co.nz,SiteHost,Web Host
 sitehost.nz,SiteHost,Web Host
+sitelbra.com.br,Sitelbra,ISP
 siteprotect.com,SiteMail,Email Provider
 sitios.win,Sitios Win,Web Host
+sitsa.com.ar,SITSA Telecomunicaciones,ISP
 sitsanetworks.net,SiTSA,ISP
+siu.edu,Southern Illinois University Carbondale,Education
+siue.edu,Southern Illinois University Edwardsville,Education
 sixinternet.com.br,Six Internet,ISP
+sjcoe.org,San Joaquin County Office of Education,Education
+sjfc.edu,St. John Fisher University,Education
 sjnettelecom.com.br,SJNet Telecom,ISP
+sjofartsverket.se,Swedish Maritime Administration,Government
 sjtransindo.com,Sumatera Jaya Transindo,Logistics
 sju.edu,Saint Joseph's University,Education
 sk.com,SK Group,Conglomerate
 skadden.com,Skadden,Legal
 skane.se,Region Skane,Government
+skanska.se,Skanska,Construction
 skatteverket.se,Swedish Tax Agency,Government
 skbroadband.com,SK Broadband,ISP
 skclube.com.br,SK Clube de Tiro,Sports
+skf.com,SKF,Manufacturing
 ski.net.id,PT Sumber Koneksi Indonesia,ISP
+skidmore.edu,Skidmore College,Education
 skku.edu,SungKyunKwan University,Education
 sknt.ru,Skynet,ISP
 sktelecom.com,SK Telecom,ISP
@@ -4992,12 +6282,15 @@ skybroadband.com,Sky,ISP
 skydsl.eu,skyDSL,ISP
 skydsl.it,skyDSL,ISP
 skymail.com.br,Skymail,Email Provider
+skymesh.net.au,SkyMesh,ISP
 skynet.kg,Skynet Telecom,ISP
 skynet.ru,Skynet,ISP
 skypoint.com,SkyPoint Communications,ISP
 skysdigital.net,SkyDigital,ISP
+skytv.co.nz,Sky NZ,Entertainment
 sl-reverse.com,IBM Cloud,PaaS
 slb.com,Schlumberger,Industrial
+slcc.edu,Salt Lake Community College,Education
 slgnt.eu,Selligent,Marketing
 slgnt.us,Selligent,Marketing
 slic.com,SLIC Network Solutions,ISP
@@ -5005,12 +6298,15 @@ slicfiber.com,SLIC Network Solutions,ISP
 slovanet.net,Slovanet,ISP
 slovanet.sk,Slovanet,ISP
 slt.lk,SLT,ISP
+slu.edu,Saint Louis University,Education
 slv.vic.gov.au,State Library of Victoria,Government
 smart.com.ph,Smart Communications,ISP
 smartape.ru,Smart Ape LLC,Web Host
 smartcitytelecom.com,MPInet,ISP
+smartcomtelephone.com,SmartCom,ISP
 smartdraw.com,SmartDraw,SaaS
 smartdrawapps1.com,SmartDraw,SaaS
+smartfren.com,Smartfren,ISP
 smarthost.pl,Smarthost,Web Host
 smartinternet.com.br,Smart Internet,ISP
 smartjobboard.com,Smartjobboard,SaaS
@@ -5024,7 +6320,9 @@ smcm.edu,St. Mary's College of Maryland,Education
 smile.com.bd,DBCOM Online,ISP
 smile.com.ng,Smile,ISP
 smileserv.com,Smileserv,Web Host
+smith.edu,Smith College,Education
 smithbucklin.com,Smithbucklin,Consulting
+smithville.com,Smithville Fiber,ISP
 smsmasivos.com.ar,SMS Masivos,SaaS
 smtp.com,SMTP.com,SaaS
 smtp.cz,Active24,Web Host
@@ -5033,6 +6331,7 @@ smtp2go.com,SMTP2GO,SaaS
 smu.edu,Southern Methodist University,Education
 snapengage.com,SnapEngage,SaaS
 snapfiles.com,SnapFiles,Technology
+snc.edu,St. Norbert College,Education
 sncc.co.kr,SNC Korea,Manufacturing
 snet.com,SNET,ISP
 snowflake.app,Snowflake,SaaS
@@ -5054,28 +6353,35 @@ softether.jp,SoftEther,Technology
 softex.cz,Softex NCP,Retail
 softnet.si,SoftNET,ISP
 softvideo.ru,СОФТВИДЕО,ISP
+sogang.ac.kr,Sogang University,Education
 sogetel.com,Sogetel,ISP
 sogomail.eu,Alinto,Email Provider
+sohonet.co.uk,Sohonet,SaaS
 soipl.co.in,Shree Omkar Infocom,ISP
 sojitz.com,Sojitz,Conglomerate
+soka.ac.jp,Soka University,Education
 sol.com.py,Sol Internet,ISP
 sola.uz,Sola,ISP
 solarwinds.com,SolarWinds Service Desk,SaaS
 solcon.nl,Solcon,ISP
 solentnewsletters.uk,Solent Newsletters,Marketing
 solfibraotica.com.br,Sol Internet Fibra Óptica,ISP
+soliton.co.jp,Soliton Systems,SaaS
 solnet.ch,SolNet,ISP
+soltia.es,Soltia,Web Host
 solutions.com.sa,STC,ISP
 somelec.mr,SOMELEC,Industrial
 somyatrans.com,Somya Translators,Consulting
 sonatel.com,Sonatel,ISP
 sonatel.sn,Sonatel,ISP
+sondercloud.com,SonderCloud,Web Host
 sonic.com,Sonic,ISP
 sonic.net,Sonic,ISP
 sonichealthcareusa.com,Sonic Healthcare USA,Healthcare
 sonicwall.com,SonicWall,Email Security
 sonygs.co.jp,Sony Global Solutions,MSP
 sonynetwork.co.jp,So-net,ISP
+soon.com.ar,Red Intercable Digital,ISP
 sooner.com,Sooner Technology,ISP
 sophos.com,Sophos,Email Security
 sorbonne-universite.fr,Sorbonne Université,Education
@@ -5083,12 +6389,15 @@ sosnc.gov,North Carolina Secretary of State,Government
 sougo-group.jp,Camcom Group,SaaS
 soui9.com.br,i9 Telecom,ISP
 soumaster.com.br,Master Internet,ISP
+southern-comms.co.uk,SCG (Southern Communications),ISP
 southernco.com,Southern Company,Utilities
 southerncompany.com,Southern Company,Utilities
 southlandind.com,Southland Industries,Construction
+southslope.com,South Slope Communications,ISP
 souuni.com,Uni Telecom,ISP
 soverin.com,Soverin,Email Provider
 soverin.net,Soverin,Email Provider
+sp.edu.sg,Singapore Polytechnic,Education
 sp2-brevo.net,Brevo (Sendinblue),Marketing
 space.net,SpaceNet,MSP
 spaceship.com,Spaceship,Web Host
@@ -5103,7 +6412,9 @@ sparklight.com,Sparklight,ISP
 sparklight.net,Sparklight,ISP
 sparkmail.jp,U-netSURF,ISP
 sparkpostmail.com,Bird (Formerly SparkPost),Marketing
+sparq.com.au,Sparq (Energex),Utilities
 sparqnet.net,Sparqnet,ISP
+spartanhost.org,Spartan Host,Web Host
 spb.ru,Smart Telecom,ISP
 spcmail.jp,SPC Mail S.T.,Email Provider
 spd-mgts.ru,MGTS,ISP
@@ -5113,6 +6424,8 @@ spectranet.com.ng,Spectranet,ISP
 spectranet.in,Spectra,ISP
 spectrum.com,Spectrum,ISP
 spectrum.net,Charter,ISP
+spectrumhealth.org,Corewell Health (Spectrum Health),Healthcare
+speedcast.com,Speedcast,ISP
 speeddns.net.br,Speed Planet Telecomunicações,ISP
 speedmax.inf.br,SpeedMax,ISP
 speednet.id,Juragan Wifi Indonesia,ISP
@@ -5131,6 +6444,7 @@ spherion-southbend.com,Spherion,Staffing
 sphostserver.com,Server Plan,Web Host
 spiecom.com,SPIE ICS,MSP
 spinnakernet.info,Spinnaker,ISP
+spintel.net.au,SpinTel,ISP
 spintheweb.com,Spin The Web,Web Host
 spitfire.co.uk,Spitfire,ISP
 spitzer.org,Spitzer Autoworld,Automotive
@@ -5141,23 +6455,32 @@ spok.com,Spok,Healthcare
 spotler.com,Spotler,Marketing
 springernature.com,Springer Nature,Education
 springfield.ma.us,Springfield Public Schools,Education
+sprint-bg.net,Sprint Bulgaria,ISP
 sprint-inet.ru,SPRINTInet (Спринт-инет),ISP
 sprintinet.ru,SPRINTInet,ISP
+sprious.com,Sprious,Web Host
+sps.net.sa,Gulf Computer Services,ISP
 spt.vn,Saigon Postel,ISP
+sptel.com,SPTel,ISP
 square7.ch,bplaced,Web Host
 square7.de,bplaced,Web Host
 square7.net,bplaced,Web Host
+srgssr.ch,Schweizerische Radio- und Fernsehgesellschaft,Government Media
 srgtelecom.com.br,SRG Telecom,ISP
 sri.com,SRI International,Education
+srpnet.com,Salt River Project,Utilities
+srt.com,SRT Communications,ISP
 srvape.com,Smart Ape LLC,Web Host
 ssc-spc.gc.ca,Shared Services Canada,Government
 ssdcloudindia.net,E2E Networks,Web Host
+sslmda.com,Maxar Space (Space Systems Loral),Defense
 ssmhealth.com,SSM Health,Healthcare
 ssnettelecom.net.br,SSNET Telecom,ISP
 sst2u.com,SST2U,Education
 ssuv.uz,"Samarkand Institute of Veterinary Medicine, Animal Husbandry and Biotechnology",Education
 st.nl,Schiphol Telematics,MSP
 stabletransit.com,Rackspace,Web Host
+stackit.de,STACKIT (Schwarz),IaaS
 stackmail.com,20i,Web Host
 stadtwerke-neumuenster.de,SWN Stadtwerke Neumünster,Utilities
 stalliongroup.com,Stallion Group,Conglomerate
@@ -5182,6 +6505,7 @@ starnetweb.com.br,Starnet,ISP
 starnova.com,Starnova,Web Host
 starry.com,Starry,ISP
 start.ca,Start Communications,ISP
+starvision.com,StarVision,ISP
 state.ak.us,Alaska Government,Government
 state.al.us,The State of Alabama,Government
 state.az.us,Arizona Government,Government
@@ -5190,29 +6514,40 @@ state.gov,U.S. Department of State,Government
 state.ky.us,Kentucky Government,Government
 state.lib.la.us,State Library of Louisiana,Government
 state.ma.us,The State of Massachusetts,Government
+state.md.us,State of Maryland,Government
 state.mn.us,Minnesota Government,Government
 state.ms.us,The State of Missouri,Government
+state.nm.us,State of New Mexico,Government
+state.nv.us,State of Nevada,Government
 state.or.us,The State of Oregon,Government
 state.sd.us,South Dakota Government,Government
 state.tn.us,Tennessee Government,Government
 station030.com,123eHost,Web Host
 staywellhealth.org,StayWell Health Center,Healthcare
+stbonifacehospital.ca,St. Boniface Hospital,Healthcare
 stc.com.bh,STC,ISP
 stc.com.kw,STC,ISP
 stc.com.sa,STC,ISP
 stcable.net,ST Cable,ISP
 stellantis.com,Stellantis,Automotive
 stellarllc.net,Gardonville Cooperative Telephone Association,ISP
+stelogy.com,Stelogy (VoIP Telecom),ISP
 stemconnect.net,Stem Connect,MSP
 stertec.co.jp,KUNIMORI-STAR Group,MSP
 stetnet.com.br,webby agora é alares,ISP
+stevens.edu,Stevens Institute of Technology,Education
 stewarthowe.com,Newfold Digital,Web Host
+stfx.ca,St. Francis Xavier University,Education
 sti.net,Sierra Tel,ISP
 stibo.com,Stibo,SaaS
 stjansdal.nl,Hospital St Jansdal,Healthcare
 stjohns.edu,St. John's University,Education
 stjude.org,St. Jude Children's Research Hospital,Healthcare
+stlawu.edu,St. Lawrence University,Education
+stnc.cn,Shanghai Science and Technology Network,ISP
 stnet.co.jp,STNet,ISP
+stockholmsstadsnat.se,Bredband2 Stockholms Stadsnat,ISP
+stockton.edu,Stockton University,Education
 stokes.nc.us,"Stokes County, North Carolina",Government
 stomabags.com,Stomabags.com,Healthcare
 stonybrook.edu,Stonybrook University,Education
@@ -5220,6 +6555,7 @@ storesonlinepro.com,StoresOnline,SaaS
 stova.io,Stova,SaaS
 stpi.in,STPI,Government
 stranzit.ru,Связьтранзит (Stranzit),ISP
+stratanetworks.com,Strata Networks,ISP
 strategictreasurer.com,Strategic Treasurer,Finance
 strato.de,STRATO,Web Host
 stratoserver.net,STRATO,Web Host
@@ -5229,6 +6565,8 @@ streamlit.io,Snowflake,SaaS
 streamlitapp.com,Snowflake,SaaS
 streamnet.co.uk,Streamline Solutions,MSP
 streamsend.com,Campaigner,Marketing
+stsci.edu,Space Telescope Science Institute,Science
+stsnet.ro,Romanian Special Telecommunications Service,Government
 stu.edu.gh,Sunyani Technical University,Education
 studio4web.com,Studio4Web,Web Host
 suanettelecom.com.br,Suanet Telecom,ISP
@@ -5243,12 +6581,18 @@ sumicity.net.br,Giga+ Fibra,ISP
 summit-broadband.com,Summit Broadband,ISP
 summithealthcare.net,Summit Healthcare,Healthcare
 summithq.com,Summit,Web Host
+sumofiber.com,Sumo Fiber,ISP
 sunet.se,SUNET,Education
+sunfield.ne.jp,Sun Field Internet,ISP
 sungardas.com,11:11 Systems,MSP
+sunnybrook.ca,Sunnybrook Health Sciences Centre,Healthcare
 sunrise.ch,Sunrise,ISP
+sunucun.com.tr,Sunucun,Web Host
 sunway.com.br,Sunway,ISP
 suny.edu,State University of New York,Education
+sunyempire.edu,SUNY Empire State University,Education
 sunypoly.edu,SUNY Polytechnic Institute,Education
+suomicom.fi,SuomiCom,ISP
 supabase.co,Supabase,PaaS
 supabase.com,Supabase,PaaS
 supabase.in,Supabase,PaaS
@@ -5262,6 +6606,7 @@ supereffort.com,Super Effort Technology,Technology
 superhosting.bg,SuperHosting.BG,Web Host
 superloop.au,Superloop,ISP
 superloop.com,Superloop,ISP
+supermedia.pl,Supermedia Polska,ISP
 supernet.com.bo,Supernet,ISP
 supernetes.tv.br,Supernet,ISP
 supernovabih.ba,Supernova,ISP
@@ -5278,14 +6623,21 @@ surf.nl,SURF,Education
 surfairwireless.com,Surf Internet,ISP
 surfer.at,T-Mobile,ISP
 surfinternet.com,Surf Internet,ISP
+surry.net,Surry Communications,ISP
 sverigesradio.se,Sveriges Radio,News
 svn-repos.de,LCube,Web Host
 swan.sk,SWAN,ISP
+swarthmore.edu,Swarthmore College,Education
+swat.coop,Southwest Arkansas Telephone,ISP
 swcp.com,Southwest Cyberport,ISP
 sweb.ru,SpaceWeb,Web Host
 swedbank.se,Swedbank,Finance
+sweet.tv,OTT Ukraine,Entertainment
+swgfl.org.uk,SWGfL South West Grid for Learning,Education
+swiatlowodem.pl,Blisko (Biznes Swiatlowodem),ISP
 swiftng.com,Swift Networks,ISP
 swiftslots.com,SwiftSlots,Web Host
+swinburne.edu.au,Swinburne University of Technology,Education
 swishmail.com,Swishmail,MSP
 swisscenter.com,SwissCenter,Web Host
 swisscom.ch,Swisscom,ISP
@@ -5300,14 +6652,17 @@ sycwin.com,Sycwin Coating & Wires,Manufacturing
 syd.com.co,SyD Colombia,Healthcare
 sydney.edu.au,University of Sydney,Education
 symbio.global,Symbio,ISP
+symphony.net.th,Symphony Communication,ISP
 syn-alias.com,Synacor,SaaS
 syn.is,Sýn,ISP
 synapse.jp,Synapse,ISP
 synapse.ne.jp,Synapse,ISP
+synapse.net.ua,Synapse Network,ISP
 synccentric.com,Synccentric,SaaS
 synchronoss.net,Synchronoss,SaaS
 syncontel.net.br,Syncontel Telecomunicações,ISP
 synergywholesale.com,Synergy Wholesale,Web Host
+synlinq.de,Synlinq,Web Host
 synoptek.com,Synoptek,MSP
 syntax.com,Syntax,MSP
 synthesys.live,Synthesys,SaaS
@@ -5316,10 +6671,14 @@ syntura.io,Syntura,MSP
 syr.edu,Syracuse University,Education
 syriantelecom.sy,Syrian Telecom,ISP
 syriatel.sy,Syriatel,ISP
+syringanetworks.net,Syringa Networks,ISP
 sysaid.com,SysAid,SaaS
 sysaidit.com,SysAid,SaaS
+sysconinfoway.com,Syscon Infoway,Web Host
+syseleven.de,SysEleven,IaaS
 sysnet.ie,VikingCloud,MSP
 systalent.com,Systalent,SaaS
+systex.com.tw,Systex,MSP
 sytes.net,No-IP,Web Host
 t-2.net,T-2,ISP
 t-com.hr,T-Com,ISP
@@ -5328,6 +6687,7 @@ t-ipconnect.de,Deutsche Telekom,ISP
 t-mobile.at,T-Mobile,ISP
 t-mobile.com,T-Mobile USA,ISP
 t-mobile.cz,T-Mobile,ISP
+t-mobile.de,T-Mobile,ISP
 t-mobile.pl,T-Mobile,ISP
 t-online.hu,Magyar Telekom,ISP
 t-systems.at,T-Systems,MSP
@@ -5336,13 +6696,21 @@ t-systems.de,T-Systems,MSP
 t2.ru,T2 Mobile,ISP
 tachc.org,Texas Association of Community Health Centers (TACHC),Healthcare
 tachus.com,Tachus Fiber,ISP
+tachyon.net.id,Tachyon,ISP
+taifo.com.tw,TAIFO,ISP
 taipeinet.com.tw,TaipeiNet (Peicity Digital Cable Television),ISP
 taiwanmobile.com,Taiwan Mobile,ISP
+take2hosting.com,Take 2 Hosting,Web Host
 takeda.com,Takeda,Healthcare
 takethemameal.com,Take Them A Meal,SaaS
+takushoku-u.ac.jp,Takushoku University,Education
+tal.de,tal.de,Web Host
+talk-straight.com,Talk Straight,ISP
+talkiefiber.com,Talkie Communications,ISP
 talktalk.business,TalkTalk Business,ISP
 talktalkbusiness.co.uk,TalkTalk Business,ISP
 talktalkplc.com,TalkTalk,ISP
+tam.ne.jp,TAMnet,ISP
 tami.pl,TAMI,MSP
 tamu.edu,Texas A&M University,Education
 tanglewoodhealth.com,Tanglewood Medical Supplies,Healthcare
@@ -5353,30 +6721,40 @@ tarhely.eu,Tárhely.Eu,Web Host
 tarr.hu,Tarr,ISP
 tatacommunications.com,Tata Communications,ISP
 tataidc.co.in,Tata Tele Business Services (TTBS),ISP
+tataindicom.com,Tata Teleservices,ISP
+tatatel.co.in,Tata Teleservices,ISP
 tatatelebusiness.com,Tata Teleservices,ISP
 tatateleservices.com,Tata Teleservices,ISP
 tattelecom.ru,Tattelecom,ISP
+tbaytel.net,TBayTel,ISP
 tbc.net.tw,TBC,ISP
 tbntelecom.com.br,TBN Telecom,ISP
 tbonet.net.br,Infix Telecom,ISP
+tbs.co.jp,Tokyo Broadcasting System,Government Media
 tcell.tj,Tcell,ISP
 tcftelecom.com.br,TCF Telecom,ISP
 tchile.com,Tchile,Web Host
 tci.ir,TCI,ISP
 tcmcorp.com,Southland Industries,Construction
 tcpnet.com.br,TCPNet,ISP
+tcrholdings.com,TCR Holdings,ISP
 tcs.com,TATA Consultancy Services,SaaS
 tct.net,TCT,ISP
 tctwest.net,TCT,ISP
 tcu.edu,Texas Christian University,Education
 tdcgroup.com,TDC,ISP
+tdf.fr,TDF,ISP
 tds.net,TDS,ISP
 tdstelecom.com,TDS Telecom,ISP
 te.eg,Telecom Egypt,ISP
+team.blue,team.blue,Web Host
 teamglac.com,TeamGLAC,Healthcare
+teammidwest.com,MEC Midwest Energy and Communications,ISP
+tec.com,TEC of Jackson,ISP
 tec.mx,Tecnológico de Monterrey,Education
 tech.ru,TECH.RU,Web Host
 tech4hosting.com,Tech 4 Hosting,Web Host
+techdata.com,Tech Data,Logistics
 teche.net,Uniti,MSP
 technolutions.com,Technolutions,SaaS
 technolutions.net,Technolutions,SaaS
@@ -5387,10 +6765,12 @@ tedforbes.com,Ted Forbes,Photography
 tees.ne.jp,Toyohashi Cable Network,ISP
 teksavvy.com,TekSavvy,ISP
 tel.net.ba,HT Eronet,ISP
+tel.ru,TEL Suntel,ISP
 telbo.net,TELBO,ISP
 telcocom.com.ar,Telcocom,ISP
 telcomaster.com,TelcoMaster,ISP
 telconet.ec,Telconet,ISP
+tele-ag.de,TELE AG,ISP
 tele.net,VOLhighspeed,ISP
 tele2.com,Tele2,ISP
 tele2.kz,Tele2,ISP
@@ -5407,6 +6787,7 @@ telecel.com.py,TELECEL,ISP
 telecentro-reversos.com.ar,Telecentro,ISP
 telecentro.com.ar,Telecentro,ISP
 telecolumbus.com,Tele Columbus,ISP
+telecom-sudparis.eu,Telecom SudParis,Education
 telecom.by,Beltelecom,ISP
 telecom.com.ar,Telecom Argentin,ISP
 telecom.kz,Kazakhtelecom,ISP
@@ -5418,10 +6799,12 @@ telecomarmenia.am,Telecom Armenia (Team),ISP
 telecomitalia.com,TIM,ISP
 telecomitalia.it,TIM,ISP
 telecomprovider.com.br,Telecom Provider,ISP
+teledata.de,TeleData,ISP
 teledyne.com,Teledyne Technologies,Manufacturing
 telefonica.com,Telefónica,ISP
 telefonica.com.ar,Telefónica Argentina,ISP
 telefonica.com.br,Telefônica Brasil,ISP
+telefonica.com.ec,Telefonica Ecuador (Otecel),ISP
 telefonica.com.pe,Telefónica Perú,ISP
 telefonica.de,Telefónica Germany,ISP
 telefonicachile.cl,Telefónica Chile,ISP
@@ -5440,14 +6823,18 @@ telemach.si,Telemach,ISP
 telemaxx.de,TelemaxX,Web Host
 telenet-ops.be,Telenet BV,ISP
 telenet.be,Telenet,ISP
+telenet.lv,Telenet Latvia,ISP
 telenor.dk,Telenor,ISP
 telenor.no,Telenor,ISP
 telenor.se,Telenor,ISP
+telenord.com.do,Telenord,ISP
 telepac.pt,SAPO,Email Provider
 telepacific.net,TPx Communications,ISP
 telepermit.co.nz,Spark NZ,ISP
 telered.com.ar,Telered,ISP
 telering.at,Magenta,ISP
+telesat.com,Telesat,ISP
+teleservice.net,Teleservice Skane,ISP
 teleson.net.br,Teleson Telecom,ISP
 telesp.net.br,Telefônica Brasil,ISP
 telesur.sr,Telesur,ISP
@@ -5461,6 +6848,7 @@ telia.no,Telia Norge,ISP
 teliacompany.com,Telia,ISP
 teligraph.com.sg,Teligraph,MSP
 telin.net,Telkom Indonesia,ISP
+telium.com.br,Telium Networks,ISP
 telium.net.br,Telium,ISP
 telkom.co.ke,Telkom Kenya,ISP
 telkom.co.za,Telkom South Africa,ISP
@@ -5471,7 +6859,9 @@ tellas.gr,Nova Telecommunications,ISP
 telma.mg,Yas,ISP
 telmex.com,Telmex,ISP
 telmex.net.ar,Telmex Argentina,ISP
+telnetworldwide.com,Telnet Worldwide,ISP
 telnyx.com,Telnyx,SaaS
+telpol.net.pl,Telpol,ISP
 telstra.com.au,Telstra,ISP
 telstra.net,Telstra,ISP
 telstrainternational.com,Telstra Global,ISP
@@ -5479,7 +6869,9 @@ telsur.cl,Telefónica del Sur,ISP
 teluq.ca,Tele-Universite,Education
 telus.com,TELUS,ISP
 telus.net,TELUS,ISP
+telviso.com.ar,TelViso,ISP
 telxius.com,Telxius,ISP
+tempe.gov,City of Tempe,Government
 temple.edu,Temple University,Education
 templehealth.org,Temple University Health System,Healthcare
 tencent.com,Tencent,Technology
@@ -5493,9 +6885,14 @@ terago.ca,TeraGo,ISP
 teraline-telecom.net,Teraline Telecom,ISP
 teraline.kz,Teraline Telecom,ISP
 teralinktelecom.com.br,Teralink,ISP
+teraswitch.com,TeraSwitch Networks,Web Host
+ternet.or.tz,TERNET Tanzania Education and Research Network,Education
 terra.com,Terra Networks,Web Host
 terra.com.br,Terra Mail,Email Provider
 terra.net.lb,TerraNet,ISP
+terratransit.de,TerraTransit,ISP
+tesatelecom.com,Tesa Telecom,ISP
+tesla.com,Tesla,Automotive
 tet.lv,Tet,ISP
 tevapharm.com,Teva Pharmaceuticals,Healthcare
 tevisat.net,Tevisat,ISP
@@ -5504,9 +6901,11 @@ textowngroup.com,Textown Group,Manufacturing
 tfn.net.tw,Taiwan Fixed Network,ISP
 thaitoko.com,Thai Toko Engineering,Construction
 thcservers.com,THCServers,Web Host
+the.hosting,THE.Hosting,Web Host
 theaccessgroup.com,The Access Group,SaaS
 thecamels.org,Thecamels,Web Host
 thechristhospital.com,The Christ Hospital,Healthcare
+thecloud.net,Sky WiFi (The Cloud),ISP
 thegameshowcompany.ca,The Game Show Company,Entertainment
 thegigabit.com,Gigabit Hosting,Web Host
 thegirlandthefig.com,the girl & the fig,Food
@@ -5516,12 +6915,18 @@ themercury.com,The Mercury,News
 thibodaux.com,Thibodaux Hospitals,Healthcare
 thomsonreuters.com,Thomson Reuters,SaaS
 three.co.uk,Three,ISP
+three.com.hk,3 Hong Kong (Hutchison),ISP
 three.ie,Three,ISP
 thunder.es,Thunder Creativos,Marketing
+thunderbox.io,ThunderBox,Web Host
 thundernet.com.ve,Thundernet,ISP
 ti-sparkle.it,Telecom Italia Sparkle,ISP
+tiaa-cref.org,TIAA,Finance
 tiaonline.org,Telecommunications Industry Association,Industrial
+tibus.com,Tibus (The Internet Business),Web Host
+tic.ir,Telecommunication Infrastructure Company,ISP
 tical.com,Grupo Tical,Logistics
+ticinocom.com,Ticinocom,ISP
 ticketor.com,Ticketor,Entertainment
 tidewater.net,Tidewater Telecom,ISP
 tie.cl,Telefónica Internet Empresas S.A.,ISP
@@ -5530,6 +6935,7 @@ tierpoint.com,TierPoint,Web Host
 tierzero.com,Tierzero,ISP
 tieto.com,Tietoevry,Consulting
 tietoevry.com,Tietoevry,Consulting
+tifr.res.in,Tata Institute of Fundamental Research,Science
 tigerconnect.com,TigerConnect,SaaS
 tigertech.net,Tiger Technologies,Web Host
 tigo.co.tz,Tigo,ISP
@@ -5546,6 +6952,7 @@ tim.com.br,TIM Brasil,ISP
 tim.it,TIM,ISP
 time.com.my,TIME,ISP
 timeetc.com,Time Etc,SaaS
+timenet.it,Timenet,ISP
 timeweb.com,Timeweb,Web Host
 timeweb.ru,Timeweb,Web Host
 timewebcloud.kz,Timeweb Cloud,Web Host
@@ -5553,14 +6960,17 @@ timmehosting.de,Timme Hosting,Web Host
 timminsfht.ca,Timmins Family Health Team,Healthcare
 tinasnet.net.br,Tinasnet,ISP
 ting.com,Ting Internet,ISP
+tingui.com.br,Tingui Telecom (ML Telecom),ISP
 tino.org,Tino Group,Web Host
 tino.vn,Tino Group,Web Host
 tis-dialog.ru,TIS Dialog,ISP
 tiscali.it,Tiscali,ISP
 tisco.mx,TISCO Networks,MSP
+tisnet.net.tw,TISNET,ISP
 titan.email,Titan,Email Provider
 titanhq.com,TitanHQ,Email Security
 titech.ac.jp,Institute of Science Tokyo,Education
+tivit.com,Tivit,MSP
 tix.it,Tuscany Internet eXchange,ISP
 tjbtn.net,Tianjin Broadcasting TV Network,ISP
 tkchopin.pl,Chopin Telewizja Kablowa,ISP
@@ -5578,23 +6988,30 @@ tmddedicated.com,TMDHosting,Web Host
 tmdhosting.com,TMDHosting,Web Host
 tmkultra.net.br,Tmk Net,ISP
 tmodns.net,T-Mobile USA,ISP
+tmone.com.my,TM Technology Services,ISP
 tmp.pe,Telcom Mikrotik Peru,ISP
 tn.gov,Tennessee Government,Government
 tnc-neuro.com,Tallahassee Neurological Clinic,Healthcare
 tng.de,TNG Stadtnetz,ISP
+tngnet.com,TNGNET,ISP
 tnm.co.mw,TNM,ISP
+tnnet.fi,TNNet,MSP
 tnsplus.kz,TNS-Plus,ISP
 tntsupport.net,TNT Support,MSP
 toast.net,TOAST.net,ISP
 today.com.kh,Today Internet,ISP
 tofinosoftware.com,Tofino,SaaS
+tohknet.co.jp,TOHKnet,ISP
+tohoku-gakuin.ac.jp,Tohoku Gakuin University,Education
 tohoku-mpu.ac.jp,Tohoku Medical and Pharmaceutical University,Education
 tohoku.ac.jp,Tohoku University,Education
 tohoyk.co.jp,Toho Pharmaceutical,Healthcare
 tojikiston.com,Babilon-T,ISP
 tokai-com.co.jp,TOKAI Communications,ISP
 tokala-mobile.com,Tokala Communications,ISP
+tombigbeefiber.com,Tombigbee Fiber,ISP
 top-tokyo.co.jp,TOP CORPORATION,Healthcare
+top86.com,Qingdao Cable TV Network Center,ISP
 topauctions24-7.com,TopAuctions24-7,Retail
 tophost.ch,NovaTrend Services,Web Host
 topmastertelecom.com.br,Top Master Telecom,ISP
@@ -5607,21 +7024,30 @@ topway.com.cn,Topway,ISP
 tornadovps.com,Tornado VPS,Web Host
 toronto.ca,City of Toronto,Government
 toronto.edu,University of Toronto,Education
+torontomu.ca,Toronto Metropolitan University,Education
 tosis.co.jp,Tosoh Information Systems,MSP
 tosoh.co.jp,Tosoh,Industrial
 totalplay.com.mx,Totalplay,ISP
+totidc.net,TOT,ISP
+toto.co.jp,TOTO,Manufacturing
+totvs.com,Totvs,SaaS
 towerstream.com,Towerstream,ISP
+towngastelecom.com,Towngas Telecom,ISP
 toya.com.pl,Toya,ISP
+toyo.ac.jp,Toyo University,Education
 toyotasystems.com,Toyota Systems,Automotive
 tpgi.com.au,TPG,ISP
 tpgtelecom.com.au,TPG,ISP
 tpnet.pl,Orange,ISP
 tps.uz,TPS Telecom,ISP
+tptel.ru,Teleport Telecom,ISP
 tpx.com,TPx Communications,ISP
 tradeeasyhk.net,TradeEasyHK,Retail
 tradeindia.com,TradeIndia,SaaS
+trafficforce.lt,TrafficForce,Marketing
 trafficmanager.net,Microsoft Azure,Technology
 trainhealthonline.com,TrainHealthOnline,Education
+transact.com.au,TransACT,ISP
 transip.nl,TransIP,Web Host
 transmail.net,Zoho,SaaS
 transocean.com,Transocean,Industrial
@@ -5643,15 +7069,21 @@ tri-c.edu,Cuyahoga Community College,Education
 tri.go.ke,Tourism Research Institute,Science
 triadefibra.com,Tríade Fibra,ISP
 triadefibra.com.br,Tríade Fibra,ISP
+triara.com,Triara,Web Host
 tricom.net,Altice Dominicana,ISP
 trifle.net,Trifle Network,ISP
+tring.al,Tring Albania,Entertainment
 trinity.cz,AB-NET,ISP
+trinity.edu,Trinity University,Education
 triolan.com,Triolan,ISP
 triolan.net,Triolan,ISP
 tripster.com,Tripster,Travel
 triton.net,Triton Technologies,Technology
+triumf.ca,TRIUMF Canada Particle Accelerator Centre,Science
 trivenet.it,Planetel,ISP
+trollfjord.no,Teneo,ISP
 trooli.com,Trooli,ISP
+troycable.net,Troy Cablevision,ISP
 trubridge.com,TruBridge,Healthcare
 true.th,TRUE,ISP
 truecorp.co.th,True Corporation,ISP
@@ -5659,8 +7091,11 @@ truefullstaq.com,TrueServer,Web Host
 truehost.cloud,Truehost Cloud,Web Host
 trueinternet.co.th,TRUE,ISP
 truemail.co.th,True Internet,ISP
+truespeed.com,TrueSpeed Communications,ISP
+truestreamfiber.com,Truestream Fiber,ISP
 truman.edu,Trueman State University,Education
 trustifi.com,Trustifi,Email Security
+truvista.net,Truvista,ISP
 tsimages.net,TSImages,SaaS
 tstc.edu,Texas State Technical College,Education
 tstt.co.tt,TSTT,ISP
@@ -5675,8 +7110,11 @@ ttn.gob.ar,Tribunal de Tasaciones de la Nación,Government
 ttnet.com.tr,Türk Telekom,ISP
 ttu.edu,Texas Tech University,Education
 ttuhsc.edu,Texas Tech University Health Sciences Center,Education
+tuc.gr,Technical University of Crete,Education
 tucows.com,Tucows,Web Host
+tucsonaz.gov,City of Tucson,Government
 tufts.edu,Tufts University,Education
+tugraz.at,Graz University of Technology,Education
 tukan.hu,Tukan,Web Host
 tulane.edu,Tulane University,Education
 tularosa.net,Tularosa Communications,ISP
@@ -5693,8 +7131,14 @@ turk.net,TurkNet,ISP
 turkcell.com.tr,Turkcell,ISP
 turksat.com.tr,Türksat,ISP
 turktelekom.com.tr,Türk Telekom,ISP
+turktelekomint.com,Turk Telekom International,ISP
 turkticaret.net,Turkticaret.Net,Web Host
+turnkeyinternet.net,Hivelocity (TurnKey Internet),Web Host
 tus.ac.jp,Tokyo University of Science,Education
+tusass.gl,Tusass Greenland,ISP
+tusd1.org,Tucson Unified School District,Education
+tussa.no,Tussa IKT,ISP
+tuve.fi,TUVE / Finnish State ICT Centre,Government
 tuwien.ac.at,TU Wien,Education
 tuwien.at,TU Wien,Education
 tva.com,Tennessee Valley Authority,Utilities
@@ -5708,11 +7152,14 @@ tvpublica.com.ar,TVP,ISP
 tvymas.co,TV&MÁS,ISP
 twilio.com,Twilio,SaaS
 twinlakes.net,Twin Lakes Communications,ISP
+twitter.com,X (Twitter),Social Media
 twl-kom.de,TWL-KOM,ISP
 twlakes.net,Twin Lakes Communications,ISP
 twmbroadband.com,Taiwan Mobile,ISP
+twncorp.com,Cherryland Services,ISP
 twnic.net.tw,Taiwan Mobile,ISP
 twnic.tw,Taiwan Mobile,ISP
+twt.com.tw,Taiwan Mobile (TNET NET),ISP
 twu.edu,Texas Woman's University,Education
 txstate.edu,Texas State University,Education
 tygrys.net,TYGRYS.NET,ISP
@@ -5720,26 +7167,45 @@ tylertech.com,Tyler Technologies,SaaS
 tyollisyysrahasto.fi,Työllisyysrahasto,Government
 typeform.com,Typeform,SaaS
 typo3server.info,Mittwald,Web Host
+tzulo.com,Tzulo,Web Host
 u-fukui.ac.jp,University of Fukui,Education
 u-ryukyu.ac.jp,University of the Ryukyus,Education
+u-shizuoka-ken.ac.jp,University of Shizuoka,Education
+u-szeged.hu,University of Szeged,Education
 u-tokai.ac.jp,Toki University,Education
 u-tokyo.ac.jp,University of Tokyo,Education
 u-toyama.ac.jp,University of Toyama,Education
+u.com.my,U Mobile Malaysia,ISP
 ua.edu,University of Alabama,Education
 uab.edu,The University of Alabama at Birmingham,Education
+uabc.edu.mx,Universidad Autonoma de Baja California,Education
+uacj.mx,Universidad Autonoma de Ciudad Juarez,Education
+uady.mx,Universidad Autonoma de Yucatan,Education
+uaem.mx,Universidad Autonoma del Estado de Morelos,Education
+uaemex.mx,Universidad Autonoma del Estado de Mexico,Education
+uag.mx,Universidad Autonoma de Guadalajara,Education
 uah.edu,University of Alabama in Huntsville,Education
 ualberta.ca,University of Alberta,Education
+ualr.edu,University of Arkansas at Little Rock,Education
+uam.mx,Universidad Autonoma Metropolitana,Education
 uams.edu,UAMS,Education
 uanl.mx,Universidad Autonoma de Nuevo Leon,Education
+uapb.edu,University of Arkansas at Pine Bluff,Education
 uar.net,UARNet,ISP
+uark.edu,University of Arkansas,Education
+uat.edu.mx,Universidad Autonoma de Tamaulipas,Education
+uba.ar,Universidad de Buenos Aires,Education
 ubannet.com.br,Ubannet,ISP
 ubc.ca,The University of British Columbia,Education
 uber.space,Uberspace,Web Host
+ubs.com,UBS,Finance
 ubxcloud.com,UBX Cloud,Web Host
+uc.cl,Pontificia Universidad Catolica de Chile,Education
 uc.edu,University of Cincinnati,Education
 ucalgary.ca,University of Calgary,Education
 ucar.edu,University Corporation for Atmospheric Research,Education
 uccs.edu,University of Colorado Colorado Springs,Education
+ucd.ie,University College Dublin,Education
 ucdavis.edu,UC Davis,Education
 ucdenver.edu,University of Colorado Denver,Education
 ucell.uz,Ucell,ISP
@@ -5751,16 +7217,21 @@ uci.edu,"University of California, Irvine",Education
 ucla.edu,UCLA,Education
 ucloud.cn,UCloud,IaaS
 uclouvain.be,UCLouvain,Healthcare
+ucmerced.edu,UC Merced,Education
+ucol.mx,Universidad de Colima,Education
 ucom.am,Ucom LLC,ISP
 ucom.ne.jp,Tsunagu Network Communications Inc.,ISP
 uconn.edu,University of Connecticut,Education
+ucop.edu,University of California Office of the President,Education
 ucr.ac.cr,Universidad de Costa Rica,Education
 ucr.edu,"University of California, Riverside",Education
+ucs.net,United Cooperative Services,ISP
 ucsb.edu,"University of California, Santa Barbara",Education
 ucsc.edu,"University of California, Santa Cruz",Education
 ucsd.edu,University of California San Diego,Education
 ucsf.edu,"University of California, San Francisco",Education
 uct.ac.za,University of Cape Town,Education
+ucv.ve,Universidad Central de Venezuela,Education
 udag.de,United Domains,Web Host
 udayton.edu,University of Dayton,Education
 udc.hk,Hong Kong Communications,Web Host
@@ -5770,43 +7241,60 @@ udlap.mx,Universidad de las Americas Puebla,Education
 udomain.hk,UDomain,Web Host
 uen.org,Utah Education Network,Education
 ufanet.ru,Ufanet,ISP
+ufba.br,Universidade Federal da Bahia,Education
 ufinet.com,Ufinet,ISP
 ufl.edu,University of Florida,Education
 ufmg.br,UFMG,Education
 ufone.com,Ufone,ISP
 ufrgs.br,UFRGS,Education
 ufsc.br,UFSC,Education
+ufv.br,Universidade Federal de Vicosa,Education
+ug.edu.gh,University of Ghana,Education
 uga.edu,University of Georgia,Education
+ugmk-telecom.ru,UGMK-Telecom,ISP
 uh.edu,University of Houston,Education
 uhc.com,United Healthcare,Healthcare
 uhs.edu.pk,University of Health Sciences,Education
 uhu.es,University of Huelva,Education
+ui.ac.id,University of Indonesia,Education
 uia.net,Ultimate Internet Access,ISP
 uibk.ac.at,University of Innsbruck,Education
 uic.edu,University of Illinois Chicago,Education
+uidaho.edu,University of Idaho,Education
 uiowa.edu,University of Iowa,Education
+ujat.mx,Universidad Juarez Autonoma de Tabasco,Education
 uk0.bigv.io,Bytemark,Web Host
 uk2.net,UK2.net,Web Host
 uk2net.com,UK2.net,Web Host
+ukg.com,UKG,SaaS
+ukraine.com.ua,Hosting Ukraine,Web Host
 ukrtel.net,Ukrtelecom,ISP
 ukrtelecom.ua,Ukrtelecom,ISP
 ukservers.com,UK Servers,Web Host
 uky.edu,University of Kentucky,Education
+ul-net.co.kr,ULNetworks,ISP
+ula.ve,Universidad de los Andes Venezuela,Education
 ulakbim.gov.tr,ULAKBIM,Education
+ulalaunch.com,United Launch Alliance,Defense
+ulaval.ca,Universite Laval,Education
 uleth.ca,University of Lethbridge,Education
 ultimate-guitar.com,Ultimate Guitar,Entertainment
 ultimatedomain.hosting,Ultimate Domain Hosting,Web Host
 ultralinkce.com.br,Ultralink,ISP
 ultralinkweb.com.br,Ultralink Telecom,ISP
+ultranet.biz,UltraNET,ISP
 ultranet.co.in,Ultranet,ISP
 ultrat.com.br,Ultratelecom,ISP
 ultravision.com.mx,Ultracel,ISP
 ultraweb.ca,Backland Communications,MSP
 ultrawebhosting.com,Ultra Web Hosting,Web Host
 ultraxx.com.br,Ultraxx,ISP
+umac.mo,University of Macau,Education
 umanitoba.ca,University of Manitoba,Education
+umaryland.edu,University of Maryland Baltimore,Education
 umass.edu,UMass Amherst,Education
 umassd.edu,University of Massachusetts Dartmouth,Education
+umassmed.edu,UMass Chan Medical School,Education
 umbc.edu,"University of Maryland, Baltimore County",Education
 umcs.pl,Maria Curie-Sklodowska University,Education
 umd.edu,University of Maryland,Education
@@ -5815,15 +7303,21 @@ umgc.edu,University of Maryland Global Campus,Education
 umich.edu,University of Michigan,Education
 umin.ac.jp,University Hospital Medical Information Network (UHIN) of Japan,Healthcare
 umk.pl,Nicolaus Copernicus University in Torun,Education
+umkc.edu,University of Missouri-Kansas City,Education
 uml.edu,University of Massachusetts Lowell,Education
 umn.edu,University of Minnesota,Education
 umniah.com,Umniah,ISP
+umnyeseti.ru,Umnyeseti,ISP
 umt.edu,University of Montana,Education
 umu.se,Umea University,Education
+unal.edu.co,Universidad Nacional de Colombia,Education
 unam.mx,Universidad Nacional Autónoma de México,Education
+unav.edu,Universidad de Navarra,Education
+unb.br,Universidade de Brasilia,Education
 unb.ca,University of New Brunswick,Education
 unbc.ca,University of Northern British Columbia,Education
 unc.edu,UNC Chapel Hill,Education
+uncc.edu,UNC Charlotte,Education
 uncg.edu,UNC Greensboro,Education
 unco.edu,University of Northern Colorado,Education
 une.com.co,UNE,ISP
@@ -5832,21 +7326,27 @@ une.net.co,UNE,ISP
 unesp.br,UNESP,Education
 unf.edu,University of North Florida,Education
 uni-frankfurt.de,Goethe University Frankfurt,Education
+uni-graz.at,University of Graz,Education
 uni-halle.de,Martin Luther University Halle-Wittenberg,Education
+uni-klu.ac.at,Universitat Klagenfurt,Education
 uni-koeln.de,University of Cologne,Education
 uni-linz.ac.at,University of Linz,Education
 uni-mainz.de,Johannes Gutenberg University Mainz,Education
 uni.edu,University of Northern Iowa,Education
 uniabita.it,UniAbita,Real Estate
+uniadex.co.jp,UNIADEX,MSP
+uniandes.edu.co,Universidad de los Andes,Education
 unicaja.es,Unicaja,Finance
 unicajabanco.es,Unicaja,Finance
 unicamp.br,Unicamp,Education
 unicanetworking.com.br,Única Networking,ISP
+unicreditgroup.eu,UniCredit,Finance
 unidata.it,Unidata,ISP
 unifiedlayer.com,UnifiedLayers,Web Host
 unifiedpostgroup.com,Unifiedpost Group,SaaS
 unifique.com.br,Unifique,ISP
 unifique.net,Unifique,ISP
+unijos.edu.ng,University of Jos,Education
 unilinktecnologia.com.br,Unilink Tecnologia,ISP
 unimedjp.com.br,Unimed João Pessoa,SaaS
 unimelb.edu.au,University of Melbourne,Education
@@ -5857,17 +7357,23 @@ uninet.az,Uninet,ISP
 uninett.no,Sikt (Formerly Uninett),Education
 unionbank.com.bd,Union Bank,Finance
 unionwireless.com,Union Wireless,ISP
+uniserve.com,Uniserve,ISP
+uniserver.nl,Uniserver,Web Host
 unisinos.br,Unisinos,Education
 unisnet.ru,ЮНИС Телеком (UNIS),ISP
+unispital-basel.ch,University Hospital Basel,Healthcare
 unisys.com,Unisys,MSP
 unitasglobal.com,Unitas Global,MSP
-United-domains.de,United Domains,Web Host
+united-domains.de,United Domains,Web Host
 united.com,United Airlines,Travel
 united.net,United Communications,ISP
 unitedfiber.com,United Fiber,ISP
 unitedyacht.com,United Yacht Sales,Retail
 unitel.ao,Unitel Angola,ISP
 unitel.com.la,Unitel,ISP
+unitel.mn,Unitel Mongolia,ISP
+unitelco.com.br,Universal Telecom Brazil,ISP
+uniteprivatenetworks.com,Unite Private Networks,ISP
 uniti.com,Uniti,MSP
 unity-health.org,Unity Health,Healthcare
 unityhealth.org,Unity Health,Healthcare
@@ -5875,20 +7381,26 @@ univac.com.sg,Univac,Industrial
 universal-shoji.co.jp,Universal Shoji,Industrial
 univie.ac.at,University of Vienna,Education
 uniwisp.co.za,UniWISP,ISP
+unlp.edu.ar,Universidad Nacional de La Plata,Education
 unm.edu,University of New Mexico,Education
+unn.com.bn,Unified National Networks Brunei,ISP
+unn.edu.ng,University of Nigeria Nsukka,Education
 uno.edu,University of New Orleans,Education
 unpl.co.in,UN Broadband,ISP
 unr.edu,"University of Nevada, Reno",Education
 unsw.edu.au,University of New South Wales,Education
 unt.edu,University of North Texas,Education
 untd.com,United Online,ISP
+uoa.gr,National and Kapodistrian University of Athens,Education
 uoc.gr,University of Crete,Education
 uoeh-u.ac.jp,"University of Occupational and Environmental Health, Japan",Education
 uog.edu,University of Guam,Education
+uoguelph.ca,University of Guelph,Education
 uol.com.br,UOL - UNIVERSO ONLINE S/A,Web Host
 uoregon.edu,University of Oregon,Education
 uottawa.ca,University of Ottawa,Education
 uovs.ac.za,University of the Free State,Education
+uow.edu.au,University of Wollongong,Education
 up.com,Union Pacific Railroad,Logistics
 up99plus.com,Up99Plus,Web Host
 upc.ie,Virgin Media Ireland,ISP
@@ -5908,10 +7420,16 @@ upsun.com,Upsun,PaaS
 uq.edu.au,University of Queensland,Education
 uqac.ca,Universite du Quebec a Chicoutimi,Education
 ural-net.ru,inetvdom,ISP
+ural.net,Ural Regional Net,ISP
 uregina.ca,University of Regina,Education
 uri.edu,University of Rhode Island,Education
 urupesnet.com.br,UrupêsNet,ISP
+us-cloud.top,Arosscloud (Uscloud),Web Host
+usach.cl,Universidad de Santiago de Chile,Education
 usanpedro.edu.pe,Universidad San Pedro,Education
+usap.gov,United States Antarctic Program,Government
+usask.ca,University of Saskatchewan,Education
+usb.ve,Universidad Simon Bolivar,Education
 usbank.com,U.S. Bank,Finance
 usc.edu,University of Southern California,Education
 uscomputers.com,U.S. Computer Corporation,MSP
@@ -5920,12 +7438,14 @@ user.fm,Fastmail,Email Provider
 usercontent.jp,Gehirn,Web Host
 usf.edu,University of South Florida,Education
 usfca.edu,University of San Francisco,Education
+usfiberpower.com,Fiberpower,ISP
 usg.edu,University System of Georgia,Education
 usgs.gov,U.S. Geological Survey,Government
 usinternet.com,US Internet (USI Fiber),ISP
 usm.edu,University of Southern Mississippi,Education
 usmd.edu,University System of Maryland,Education
 usnh.edu,University System of New Hampshire,Education
+uson.mx,Universidad de Sonora,Education
 usp.br,University of São Paulo,Education
 usps.gov,United States Postal Service,Government
 usq.edu.au,University of Southern Queensland,Education
@@ -5939,27 +7459,40 @@ uta.fi,Tampere University,Education
 utah.edu,University of Utah,Education
 utah.gov,State of Utah,Government
 utas.edu.au,University of Tasmania,Education
+utc.edu,University of Tennessee at Chattanooga,Education
 utclonline.co.ug,Uganda Telecom,ISP
+utdallas.edu,University of Texas at Dallas,Education
+utelecom.com.ua,Ukrainian Telecommunication Group (UTG),ISP
 utelesup.edu.pe,Universidad privada Telesup,Education
 utep.edu,University of Texas at El Paso,Education
 utexas.edu,University of Texas at Austin,Education
 uth.edu,UT Health Houston,Education
 uthsc.edu,University of Tennessee Health Science Center,Education
+utilitytelephone.com,Utility Telecom,ISP
 utilprovedor.psi.br,Util Provedor,ISP
 utl.co.ug,Uganda Telecom,ISP
+utm.my,Universiti Teknologi Malaysia,Education
 utmb.edu,University of Texas Medical Branch,Education
+utmedicalcenter.org,University of Tennessee Medical Center,Healthcare
 utoledo.edu,University of Toledo,Education
 utopianet.com.br,Utopia,ISP
 utoronto.ca,University of Toronto,Education
+utp.ac.pa,Universidad Tecnologica de Panama,Education
 utrgv.edu,University of Texas Rio Grande Valley,Education
 uts.cw,United Telecommunication Services,ISP
 utsa.edu,University of Texas at San Antonio,Education
+utsi.edu,University of Tennessee Space Institute,Education
 utsouthwestern.edu,UT Southwestern Medical Center,Education
 utsystem.edu,University of Texas System,Education
+uttyler.edu,UT Tyler,Education
+utulsa.edu,University of Tulsa,Education
+utwente.nl,University of Twente,Education
 uu.net,UUNET Japan,ISP
 uu.se,Uppsala universitet,Education
+uv.mx,Universidad Veracruzana,Education
 uva.nl,Universiteit van Amsterdam,Education
 uvawise.edu,UVA Wise,Education
+uvi.edu,University of the Virgin Islands,Education
 uvic.ca,University of Victoria,Education
 uvm.edu,University of Vermont,Education
 uw.edu,University of Washington,Education
@@ -5967,40 +7500,56 @@ uwa.edu.au,University of Western Australia,Education
 uwaterloo.ca,University of Waterloo,Education
 uwec.edu,University of Wisconsin-Eau Claire,Education
 uwf.edu,University of West Florida,Education
+uwinnipeg.ca,University of Winnipeg,Education
 uwm.edu,University of Wisconsin-Milwaukee,Education
 uwo.ca,University of Western Ontario,Education
 uws.edu.au,Western Sydney University,Education
 uww.edu,University of Wisconsin-Whitewater,Education
 uwyo.edu,University of Wyoming,Education
 uzpak.uz,uzpak.uz,Industrial
+v-sys.org,VSYS Host,Web Host
 v0.build,Vercel,PaaS
 v2soft.com,V2Soft,MSP
 va.gov,U.S. Department of Veterans Affairs,Government
 vadesecure.com,Vade Secure,Email Security
+vaioni.com,Vaioni,ISP
 valenet.com.br,Valenet,ISP
 valero.com,Valero,Industrial
 valley-widehealth.org,Wally-Wide Health,Healthcare
+valleyfiber.ca,Valley Fiber,ISP
+valorc3.com,ValorC3 Data Centers,Web Host
+valverde.edu,Val Verde Unified School District,Education
 vanderbilt.edu,Vanderbilt University,Education
+vanderbilthealth.com,Vanderbilt Health,Healthcare
+vantagepnt.com,Vantage Point Solutions,ISP
 vanwerthospital.org,Van Wert Health,Healthcare
 varzeanet.com.br,Varzea Net,ISP
+vassar.edu,Vassar College,Education
 vccs.edu,Virginia Community College System,Education
 vck-gmbh.de,Vestische Caritas-Klinike,Healthcare
 vcn.com,Visionary Broadband,ISP
+vcoe.org,Ventura County Office of Education,Education
 vctelecom.com.br,Voce Telecomunicações,ISP
 vcu.edu,Virginia Commonwealth University,Education
+vd.ch,Canton de Vaud,Government
 vdonsk.ru,Microel,ISP
 vdsina.com,VDSina,Web Host
+vdsina.ru,VDSina,Web Host
+vectorfibre.co.nz,Vector Fibre,ISP
 vectra.pl,Vectra,ISP
 vectranet.pl,Vectra,ISP
 vedco.com,Vedco,Healthcare
 vee.com.tw,VeeTIME,ISP
+veesp.com,Veesp,Web Host
 veetime.com,VeeTIME,ISP
 veganet.com.tr,Veganet,ISP
 vegans.it,vegan/s,MSP
 vege.net,vege.net,Web Host
 vegvesen.no,Statens Vegvesen,Government
 veiganet.com.br,VEIGANET,ISP
+velfibra.com.br,Vel Fibra,ISP
 velia.net,velia.net,Web Host
+velocitynetwork.net,Velocity Network,ISP
 veloxfiber.com.br,Velox,ISP
 velozfibra.com.br,Veloz Fibra,ISP
 ventech.com,C1,MSP
@@ -6011,6 +7560,7 @@ vercel.com,Vercel,PaaS
 vercel.dev,Vercel,PaaS
 vercel.run,Vercel,PaaS
 verde.ag,Verde Agritech,Agriculture
+vereinigte-stadtwerke.de,Vereinigte Stadtwerke,ISP
 verginia.edu,University of Virginia,Education
 veridyen.com,Veridyen,Web Host
 verisign.com,Verisign,Technology
@@ -6019,6 +7569,7 @@ verizon.com,Verizon,ISP
 verizon.net,Verizon,ISP
 verizonbusiness.com,Verizon Business,ISP
 vermont.gov,Vermont Government,Government
+verobroadband.com,Vero Fiber,ISP
 verointernet.com.br,Internet de Verdade,ISP
 versanet.de,1&1 Versatel,ISP
 vertikal6.com,Vertikal6,MSP
@@ -6029,6 +7580,7 @@ vgonline.com,Video Graphics,Web Host
 vgpinternet.net.br,VGP Internet,ISP
 vgregion.se,Västra Götalandsregionen,Government
 viaccess.net,ONE Communications,ISP
+vialis.net,Vialis,ISP
 vialuxfibra.com.br,VialuxFibra,ISP
 viamartelecom.com.br,Viamar Telecom,ISP
 viananet.net.br,VianaNet,ISP
@@ -6043,6 +7595,7 @@ vibconexao.com.br,Vib Conexão,ISP
 vibrantwellnessvoyage.com,Vibrant Wellness Voyage,Healthcare
 vicc.co,Venco Imtiaz Contracting Co,Industrial
 victorkaiser.com,Global Transport,Logistics
+vidanet.hu,ViDaNet,ISP
 video-broadcast.at,Video-Broadcast,ISP
 videotron.ca,Videotron,ISP
 videotron.com,Videotron,ISP
@@ -6050,11 +7603,15 @@ viecuri.nl,VieCuri,Healthcare
 viethwebhosting.com,MemberLeap,Web Host
 viettel.com.vn,Viettel,ISP
 viettel.vn,Viettel,ISP
+viettelidc.com.vn,Viettel IDC,Web Host
+viewqwest.com,ViewQwest,ISP
 vigban.com.br,Vigban,Physical Security
 vikingcloud.com,VikingCloud,MSP
+villanova.edu,Villanova University,Education
 vinahost.vn,VinaHost,Web Host
 vinakom.com,Vinakom,MSP
 vinedisposal.com,Vine Disposal,Logistics
+vinu.edu,Vincennes University,Education
 vip.hr,A1,ISP
 vipfibertelecom.com.br,VIP Fiber,ISP
 vipowernet.net,ONE Communications,ISP
@@ -6074,6 +7631,7 @@ virtex.com.br,Virtex Telecom,ISP
 virtru.com,Virtu,Email Security
 virtrugateway.com,Virtu,Email Security
 virtua.com.br,Virtua Brizil,Marketing
+virtua.org,Virtua Health,Healthcare
 virtuaal.com,Virtuaal,Web Host
 virtual1.com,PXC,ISP
 virtualhosting.hk,UDomain,Web Host
@@ -6085,6 +7643,7 @@ visabeira.co.ao,COMATEL,ISP
 visi.com,US Signal,MSP
 visitmiddlesex.ca,"Middlesex County, Canada",Government
 vismap.it,Industrie Vismap,Retail
+vistabroadband.com,Vista Broadband,ISP
 vitalnetprovedor.com.br,Vital Net,ISP
 vitelcom.net,ONE Communications,ISP
 vitroconnect.de,vitroconnect,ISP
@@ -6098,16 +7657,26 @@ vivatele.com,Viva Telecom,ISP
 vivatele.com.br,Viva Telecom,ISP
 vivicta.com,Vivicta,Consulting
 vivozap.com.br,Vivo Mobile,ISP
+vk.com,VK,Social Media
 vk.company,VK,Social Media
+vladinfo.ru,Vladinfo,ISP
+vladlink.ru,Vladlink,ISP
 vm.bytemark.co.uk,Bytemark,Web Host
+vm.co.mz,Vodacom Mozambique,ISP
+vmi.edu,Virginia Military Institute,Education
+vnet.sk,VNET Slovakia,ISP
+vng.com.vn,VNG Online,SaaS
+vnnic.vn,VNNIC Vietnam Internet Network,Government
 vnpt.com.vn,VNPT,ISP
 vnpt.vn,VNPT,ISP
 vnr.de,VNR Group,SaaS
 vnrgroup.com,VNR Group,SaaS
 vntelecom.com.br,VN Telecom,ISP
 voartelecom.com.br,Voar Telecom,ISP
+vocalocity.com,Vonage Business (Vocalocity),SaaS
 vocus.co.nz,2degrees,ISP
 vocus.com.au,Vocus,ISP
+vodacom.co.ls,Vodacom Lesotho,ISP
 vodacom.co.tz,Vodacom Tanzania,ISP
 vodacom.co.za,Vodacom,ISP
 vodacom.com,Vodacom,ISP
@@ -6137,8 +7706,11 @@ voith.com,Voith,Industrial
 volcengine.com,Volcengine (ByteDance),IaaS
 volhighspeed.at,VOLhighspeed,ISP
 volia.com,Volia,ISP
+volico.com,Volico Data Centers,Web Host
 volkswagengroupamerica.com,Volkswagen of America,Automotive
 volstate.net,IT Voice,MSP
+volvo.com,Volvo,Manufacturing
+volz.ua,Volz Ukraine,ISP
 vom.com,Valley of the Moon,ISP
 voo.be,VOO,ISP
 vootelecom.com.br,Voo Telecom,ISP
@@ -6152,11 +7724,15 @@ voyager.nz,Voyager,ISP
 vpath.co.za,Pathcare Vermaak,Healthcare
 vpls.com,VPLS,MSP
 vpndns.net,Now-DNS,Web Host
+vr.fi,VR Group (Finnish Railways),Logistics
 vrmgr.com,Virtual Resort Manager,Real Estate
+vsc.edu,Vermont State Colleges,Education
+vsenet.de,VSE NET,ISP
 vshosting.cz,vshosting,Web Host
 vsu.by,Vitebsk State University,Education
 vt.edu,Virginia Tech,Education
 vtal.com,V.tal,ISP
+vtc.vn,VTC Digicom,Government Media
 vtext.com,Verizon SMS,ISP
 vtgus.com,Virtual Technologies Group,MSP
 vtr.com,VTR,ISP
@@ -6164,9 +7740,12 @@ vtr.net,VTR,ISP
 vtt.fi,VTT Technical Research Centre of Finland,Education
 vtx.ch,VTX,ISP
 vtxnet.net,VTX Services,ISP
+vu.edu.au,Victoria University,Education
 vulcnmold.com,VulcanMold,Industrial
 vultrusercontent.com,Vultr,Web Host
 vusercontent.net,Vercel,PaaS
+vut.cz,Brno University of Technology,Education
+vutbr.cz,Brno University of Technology,Education
 vwhs.org,Valley-Wide Health,Healthcare
 vyvebroadband.com,Vyve Broadband,ISP
 vyvebroadband.net,Vyve,ISP
@@ -6174,6 +7753,8 @@ wa-k20.net,Washington K-20 Network,Education
 wa.gov,State of Washington,Government
 wadax-sv.jp,WADAX,Web Host
 wadax.ne.jp,WADAX,Web Host
+wainet.co.jp,Cable Media WaiWai,ISP
+wakayama-u.ac.jp,Wakayama University,Education
 wal-mart.com,Walmart,Retail
 waldmann.com,Waldmann,Industrial
 walmartstores.com,Walmart,Retail
@@ -6182,6 +7763,7 @@ wananchi.com,Wananchi Group,ISP
 wanao.com,Wanao,SaaS
 warian.net,Warian,SaaS
 warwick.ac.uk,University of Warwick,Education
+waseda.jp,Waseda University,Education
 washington.edu,University of Washington,Education
 wasip.com,WASIP Ltd.,Healthcare
 watchcomm.net,Watch Communications,ISP
@@ -6192,6 +7774,7 @@ wavebroadband.com,Wave Broadband,ISP
 wavemax.com.br,Wavemax Internet,ISP
 wavenet.co.uk,Wavenet,ISP
 wavenetuk.net,Wavenet,MSP
+waveruralconnect.com,Wave Rural Connect,ISP
 wavetech.co.za,WaveTech,Industrial
 waxcreative.com,Waxcreative Design,Marketing
 waypointcentre.ca,Waypoint Centre,Healthcare
@@ -6199,10 +7782,16 @@ wbhcp.com,Williams Bros Pharmacy,Healthcare
 wbroadband.net.au,Wholesale Communications Group,ISP
 wcoil.com,Watch Communications,ISP
 wconect.com.br,WCONECT,ISP
+wctc.net,Solarus,ISP
+wctel.com,West Carolina Communications,ISP
 wcupa.edu,West Chester University,Education
+wcvt.com,Waitsfield and Champlain Valley Telecom,ISP
+wd6.net,WD6.NET,ISP
 wdide.com.br,W.Dide Telecom,ISP
+wdr.de,WDR Westdeutscher Rundfunk,Government Media
 wdstelecom.com.br,WDS Telecom,ISP
 we.bs,LiquidNet,Web Host
+wearecms.com,Charlotte-Mecklenburg Schools,Education
 web-dns1.com,Web Hosting Canada,Web Host
 web-hosting.com,Namecheap,Web Host
 web.ad.jp,Fujitsu,Technology
@@ -6210,7 +7799,10 @@ web.africa,Webafrica,ISP
 web.app,Google,PaaS
 web.com.ph,Web.com Philippines,Web Host
 web.de,Web.de,ISP
+web2objects.de,web2objects,Web Host
 webadorsite.com,JouwWeb,Web Host
+webair.com,Webair Internet Development,Web Host
+webbingsolutions.com,Webbing,ISP
 webbytelecom.com.br,Webby Internet,ISP
 webd.pl,WEBD.PL,Web Host
 webetic.net,Webetic,Web Host
@@ -6254,21 +7846,31 @@ webzilla.com,Webzilla,Web Host
 webzine1.com,Webzine Online,Web Host
 webzineonline.com,Webzine Online,Marketing
 weclix.com.br,Weclix,ISP
+weendeavor.com,Endeavor Communications,ISP
 welcomeitalia.it,Vianova,ISP
 well.com,The WELL,Email Provider
+wellesley.edu,Wellesley College,Education
 wellmont.org,Wellmont Health System,Healthcare
 wellsfargo.com,Wells Fargo,Finance
+wellstar.org,Wellstar Health System,Healthcare
+wemacom-breitband.de,WEMACOM Breitband,ISP
 wescor.com,ELITechGroup,Healthcare
+wesleyan.edu,Wesleyan University,Education
 westbrook.ms,Westbrook Construction,Construction
 westcall.ru,WestCall,ISP
+westchestergov.com,County of Westchester,Government
 westcloudvalley.com,Ningxia West Cloud Data,IaaS
 westcoastinternet.com,West Coast Internet (WCI),ISP
 westdc.net,WestHost,Web Host
+westmancom.com,Westman Communications,ISP
 westriv.com,WRT,ISP
+weverfastfiber.com,Everfast Fiber Networks,ISP
 wewehost.com,WeWeHost,Web Host
 wexzone.com,WexZone,Web Host
 wf.net,Web Fire Communications,MSP
 wfn.ca,Westbank First Nation,Government
+wfu.edu,Wake Forest University,Education
+wgeld.org,City of Westfield (WG&E),Utilities
 wgo.com.br,WGO,ISP
 what-if.com,The Imagination Factory,MSP
 whatbox.ca,Whatbox,Web Host
@@ -6279,24 +7881,39 @@ wheelhouseracingschool.com,The Ford Performance Racing School,Automotive
 whirlpoolcorp.com,Whirlpool,Manufacturing
 whitelighthost.net,Acklo,MSP
 whiteoakemail.com,MailEnable,Email Provider
+whitesky.us,Whitesky Communications,ISP
+whizcomms.com.sg,WhizComms,ISP
 whmpanels.com,WHM Panels,Web Host
+who.int,World Health Organization,Nonprofit
+whoi.edu,Woods Hole Oceanographic Institution,Science
 wholesaleinternet.net,WholeSale Internet,ISP
 whplanet.com,WH Planet Web Hosting,Web Host
+wi-fiber.io,Wi-Fiber,ISP
 wi.gov,The State of Wisconsin,Government
+wia.cz,WIA Telecommunications,ISP
+wichita.edu,Wichita State University,Education
+wide.ad.jp,WIDE Project,Science
+widener.edu,Widener University,Education
 wien.gv.at,City of Vienna,Government
 wifeet.com.do,Wifeet,ISP
 wifire.ru,MegaFon,ISP
 wifirst.com,Wifirst,ISP
 wightman.ca,Wrightman Telecom,ISP
+wigner.hu,Wigner Research Centre for Physics,Science
 wiit.cloud,WIIT,IaaS
 wikitelecom.com.br,Wki Telecom,ISP
+wildpark.net,WildPark,ISP
 wilhelm-tel.de,wilhelm.tel,ISP
 wiline.com,WiLine Networks,ISP
+wilkes.edu,Wilkes University,Education
+wilkes.net,RiverStreet (Wilkes Communications),ISP
+willamette.edu,Willamette University,Education
 williams.edu,Williams College,Education
 williamsbrospharmacy.com,Williams Bros Pharmacy,Healthcare
 willnet.org,WilliNet,ISP
 wilsoncomputer.com,Wilson Computer Support,MSP
 wilsonss.com,Wilson Computer Support,MSP
+win.pe,Win Telecom Peru,ISP
 wind.com.do,WIND Telecom,ISP
 wind.it,WINDTRE,ISP
 windriver.com,Wind River,SaaS
@@ -6306,22 +7923,32 @@ wingnet.com.br,WINGNET,ISP
 wingo.ch,Wingo,ISP
 winknet.ne.jp,Himeji Cable Television,ISP
 winnermedical.com,Winner Medical,Healthcare
+wintek.com,Wintek,ISP
+wire3.com,Wire 3,ISP
 wiredblade.com,Wired Blade,Web Host
+wiredisp.com,WiredISP,ISP
+wirelesslogic.com,Wireless Logic,ISP
+wireline.com.au,Wireline,ISP
 wirelink.com.br,DB3 Telecom,ISP
 wirenet.com.ar,El Cuatro,ISP
+wiru.co.za,WIRUlink,ISP
 wisc.edu,University of Wisconsin–Madison,Education
 wiscnet.net,WiscNet,Education
 wisconsin.edu,University of Wisconsin,Education
 wisconsin.gov,The State of Wisconsin,Government
 wisdomisp.com,Wisdom ISP,ISP
 wise.net.lb,WISE,ISP
+wishisp.com,Priority of Fashion ISP,ISP
+wishnet.co.in,Wish Net,ISP
 wisperisp.com,Wisper,ISP
+wiu.edu,Western Illinois University,Education
 wix.com,Wix,SaaS
 wixsite.com,Wix,SaaS
 wixstudio.com,Wix,SaaS
 wixstudio.io,Wix,SaaS
 wizmoworks.com,Wizmo,MSP
 wktelecom.net.br,WK Telecom,ISP
+wku.edu,Western Kentucky University,Education
 wlannetwork.com.br,WLAN Network,ISP
 wlink.com.np,WorldLink Communications,ISP
 wlu.edu,Washington & Lee University,Education
@@ -6330,16 +7957,21 @@ wm.ru,Webmaster Agency,Marketing
 wmaker.net,WMaker,ISP
 wmatera.com.br,WMatera Telecom,ISP
 wmservice.com.do,WMService,ISP
+wnet.global,WNET Telecom,ISP
 wnetsystem.com.br,WNET,ISP
 wntellecom.net.br,WN Tellecom,ISP
 wntpr.net,WorldNet Telecommunications,ISP
+wobcom.de,Wobcom Wolfsburg,ISP
 wockhardt.com,Wockhardt,Healthcare
 wolnet.it,Wolnet,ISP
 wolseleyinc.ca,Wolseley Canada,Industrial
 wom.cl,WOM,ISP
 wom.co,Partners Telecom Colombia (Formerly WOM Colombia),ISP
+woodside.com.au,Woodside Energy,Industrial
 woodstocktel.net,Woodstock Communications,ISP
+woodynet.net,WoodyNet (Packet Clearing House),Nonprofit
 woolworths.co.za,Woolworths,Retail
+wooster.edu,College of Wooster,Education
 wordpress.com,Wordpress.com,Web Host
 workbandalarga.com.br,Work Banda Larga,ISP
 workday.com,Workday,SaaS
@@ -6350,14 +7982,21 @@ worksmobile.com,Naver Works,SaaS
 worldbank.org,World Bank Group,Nonprofit
 worldbankgroup.org,World Bank Group,Nonprofit
 worldcall.net.pk,WorldCom Telecom,ISP
+worldline.com,Worldline,SaaS
 worldlink.com.np,WorldLink Communications,ISP
+worldphone.in,World Phone India,ISP
 worldstream.com,Worldstream,Web Host
+worria.com,Cloudie,Web Host
+wortmann.de,Wortmann,Manufacturing
+wowrack.com,Wowrack,Web Host
 wowway.com,WOW!,ISP
 wp.pl,Wirtualna Polska,Web Host
 wpenginepowered.com,WP Engine,Web Host
+wpunj.edu,William Paterson University,Education
 wpx.ne.jp,wpX Speed,Web Host
 wpx.net,WPX Hosting,Web Host
 wpxhosting.com,WPX Hosting,Web Host
+wroc.pl,Wroclaw Centre of Networking and Supercomputing,Science
 wsh.care,The Woodlands Specialty Hospital,Healthcare
 wsigenesis.com,Action Hosting,Web Host
 wsnetfibra.com.br,WSNET,ISP
@@ -6373,7 +8012,10 @@ wwwowww.co.za,wwwOwww,Marketing
 wwz.ch,WWZ,Utilities
 wylance.com,Emma Solutions (Formerly Wylance),MSP
 wyo.gov,State of Wyoming,Government
+wyocore.com,Wyocore Technologies,Web Host
+wyoming.com,Wyoming.com,ISP
 wyyerd.com,Wyyerd Fiber,ISP
+x-city.ua,X-City,ISP
 x-com.kz,X-COM,ISP
 x-mailer.de,Power-Netz,Web Host
 xbiz.ne.jp,Xserver,Web Host
@@ -6383,24 +8025,32 @@ xcitium.com,Xcitium,SaaS
 xecu.net,Xecunet,MSP
 xen.prgmr.com,prgmr.com,Web Host
 xerox.com,Xerox,Technology
+xfernet.com,Xfernet,Web Host
 xfinity.com,Comcast,ISP
+xg.ar,XG Networks Argentina,ISP
+xilinx.com,Xilinx,Manufacturing
 xinet.com.mx,Xinet,MSP
 xipline.com,Ritter Communications,ISP
 xl.co.id,XL Axiata,ISP
+xlsmart.co.id,XL Smart (XL Axiata),ISP
 xmission.com,XMission,SaaS
 xmr3.com,OpenText,SaaS
+xn.net,XNNET,Web Host
 xn.qh.cn,China Telecom,ISP
 xneelo.co.za,Xneelo,Web Host
 xnet.co.nz,One NZ (Formerly Vodafone New Zealand),ISP
 xnet.mx,Xnet,MSP
+xphone.co.il,XPhone,ISP
 xplore.ca,Xplore,ISP
 xrea.com,XREA,Web Host
+xruiserver.com,XRUI,Web Host
 xserver.cloud,XServer,Web Host
 xserver.co.jp,Xserver,Web Host
 xserver.jp,Xserver,Web Host
 xserver.ua,XServer,Web Host
 xsinfosol.com,XS Infosol,SaaS
 xtfibra.com.br,XT Fibra,ISP
+xtglobal.vg,XT Global Networks,ISP
 xtom.com,xTom,IaaS
 xtrim.com.ec,Xtrim,ISP
 xturbo.com.br,Xturbo,ISP
@@ -6410,7 +8060,9 @@ yadtel.net,Zirrus,ISP
 yahoo.co.jp,Yahoo Japan,Email Provider
 yahoo.com,Yahoo,Email Provider
 yahooinc.com,Yahoo,Email Provider
+yahsat.ae,Yahsat,ISP
 yale.edu,Yale University,Education
+yamagata-u.ac.jp,Yamagata University,Education
 yamaguchi-u.ac.jp,Yamaguchi University,Education
 yamanashi.ac.jp,Yamanashi University,Education
 yamaoka.co.jp,Yamaoka,Industrial
@@ -6428,10 +8080,13 @@ yelpcorp.com,Yelp,Social Media
 yemen.net.ye,YemenNet,ISP
 yesfibra.com.br,YES Fibra,ISP
 yettel.hu,Yettel,ISP
+yisu.com,Yisu Cloud,Web Host
 ykwc.com,Yellowknife Wireless,ISP
 yonsei.ac.kr,Yonsei University,Education
 yorku.ca,York University,Education
+yotta.com,Yotta Network Services,IaaS
 youbroadband.in,YOU Broadband,ISP
+youfibre.com,YouFibre,ISP
 your-server.de,Hetzner,Web Host
 your-site.com,Your-Site.Com,Web Host
 your.org,YOUR.ORG,Web Host
@@ -6440,9 +8095,12 @@ yourhosting.nl,Yourhosting,Web Host
 yourhostingaccount.com,Newfold Digital,Web Host
 yourmailgateway.de,netcup,Web Host
 yoursitesecure.net,REDCITEL,Physical Security
+ysu.edu,Youngstown State University,Education
 ytelecom.com.br,Hootix Telecom,ISP
 ytlcomms.my,YTL Communications,ISP
+yu.ac.kr,Yeungnam University,Education
 yu.edu,Yeshiva University,Education
+yu.net,YUnet International,ISP
 yukanet.com.br,Ykaline,ISP
 yurekpharmacy.com,Yurek Pharmacy,Healthcare
 yuuai.or.jp,Social Medical Corporation Yuuaikai,Healthcare
@@ -6463,8 +8121,10 @@ zapto.org,No-IP,Web Host
 zaq.ne.jp,ZAQ,Email Provider
 zare.com,Zare,Web Host
 zayo.com,Zayo,ISP
+zayoeurope.com,Zayo Europe,ISP
 zbltelecom.net.br,ZBL Telecom,ISP
 zcmail.net,Zoho Campaigns,Marketing
+zcolo.com,zColo,Web Host
 zcom.it,Limitis,Technology
 zcsend.net,Zoho Campaigns,Marketing
 zdsys.com,Zendesk,SaaS
@@ -6480,10 +8140,13 @@ zeop.re,Zeop,ISP
 zetaglobal.com,Zeta Global,Marketing
 zetaglobal.net,Zeta Global,Marketing
 zetahosting.net,Zeta Hosting,Web Host
+zettagrid.com,Zettagrid,Web Host
 zf.com,ZF Friedrichshafen,Automotive
+zicom.pl,Zicom Next,ISP
 zid.com,ZiD Internet,ISP
 ziggo.nl,Ziggo,ISP
 ziggozakelijk.nl,Ziggo,ISP
+zillion.network,Zillion Network,ISP
 ziplyfiber.com,Ziply Fiber,ISP
 zipweb.net,Zipweb,Web Host
 zirrus.com,Xirrus.com,ISP
@@ -6493,6 +8156,7 @@ zixcorp.com,Zix,Email Security
 zixsmbhosted.com,Zix,Email Security
 zixworks.com,Zix,Email Security
 zjtelecom.com.cn,China Telecom,ISP
+zlidc.net,Zhilian Technology IDC,Web Host
 zoho.com,Zoho,SaaS
 zoho.com.au,Zoho,SaaS
 zoho.eu,Zoho,SaaS
@@ -6501,12 +8165,14 @@ zohocloud.ca,Zoho,SaaS
 zohocorporation.com,Zoho,SaaS
 zohomail.com,Zoho,SaaS
 zoneedit.com,Zoneedit,Web Host
+zong.com.pk,Zong (CMPak),ISP
 zoom.com,Zoom,SaaS
 zoom.us,Zoom,SaaS
 zscaler.com,Zscaler,SaaS
 zsttk.ru,TTK,ISP
 ztv.co.jp,ZTV,ISP
 zumpnet.com.br,Zumpnet,ISP
+zumtobelgroup.com,Zumtobel Group,Manufacturing
 zurich.com,Zurich Insurance,Finance
 zyner.net,Zyner,Email Provider
 zyner.one,Zyner,Email Provider

--- a/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
+++ b/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
@@ -1,4 +1,3 @@
-1-grid.com
 1001darknights.com
 103-sbcplindia.com
 119-pbb.net.pk
@@ -71,6 +70,7 @@ aceville.net
 achnet.am
 acinternet.net.br
 acrsolutions.com
+acs-hartmann.de
 actcapitaledge.com
 activaicon.com
 active-ns.com
@@ -84,7 +84,6 @@ adlucrumnewsletter.com
 admin.corpivensa.gob.ve
 admincomp.com
 adriadns.com
-adsl.cat
 adslplus.ch
 adsnet-telecom.net.br
 advance.com.ar
@@ -157,11 +156,12 @@ ambyrenodes.net
 americanannex.com
 americaneagle.com
 americanstorageca.com
-americatelnet.com.pe
 amfm.live
 amik.net.ru
+amis.hr
 amointernet.net.br
 amplusserver.info
+ampr.be
 amtcyemens.com
 anavcloudsoftwaresolutions.com
 ancel.net.uy
@@ -181,7 +181,6 @@ anwrgrp.lat
 anythingemail.com
 anzamanagement.com
 aogss.ru
-aoiot.ru
 aosau.net
 aparadiserental.com
 apexihl.com
@@ -225,9 +224,9 @@ asahi-hp.jp
 asbaumhosting.com
 ascentlenses.com
 asd.tj.cn
+aseva.com
 ashrapidslodge.com
 asiaituhost.com
-asianaidt.com
 asiawhere.com
 asicontrols.com
 asj.ne.jp
@@ -369,7 +368,6 @@ botngot.com
 bouten.shop
 boyersbuilding.com
 bpaserver.net
-br.digital
 brackenly.live
 brainity.com
 braintel.net.pk
@@ -425,6 +423,7 @@ bzconcept.com
 c53dw7m24rj.com
 c5ace.com
 ca-expressive.site
+cableatlantico.com
 cablecolor.com.sv
 caccaweb.com
 caem-it.co
@@ -439,7 +438,6 @@ camellenses.com
 campmicha.com
 canaatelecom.net.br
 canal13.cl
-canon-its.co.jp
 capacivolley.com
 capitaldeni.com
 capitalfibra.com.br
@@ -480,9 +478,9 @@ ccstv.com.br
 cda.gov.bd
 cdcservices.com
 cdn1000.com
-cdt.cz
 cegalvez.com.ar
 ceiausa.com
+ceniai.inf.cu
 centralmalaysia.com
 centralnic.net
 centrum.dk
@@ -496,6 +494,7 @@ ch-dns.net
 ch-tournon.fr
 chacoonline.net
 chamberscc.com
+chaney.net
 chantiernavalducapfagnet.com
 chauffeurplan.co.uk
 chcnev.com
@@ -585,6 +584,7 @@ collegespherecollege.com
 collibra.com
 colliersar.com
 colman.net.nz
+colocationguard.com
 colombiaceropapel.org
 colorcodedlabels.com
 coloriuris.net
@@ -616,15 +616,18 @@ contactsacademy.com
 contactsglamour.info
 contactssafari.com
 contenucredit.com
+conterra-inc.com
 conxxus.net
 cookingartsnetwork.com
 coolblaze.com
 coollink.us
+coolnet.ps
 coop-oliva.com.ar
 coop5.com.ar
 coopservluque.com.ar
 coowo.com
 copixa.com
+coralnet.or.jp
 corklink.com
 corpemail.net
 corpivensa.gob.ve
@@ -656,10 +659,8 @@ crownaku.com
 crt.fr
 crystallations.com
 csii.com.hk
-csl.de
 cspirefiber.net
 ct.co.cr
-ctc-g.co.jp
 ctinets.com
 ctla.co.kr
 ctstelecom.net
@@ -689,6 +690,7 @@ dallerton.cloud
 danceusa-services.com
 danisstabilizer.com
 dansdungeon.com
+dansknet.dk
 danspharmacy.com
 das-vierte-portal.de
 dashersdugout.com
@@ -761,6 +763,7 @@ dipelnetfoz.com.br
 directcom.com
 directlan.net.br
 directorysecure.com
+directv.com.ar
 directvnet.cl
 directvnet.com.ar
 direkt-domains.de
@@ -818,13 +821,11 @@ dr.com.tr
 draffin-tucker.com
 draimsecurevavlt.com
 draycottia.digital
-drc.gov.cn
 dream-mark1.co.kr
 dream.jp
 dreampox.fun
 dreamtechmedia.com
 drhinternet.net
-drpeng.com.cn
 ds.network
 dsi.ru
 dsl.net
@@ -843,7 +844,6 @@ dxmusicstudio.com
 dynamic-wiretel.in
 dynamicanalojix.net.bd
 dyntcorp.com
-e-catv.ne.jp
 e-gia.com
 e-shops.jp
 e-tiger.net
@@ -872,6 +872,7 @@ educaconigualdad.com
 edzone.net
 efibre.net.za
 efzapps.com
+eggcrane.net
 egosimail.com
 eilopu.iki.fi
 einbecker-buergerspital.de
@@ -905,6 +906,7 @@ enetnube.com
 enetworksgy.com
 enfasysco.com
 enhancebeautytanning.com
+enivest.no
 enjoygreekislands.com
 enlacesrss.com
 enmail.co
@@ -913,7 +915,6 @@ entelpcs.cl
 entendercopilot.com
 enticingofdisadvantage.com
 entretothom.net
-enzu.com
 epaycontrol.com
 epchd.org
 epectelco.com.ar
@@ -988,7 +989,6 @@ fastcloudpr.net
 faster.com.br
 fastestgrowthreview.com
 fastnet.net.br
-fastnetdata.com
 fastsecurehost.com
 fastweb360.it
 fastwebnet.it
@@ -1007,6 +1007,7 @@ fgvtelecom.com.br
 fiberalley.com
 fibercorp.com.ar
 fiberlinkpe.net.br
+fiberstate.com
 fibramaxbandalarga.com.br
 fibranetbrasil.net.br
 fibravip.net
@@ -1051,7 +1052,6 @@ formedic.com
 formicidaehunt.net
 fornex.cloud
 forteline.net.br
-fortressitx.com
 fosterheap.com
 fotographix.com
 fotomaury.com
@@ -1091,7 +1091,6 @@ galeforcewebpros.com
 galop.online
 gamersprotectionvpn.online
 gangbild.net
-gaoland.net
 gaplan.shop
 garbinc.com
 gardengrovephotographer.com
@@ -1101,8 +1100,8 @@ gavdavison.com
 gaysino.net
 gbmooneybooks.com
 gcplearning.com
-gcs.co.kr
 gdigitalindia.in
+gds.vn
 geekcommerce.net
 geisenhainer.net
 gendns.com
@@ -1193,7 +1192,6 @@ gs-bates.com
 gsbb.com
 gstackhosting.com
 gstsoft.in
-gtdmanquehue.com
 gtt.co.gy
 guardiandigital.com
 guardianswipe.net
@@ -1247,6 +1245,7 @@ hgnbroken.us.com
 hhost.eg
 hi-ag.com
 highspeedbb.bn
+highspeedweb.net
 hightemperatureceramics.com
 highwey-diesel.com
 hilltop.net
@@ -1255,7 +1254,6 @@ hipernet.inf.br
 hirofactory.com
 hitachi.eu
 hjd.asso.fr
-hkglobalnetwork.com
 hlogin.net
 hmplaza.net
 hnnet.com.br
@@ -1270,7 +1268,6 @@ hongchenggco.pro
 hongkongtaxi.co
 hongoudai-jibika.com
 hoosierpc.com
-hopone.net
 hopsinthehanger.com
 hori-kazu.com
 hospital.nagano.nagano.jp
@@ -1333,7 +1330,6 @@ huntndogsestates.com
 hurleyspace.net
 hwccustomers.com
 hwclouds-dns.com
-hya.com.tw
 hybridinternet.co
 hypericine.com
 hypointfarms.com
@@ -1365,7 +1361,6 @@ ientc.mx
 ientc.net.mx
 ife.co.th
 iffc.com.br
-iforte.co.id
 igamma.ru
 igmohji.com
 igppevents.org.uk
@@ -1386,7 +1381,6 @@ imazu-chemical.co.jp
 imjtmn.cn
 immenzaces.com
 imobie.com
-imp.ch
 impey.shop
 improvation.us
 in-addr-arpa
@@ -1436,6 +1430,7 @@ interfarma.kz
 interflixtelecom.com.br
 interiordesignersyonkers.com
 interlink.com.br
+intermanaged.com
 internet-corporativa.com.br
 internet-service.be
 internetvox.net.br
@@ -1470,7 +1465,6 @@ iranita.com
 irapture.com
 ireo-perigord.com
 irrestal.com
-ishantechnologies.com
 isidors.net
 isiline.org
 ismtj.co
@@ -1479,15 +1473,16 @@ isomedia.com
 ispconecta.com.br
 ispguatemala.com.gt
 ispservices.us
-isu.net.sa
 iswhatpercent.com
 isx.net.nz
 itc.net.il
+itcng.net
 ite.bg
 itelcel.com
 itelsa.com.ar
 ithinc.net
 itourismlimited.com
+itproximus.com
 itsidc.com
 itsweb.com.br
 itv-3.com
@@ -1508,7 +1503,6 @@ japbuk.com
 jarmuloviktazone.com
 jasarekber.id
 jatimnet.com.br
-jaxa.jp
 jazhostingco.com
 jcis.ca
 jcps.com.tw
@@ -1548,7 +1542,6 @@ k2telecom.net.br
 kabsi.at
 kadastr.ru
 kadimconnect.com.br
-kagoya.com
 kahlaa.com
 kanarick.com
 karensilverbloom.com
@@ -1559,7 +1552,6 @@ kazusaohara-church.com
 kbrnet.ru
 kbronet.com.tw
 kcmc.jp
-kctvjeju.com
 kdnursing.org
 kdsaccessories.com
 kemri-rctp.org
@@ -1603,7 +1595,6 @@ kula.co.mz
 kulttsolutions.co.in
 kuritzen.net
 kvartal-net.ru
-kvhasia.com
 kyivstar.net
 kyushu-u.ac.jp
 kzmn.ir
@@ -1691,7 +1682,6 @@ longwoodmgmt.com
 looppose.com
 loopus.co.jp
 lostmall.net
-lotteinnovate.com
 lotusbirth.info
 lowafraid.net
 lowcostpetvaccinations.net
@@ -1705,6 +1695,7 @@ lstnetworks.com
 lucky7powersports.com
 luckysrv.de
 lumiserver.com
+lumosnet.com
 lunami.life
 lunanode.net
 lunberjack.com.br
@@ -1715,7 +1706,6 @@ luxebidet.com
 luxemburtij.net
 lwegatech.info
 lwl-puehringer.at
-lycorp.co.jp
 lynx.net.lb
 lyse.net
 m-sender.com.ua
@@ -1724,6 +1714,7 @@ m-sia.com
 m12solutions.net
 m2.ist
 m2tel.net.br
+mabnatelecom.com
 mabnet.net.br
 macarrltd.com
 machaikapps.net
@@ -1820,10 +1811,8 @@ memphissewingmachine.com
 meowly.org
 meqlobal.com
 mercian.space
-metanet.co.kr
 metasecure.net
 metro86.ru
-metrotel.net.co
 meuip.tv.br
 mgn.ru
 mgts.by
@@ -1854,11 +1843,9 @@ mjchotoku.com
 mjinn.com
 mkegs.shop
 mmhosp.com
-moack.co.kr
 mobius.fr
 model-ac.ink
 moderntradingnews.com
-moe.go.th
 molderly.world
 moldex.com
 molecullesoft.com
@@ -1943,6 +1930,7 @@ name-servers.gr
 name.tools
 namethatserver.com
 nanshenqfurniture.com
+nationwideinc.com
 nationwidenotaryregistry.com
 natomsvete.ru
 natrohost.com
@@ -1970,24 +1958,25 @@ netbuild.net
 netcarrier.net
 netcell.inf.br
 netcentertelecom.net.br
-netcom-bw.de
 netcom.host
 netcom.psi.br
 netdoor.com
 netfiber.inf.br
 netfibra.com.br
 netflexbr.com
+netglobal.it
 netglowstudios.pl
 neti.ee
 netkl.org
+netkom.de
 netlatin.net.ar
 netlilfy.com
 netlinebahia.net.br
 netminasfibra.net.br
 netorn.ru
-netsat.in
 netscan.hu
 netsky.net.br
+netstartech.sg
 netsystemrn.com.br
 networkiowa.com
 networkship.com
@@ -2012,7 +2001,6 @@ nexuserver.net
 ngoinhamang.com
 ngvcv.cn
 nhpil-ng.com
-nibtv.co.kr
 nic.name
 nicehealthtoday.top
 nicesrv.de
@@ -2032,6 +2020,7 @@ nmeuh.cn
 nobuyuki.ninja
 nocrctelecomnet.com.br
 nodevm.com
+nodosud.com.ar
 nofrillscloud.com
 nohasslejr.com
 noisndametal.com
@@ -2039,6 +2028,8 @@ nojabrsk.ru
 nokissing.shop
 nongyu.live
 nonxtutti.com
+nordstorm.com
+nortech.com.ar
 northbayle.xyz
 northeyphotography.com
 northtelecom.com.br
@@ -2049,12 +2040,10 @@ novuscom.net
 npbnl.net
 nqntv.com.ar
 ns360.net
-nsk-kk.com
 nssonline.com
 nstelecablecr.com
 nt-isp.net
 ntesmail.com
-nthu.edu.tw
 nty.uy
 nucleusemail.com
 nuendel.de
@@ -2086,6 +2075,7 @@ offerslatedeals.com
 office365.us
 ogicom.net
 ogreserve.com
+okbprogress.ru
 okweb3.jp
 olb-access.net
 olbitx.network
@@ -2109,7 +2099,9 @@ onlineaccount.net
 onlineconsumernews.com
 onlinecorp.me
 onlinetelecom.ir
+only.yt
 onumubunumu.com
+opcaonet.com.br
 openaccessjrnl.info
 opentouch.site
 oppt-ac.fit
@@ -2133,7 +2125,6 @@ otmprint.com
 ourhosted.com
 outinmarbella.com
 outlandishnews.com
-outremer-telecom.fr
 outsidences.com
 outsource-philippines.com
 ovaapart.com
@@ -2213,6 +2204,7 @@ planurevents.com
 plateautel.net
 playamedia.io
 plazanote.com
+pld.com
 plugarinternet.net.br
 pmf.hr
 pmnhost.net
@@ -2228,6 +2220,7 @@ polytechnique.org
 pombonet.net.br
 pomeroysports.com
 pontocomnet.net.br
+pop-i.de
 popiup.com
 porar.net
 portal-r4c.com
@@ -2278,6 +2271,7 @@ psnm.ru
 pstconnect.net.br
 pt-panjunan.com
 ptempresas.pt
+ptl.ru
 puls.net
 pvcwindowsprices.live
 qontenciplc.autos
@@ -2295,13 +2289,12 @@ qxyxab44njd.com
 r75.info
 rack1host.com
 rackspeed-cloud.de
-racsa.co.cr
 radcom.hosting
 radianthealthrenaissance.com
 radicaltechreveal.com
 radioactive.name
 radiodays.jp
-railtelindia.com
+radius.ph
 raimax.com.br
 ranchesmontana.com
 rapidanet.com
@@ -2309,6 +2302,7 @@ rapidns.com
 ratikka.iki.fi
 raxa.host
 rcncustomer.com
+rcp.pe
 rdock.ru
 reachesbeast.com.de
 readyidc.com
@@ -2347,17 +2341,20 @@ researchpulseusa.com
 resellerex.com
 reso-tech.ca
 restocarpediem.com
+reston.va.us
 resurrectioncatholic.church
 retemetis.net
 rethos.com.mx
 retirementconcepts.com
 retroflect.shop
+rettigicc.com
 rev0telecablecr.com
 reverearea.com
 reverse-network.de
 revnomix.local
 rezzultat.com
 rgb365.eu
+rialcom.ru
 richworks.com
 riddlecamera.net
 riddletrends.com
@@ -2365,6 +2362,7 @@ rifnet.jp
 rillcrestly.xyz
 rioaccess.com
 rippecloud.com
+rittercommunications.com
 rivencroft.space
 riverwindy.xyz
 rmeniaa.net
@@ -2374,7 +2372,6 @@ robertstevens.co.uk
 roboneri.shop
 robs-journeys.co.uk
 roccopugliese.com
-roedu.net
 ropocapital.fi
 rose.net
 royal-gallery.com
@@ -2382,6 +2379,7 @@ rpgwebserver.com
 rpnet.net.br
 rscb.org.in
 rsconnection.net.br
+rtat.net
 rtpgiga33.site
 rubypluspl.us
 rudyguerra.com
@@ -2420,7 +2418,6 @@ samsales.site
 sandhilldealerservices.com
 sanluisctv.com.ar
 santa-fe.nm.us
-santandergto.com
 sante-lorraine.fr
 saransk.ru
 satirogluet.com
@@ -2434,7 +2431,6 @@ scotnet.net
 scripcorp.com
 scrolldesigning.com
 scs-net.org
-scs.co.kr
 sdcc.my
 sdf.org
 sdssoftltd.co.uk
@@ -2505,6 +2501,7 @@ shot05.accesscam.org
 siditelecom-isp.com.br
 sify.net
 sigmapharm.com
+signalx.cloud
 signofthewhaleonline.com
 sih09.fr
 silverforda.store
@@ -2539,6 +2536,7 @@ sltelecom.net.br
 smallvillages.com
 smart9.net.br
 smartape-vps.com
+smartcity.com
 smartfindslive.com
 smartstockboost.com
 smewell.com
@@ -2548,6 +2546,7 @@ smswetten.com
 smtinfo.net
 smtpi.com
 smunion.biz
+sni.ne.jp
 snorkledwint.org
 snositesaso2.com
 socialflag.net
@@ -2561,7 +2560,6 @@ sollutium.com
 solucija.eu
 solusoftware.com
 solutionspal.com
-soon.com.ar
 sopricom.fr
 soultelecom.net.br
 sounditaly.com
@@ -2587,7 +2585,6 @@ spiritualtechnologies.io
 spkrl.com
 sporthotelalacati.com
 sportsimpressionsonline.com
-sprious.com
 sprout.org
 srhc.com
 srshta.in
@@ -2664,7 +2661,7 @@ swissbluetopaz.com
 switer.shop
 swmhosting.in
 symbolhost.com
-symphony.net.th
+synterra.ru
 sysop4.com
 sysscan.com.hk
 system.eu.com
@@ -2681,7 +2678,6 @@ taosend.com
 taquaranet.com.br
 tascom.com.br
 tataidc.com
-tataindicom.com
 taunus-auto.de
 tbkinternet.net.br
 tcdsb.org
@@ -2719,7 +2715,6 @@ tenet.odessa.ua
 tenkids.net
 tenriyorozu.jp
 tenten.vn
-teraswitch.com
 terawiz.com
 terminavalley.com
 tetrocapital.com
@@ -2730,7 +2725,6 @@ tgchosting.com
 thaicloudsolutions.com
 thaikinghost.com
 thaimonster.com
-the.hosting
 thebeantownphotobooth.com
 thebitcoincode.site
 thebits.biz
@@ -2754,7 +2748,6 @@ threembb.co.uk
 threembb.ie
 throughputclimb.com
 tiagosilvaprovedores.com.br
-tic.ir
 ticdns.com
 ticowebsite.com
 tietoenator.com
@@ -2771,8 +2764,8 @@ tmg.md
 tmndesign.com
 tnetsolucoes.com.br
 tnnet.com.br
+tocochannel.jp
 todaytechupdates.com
-tohknet.co.jp
 tokushukai.or.jp
 tokyorinkai.jp
 toledofibra.net.br
@@ -2788,7 +2781,6 @@ toservers.com
 toshosting.com
 totaal.net
 totalplay.net
-totidc.net
 totisp.net
 totonline.net
 toumail.com
@@ -2834,7 +2826,6 @@ turbonetminas.com.br
 turbonetwifi.net.br
 turbosportis.store
 turbotech.com
-tuve.fi
 tveps.net
 tvetcdacc.go.ke
 tvkompass.de
@@ -2848,7 +2839,6 @@ twp-capital.com
 txw-taishin.com
 tylerfordonline.com
 tymtalk.com
-tzulo.com
 u-ikoi.co.jp
 u-team.by
 uaehostings.com
@@ -2874,6 +2864,7 @@ unaxus.net
 undersilence.net
 uneedacollie.com
 unetelecom.psi.br
+uni-mb.si
 uni.net.th
 unicornbulletin.com
 unified.services
@@ -2881,6 +2872,7 @@ unifiedregistration-2026.com
 unipharm.com
 uniredes.net.br
 unite.services
+unitedrdc.com
 untexklante.org
 unwiredbb.net
 urawasl.com
@@ -2940,6 +2932,7 @@ virginmedia.net
 virtualalim.org
 virtualine.org
 virtualsolution.net
+vision.net
 visit.docotor
 viszontelado-tarhely.hu
 vivatranquilo.com.br
@@ -2960,7 +2953,6 @@ vovantan.com
 vpeipics.com
 vrns.net
 vs-ukraine.com
-vsenet.de
 vsi.ru
 vst-adler.com
 vst.net.br
@@ -2979,6 +2971,7 @@ wan55.co.jp
 wanekoohost.com
 warriorofzen.life
 wateen.net
+watercorporation.com.au
 wavecable.com
 way-interactive.com
 waylink.pk
@@ -2996,8 +2989,6 @@ web-hosting.tech
 web-life.co.jp
 web-login.eu
 web-profit.com.pl
-web2objects.de
-webair.com
 webalias.net
 webcountry.com.au
 webhostingserver.nl
@@ -3032,7 +3023,6 @@ westongraphics.net
 westparkcom.com
 westsidelenses.info
 wetransfer-eu.com
-weverfastfiber.com
 wginfor.com.br
 whatstools.com
 wheelch.me
@@ -3054,6 +3044,7 @@ wilks.shop
 willardstreetcollision.com
 willcoxmedia.net
 willsit.jp
+winde.jp
 winempresas.pe
 wingerslikane.com
 winstonsalemmuseum.com
@@ -3073,14 +3064,14 @@ wordpresshosting.xyz
 workoutchronic.com
 worktual.net
 worldclassdevelop.com
+worldcom.ch
 worldnetparaiso.com.br
-worria.com
 wowamazing.shop
 wpdns.com
 wpgdedihost7.com
-wroc.pl
 wsiph2.com
 wspfibra.com.br
+wsr.ac.at
 wszz.torun.pl
 wtcks.net
 wtutelecom.com.br
@@ -3127,7 +3118,6 @@ zainagroup.ltd
 zanob.nl
 zazzinternet.com
 zcn-c7c7app.com
-zcolo.com
 zdravkniga.net
 zelenaya.net
 zencha-club.com
@@ -3137,7 +3127,6 @@ zetadns.net
 zetanet.com.br
 zgtwhite.org
 zh-with-leisu.com
-zillion.network
 zimbramail.cl
 zmml.uk
 znlc.jp


### PR DESCRIPTION
## Summary

Walked the bundled IPinfo Lite MMDB for ASN domains absent from `base_reverse_dns_map.csv`, processed the top ~1,950 by IPv4 weight across five batches using `collect_domain_info.py` + tier-based classification per [AGENTS.md](https://github.com/domainaware/parsedmarc/blob/master/AGENTS.md), and added **1,664 new map entries** in this PR.

**Coverage delta:**
- ASN-domain coverage by IPv4 weight: **~92.9% → 95.3%**
- ASN-domain coverage by domain count: 5.4% → 8.0%
- Map total entries: 6,515 → 8,180

**Composition of additions:**
- ~250 universities and government / municipalities (Tier 0 — restricted TLD + MMDB as_name)
- ~80 globally-known brands (Saudi Telecom, JAXA, RailTel, LY Corporation, Tesla, Intel, Citi, Schwab, Disney, EA, Volvo, Mitsubishi Electric, Cargill, Hallmark, Medtronic, Banco do Brasil, Petrobras, etc.)
- Direct aliases for already-mapped brands (HKBN, Tata Teleservices, Cox, NTT, T-Mobile, KAGOYA, etc.)
- Long tail of regional ISPs / hosters / data center operators classified via MMDB `as_name` + homepage corroboration

**known-unknown changes:** 66 entries promoted out of `known_unknown_base_reverse_dns.txt` where the new collector data cleared the two-corroborating-sources bar; 55 added where the bar still wasn't met. The two files remain disjoint per the workflow guardrail.

## Test plan

- [x] `python sortlists.py` exits 0 (types valid, alphabetic sort, dedupe)
- [x] CRLF line endings preserved in `base_reverse_dns_map.csv`
- [x] No domain appears in both `base_reverse_dns_map.csv` and `known_unknown_base_reverse_dns.txt` (`comm -12` check passes)
- [x] No full-IP entries in either file (privacy rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)