### PR TITLE
Classify ~970 more reverse DNS map entries from MMDB ASN-domain coverage gap (round 2)

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -3,6 +3,7 @@ base_reverse_dns,name,type
 012.net.il,012Mobile (Partner),ISP
 018.co.il,XPhone (XFone 018),ISP
 02online.de,Telefonica O2 Germany,ISP
+099.net.il,099 Primo Communications,ISP
 1-2-1marketing.com,foreUP,SaaS
 1-grid.com,1-grid,Web Host
 1-net.com.sg,1-Net Singapore,ISP
@@ -70,7 +71,9 @@ base_reverse_dns,name,type
 5gnetworks.com.au,5G Networks Australia,MSP
 6dg.co.uk,Six Degrees,MSP
 6ptelecom.com.br,6P Telecom,ISP
+7-dj.com,Fujitsu Systems Applications,MSP
 702com.com,702 Communications,ISP
+84grams.se,84 Grams,ISP
 8x8.com,8x8,SaaS
 99cloudhosting.com,99CloudHosting,Web Host
 a-hadar.co.il,Hadar Group,Real Estate
@@ -79,6 +82,7 @@ a1.by,A1,ISP
 a1.hr,A1,ISP
 a1.mk,A1,ISP
 a1.net,A1,ISP
+a1.rs,A1 Serbia,ISP
 a1.si,A1,ISP
 a2b-internet.com,A2B Internet,ISP
 a2hosted.com,A2 Hosting,Web Host
@@ -88,6 +92,7 @@ a2telecomfibra.com.br,A2 Telecom Fibra,ISP
 a2webhosting.com,hosting.com,Web Host
 a2zcreatorz.ca,A2Z Creatorz,Technology
 aa.net.uk,Andrews & Arnold,ISP
+aaa.com,AAA,Travel
 aalto.fi,Aalto University,Education
 aaltoscientific.com,Aalto Scientific,Healthcare
 aamranetworks.com,Aamra Networks,ISP
@@ -98,9 +103,11 @@ ab-group.biz,AsiaBell,ISP
 aba2net.com,ABA2Net,ISP
 abb.com,ABB,Industrial
 abbott.com,Abbott,Healthcare
+abbvie.com,AbbVie,Healthcare
 abc.net.au,ABC,Government Media
 abchk.com,ABCHK,Web Host
 abchk.net,ABCHK,Web Host
+abissnet.al,Abissnet,ISP
 ablbrasil.com.br,ABL Brasil,Healthcare
 abn.co.kr,Areum Broadcasting Network,ISP
 abnamro.com,ABN AMRO,Finance
@@ -115,12 +122,15 @@ acantho.it,Acantho,ISP
 accelecom.net,Accelecom,ISP
 accelia.net,Accelia,SaaS
 accenture.com,Accenture,Consulting
+accesscom.com,HyperSurf (Accesscom),ISP
 accesshaiti.net,Access Haiti,ISP
 accessmedlab.com,Access Medical Labs,Healthcare
 accessnet.com.br,AccessNet,ISP
+accessoneinc.com,Access One,MSP
 accesstel.net,AccessTEL,ISP
 accretive-networks.net,Accretive Technology Group,SaaS
 acd.net,ACD.net,ISP
+ace-fiber.com,ACE Fiber,ISP
 acedatacenter.com,Ace Data Centers,Web Host
 acedatacenters.com,Ace Data Centers,Web Host
 acelerate.net,AXS Bolivia S. A.,ISP
@@ -128,6 +138,7 @@ acems2.com,ActiveCampaign,Marketing
 acemsa1.com,ActiveCampaign,Marketing
 acens.com,acens,Web Host
 acentek.net,AcenTek,ISP
+aceredc.com,Acer e-Enabling Data Center,Web Host
 acessecomunicacao.com.br,Acesse,ISP
 acessoline.net.br,Alt Telecom,ISP
 ach.or.jp,Ageo Central General Hospital,Healthcare
@@ -149,11 +160,17 @@ activegate-ss.jp,Active! gate SS,Email Security
 activetrail.biz,ActiveTrail,Marketing
 acu.edu,Abilene Christian University,Education
 acuperfectwebsites.com,AcuPerfect Websites,Web Host
+ada.net.tr,AdaNET,ISP
 adabank.com.tr,Dünya Katılım,Finance
 adairit.com,Adair IT,MSP
+adam.es,Adam EcoTech,Web Host
+adamant.ua,Adamant,ISP
 adamo.es,Adamo,ISP
 adams.net,Adams Fiber,ISP
 adamthecomputerguy.com,Adam the Computer Guy,MSP
+adaptiv-networks.com,Adaptiv Networks,SaaS
+adc.net.ar,Aguas del Colorado,Utilities
+adcstack.com,ADC Group,Web Host
 additionnetworks.net,CherryRoad Technologies,MSP
 adelaide.edu.au,University of Adelaide,Education
 adient.com,Adient,Manufacturing
@@ -173,8 +190,10 @@ adsl.cat,SkyQuantum,ISP
 advancedhosters.com,Advanced Hosting,Web Host
 advancedhosting.com,Advanced Hosting,Web Host
 advania.com,Advania,MSP
+advania.fi,Advania Finland,MSP
 advania.is,Advania Iceland,MSP
 adventconstructions.co.tz,Advent Construction Limited,Industrial
+adventhealth.com,AdventHealth,Healthcare
 adyl.com.br,Adyl Telecom,ISP
 aebc.com,AEBC Internet,ISP
 aegon.com,Aegon,Finance
@@ -183,6 +202,7 @@ aeneas.net,Aeneas Internet and Telephone,ISP
 aep.com,American Electric Power,Utilities
 aero.org,The Aerospace Corporation,Defense
 aeroinc.net,The Areo Group,Industrial
+aeronetpr.com,AeroNet Wireless Puerto Rico,ISP
 aesbg.net,AESNET,ISP
 aevengroup.com,Aeven,MSP
 aeza.net,Aeza,Web Host
@@ -191,10 +211,12 @@ af-k.de,I-NetPartner GmbH,ISP
 af.mil,U.S. Air Force,Defense
 afes.com,AFES Network Services,ISP
 afghan-wireless.com,Afghan Wireless,ISP
+afghantelecom.af,Afghan Telecom,ISP
 afilias.info,Identity Digital (Afilias),Technology
 afinet.com.br,OnTelecom,ISP
 afnet.net,AFNET,ISP
 afp.com,Agence France-Presse,News
+afr-ix.com,AFR-IX Telecom,ISP
 afranet.com,Afranet,ISP
 africaoncloud.net,Africa on Cloud,IaaS
 afrihost.com,Afrihost,ISP
@@ -212,13 +234,16 @@ agrestelink.com.br,Agreste Link,ISP
 agribank.com,AgriBank,Finance
 agtnet.com.br,AGT Net,ISP
 ahi.ca,Alexandra Hospital,Healthcare
+ahn.org,Allegheny Health Network,Healthcare
 ahold.com,Ahold,Retail
 aholddelhaize.com,Ahold Delhaize,Retail
 ahrt.hu,4iG Telecommunications,ISP
 aichi-colony.jp,Aichi Developmental Disability Center,Healthcare
 aigmedical.com,Affiliates in Gastroenterology,Healthcare
 aila.org,American Immigration Lawyers Association,Nonprofit
+ainet.at,Ainet,ISP
 air-cargo.kiev.ua,Air-Cargo,Logistics
+airadvantage.net,Air Advantage,ISP
 airbus.com,Airbus,Defense
 aircleaningspecialists.com,"Air Cleaning Specialists, Inc.",Industrial
 aircomusa.com,FaxPipe (Formerly AirCom USA),SaaS
@@ -264,9 +289,11 @@ akamaized.net,Akamai,Technology
 akari.hk,Akari Networks HK,ISP
 akilecloud.com,AkileCloud,Web Host
 akkodis.com,AKKODiS,Staffing
+akn.ca,Centrilogic (AKN),MSP
 aknet.kg,AkNet,ISP
 akomp.com.pl,AKOMP,ISP
 akomp.pl,AKOMP,ISP
+akton.si,Akton,ISP
 akura.ne.jp,Akura,Logistics
 alabama.gov,The State of Alabama,Government
 alagoinhastelecom.psi.br,Alagoinhas Telecom,ISP
@@ -302,16 +329,20 @@ aliyun.com,Alibaba Cloud,Web Host
 aljeel.ly,Aljeel Aljadeed,ISP
 alkimnet.net,Alkim Basin Yayin Iletisim,ISP
 all-in-1.com,All In One,Technology
+all-inkl.com,ALL-INKL,Web Host
+allalphacloud.com,AllAlphaCloud (Malakmadze Web),Web Host
 allamericanspeakers.com,All American Speakers Bureau,Event Planning
 allconecta.net.br,All Conecta,ISP
 allete.com,ALLETE,Utilities
 alliancebroadband.co.in,Alliance Broadband,ISP
 alliancebroadband.in,Alliance Broadband,ISP
+alliancecom.net,Alliance Communications,ISP
 allianzsna.com,SNA Insurance,Finance
 alliedtelecom.net,Allied Telecom,ISP
 alligacom.com,TrueCommerce,SaaS
 allinahealth.org,Allina Health,Healthcare
 allocommunications.com,ALLO,ISP
+allpointsbroadband.com,All Points Broadband,ISP
 allpointsfibre.uk,AllPoints Fibre,ISP
 allrede.com.br,Allrede Telecom,ISP
 allrede.tec.br,Allrede,ISP
@@ -335,6 +366,7 @@ altafiber.com,altafiber,ISP
 altafibra.mx,Altafibra,ISP
 altarede.com.br,AltaRede,ISP
 altayer.om,Al-Tayer Engineering Services,Construction
+altegrosky.ru,AltegroSky,ISP
 altel.kz,Atal,ISP
 altemica.net,Altemica,MSP
 alterway.fr,Alter Way,MSP
@@ -347,7 +379,9 @@ altnet.md,Altnet,ISP
 altovalenet.com.br,Alto Vale Net,ISP
 alwaysdata.com,alwaysdata,Web Host
 alwaysdata.net,alwaysdata,Web Host
+amadeus-it.com,Amadeus IT Group,SaaS
 amatechtel.com,AMA TechTel,ISP
+amatisnetworks.com,amatis,MSP
 amazon.com,Amazon,Technology
 amazonasnettelecom.com.br,Amazonas Net,ISP
 amazonaws.com,Amazon Web Services (AWS),PaaS
@@ -372,6 +406,7 @@ amerinoc.com,AmeriNOC,Web Host
 ameslab.gov,Ames Laboratory,Government
 amethyst.co.jp,Amethyst,Healthcare
 amfam.com,American Family Insurance,Finance
+amis.hr,A1 Croatia (Amis),ISP
 amobia.com,Amobia,ISP
 ampernet.com.br,Ampernet,ISP
 amplia.co.tt,AMPLIA,ISP
@@ -379,6 +414,7 @@ amplifyapp.com,Amazon AWS,PaaS
 amplitudo.me,Amplitudo,SaaS
 amres.ac.rs,AMRES,Education
 amur.ru,Rostelecom Amur,ISP
+an-net.ru,Annet Tver,ISP
 analabs.com.sg,ANALABS,Construction
 andorratelecom.ad,Andorra Telecom,ISP
 andrews.edu,Andrews University,Education
@@ -388,9 +424,11 @@ anexia-it.com,Anexia,Web Host
 anexia.com,Anexia,Web Host
 angolatelecom.com,Angola Telecom,ISP
 anid.com.br,ANID,Nonprofit
+ankara.edu.tr,Ankara University,Education
 anl.gov,Argonne National Laboratory,Government
 anonet.in,Anonet,ISP
 ans.co.uk,ANS,MSP
+anschlusswerk.de,AnschlussWerk,ISP
 ansto.gov.au,Australian Nuclear Science and Technology Organisation,Government
 antagonist.cloud,Antagonist,Web Host
 antboxnetworks.com,Antbox Networks,Web Host
@@ -406,6 +444,7 @@ antispameurope.com,Hornetsecurity,Email Security
 anydigital.sg,AnyDigital,Web Host
 anylogic.com,AnyLogic,SaaS
 aoc.gov,Architect of the Capitol,Government
+aofidc.com,Aofei Data International,Web Host
 aoiot.ru,IOT (Skolkovo),IaaS
 aopa.org,AOPA,Travel
 aoyama.ac.jp,Aoyama Gakuin University,Education
@@ -413,16 +452,19 @@ apa-it.at,APA-Tech,MSP
 apa.at,APA-Tech,MSP
 apaudit.eu,Transparent,Finance
 apexsol.com,Apex Technology,Marketing
+aphp.fr,APHP Paris Hospitals,Healthcare
 aplusgroup.net,A Plus International,Healthcare
 apnic.net,APNIC,Nonprofit
 apogee.us,Boldyn,ISP
 apogeehost.com,ApogeeHOST,Web Host
 apol.com.tw,APOL,ISP
 app-ionos.space,IONOS,Web Host
+app-tec.com,Applied Technologies,ISP
 apple.com,Apple,Email Provider
 applefibernet.com,Apple Fibernet,ISP
 applicationx.net,Application X,MSP
 appliedmaterials.com,Applied Materials,Manufacturing
+appliwave.com,Eurofiber France (Appliwave),ISP
 appnexus.com,Microsoft Advertising (Xandr),Marketing
 appriver.com,OpenText AppRiver,Email Security
 apps-1and1.com,IONOS,Web Host
@@ -442,7 +484,9 @@ aragon.es,Government of Aragon,Government
 araguaianetmt.com.br,ARAGUAIANET,ISP
 aramcoinc.com,Saudi Aramco,Industrial
 arapabruzzo.it,ARAP,Industrial
+arax.md,Arax-Impex,ISP
 archerirm.us,Archer GRC,SaaS
+archtopfiber.com,Archtop Fiber,ISP
 arcor-ip.net,Vodafone,ISP
 ardc.net,Amateur Radio Digital Communications,Nonprofit
 arelion.com,Arelion,ISP
@@ -456,6 +500,7 @@ arikiinternet.com.br,Ariki Internet,ISP
 ariskisp.com,Arisk Communications,ISP
 aristotle.net,Aristotle Internet,ISP
 arizona.edu,University of Arizona,Education
+arkaden.se,Arkaden Konsult,MSP
 arkansas.gov,Arkansas Government,Government
 arkdna.com,ARK Data Centers,Web Host
 arkitech.it,Arkitech,Technology
@@ -464,6 +509,7 @@ armstrongonewire.com,Armstrong,ISP
 arnes.si,ARNES,Education
 arosscloud.com,AROSSCLOUD,Web Host
 arpinet.am,Arpinet,ISP
+arqiva.com,Arqiva,ISP
 arsat.com.ar,ARSAT,ISP
 arsys.net,Arsys,Web Host
 artectelecom.net,Artec Telecom,ISP
@@ -471,6 +517,8 @@ artehosting.com.mx,Artehosting,Web Host
 artelecom.pt,AR Telecom,ISP
 arteria-net.com,ARTERIA Networks,ISP
 artfiles.de,Artfiles,Web Host
+artnet.pl,Artnet,Web Host
+artx.ru,ArtX,ISP
 aruba.it,Aruba.it,Web Host
 arvancloud.ir,Arvancloud,IaaS
 arvato-systems.de,Arvato Systems,MSP
@@ -497,6 +545,7 @@ asem-tech.com,ASEMtech,Industrial
 aserv.co.za,Afrihost,ISP
 asfsteelco.com,ASF Steel,Manufacturing
 ashtelstudios.com,Ashtel Studios,Healthcare
+asiacell.com,Asiacell,ISP
 asiaitserver.com,Asia IT Solution Co.,MSP
 asianaidt.com,Asiana IDT,MSP
 asianet.co.th,Ttur Internet Corporation,ISP
@@ -506,6 +555,7 @@ asiatech.ir,Asiatech Data Transmission,ISP
 asiera.ie,Asiera,Education
 ask4.com,ASK4,ISP
 askbis.com,BIS,Web Host
+askiran.com,Andishe Sabz Khazar,Web Host
 asklepios.com,Asklepios,Healthcare
 asl2.liguria.it,ASL2,Healthcare
 asmecal.it,ASMENET CALABRIA,Government
@@ -516,17 +566,22 @@ assentportal.com,Assent,SaaS
 assp.org,American Society of Safety Professionals,Healthcare
 asta-net.pl,Asta-Net,ISP
 astate.edu,Arkansas State University,Education
+astel.kz,Freedom Satellite (Astel),ISP
 asteria.com,Asteria,SaaS
 astound.com,Astound Broadband,ISP
 astralinfo.co.uk,Astral Informatics,Marketing
 asu-vei.ru,ASU-VEI,Industrial
 asu.edu,Arizona State University,Education
+asvt.ru,ASVT,ISP
 at-home.ru,еТелеком,ISP
 atb-nett.no,ATB-Nett (Telefiber),ISP
+atea.dk,Atea,MSP
 ateky.net.br,Ateky Internet,ISP
 atextelecom.com.br,ATEX Telecom,ISP
+athenet.net,NTD Networks (Athenet),ISP
 athleanx.com,ATHLEAN-X,Retail
 ati.org,ATI Advanced Technology International,Defense
+ati.pe.gov.br,ATI Pernambuco,Government
 ati.tn,Agence Tunisienne d'Internet,Government
 atiinternet.com.br,ATI Internet,ISP
 atlantech.net,Atlantech Online,ISP
@@ -540,6 +595,7 @@ atman.pl,Atman,IaaS
 atmc.com,Focus Broadband (ATMC),ISP
 atmc.net,FOCUS Broadband,ISP
 atni.com,ATN International,ISP
+atom86.net,atom86,ISP
 atomic.ac,Atomic,ISP
 atonementonline.com,Our Lady of the Atonement,Religion
 atos.net,Atos,Consulting
@@ -547,6 +603,8 @@ ats.ca,ATS Healthcare,Healthcare
 att.com,AT&T,ISP
 att.net,AT&T,ISP
 attachmate.com,Attachmate (Rocket Software),Technology
+attokyo.co.jp,AT Tokyo,Web Host
+atw.co.hu,ATW.hu RendszerNET,Web Host
 atw.jp,ATW,Web Host
 atw.ne.jp,ATW,Web Host
 au-net.ne.jp,KDDI,ISP
@@ -555,6 +613,7 @@ au.edu,Assumption University of Thailand,Education
 auburn.edu,Auburn University,Education
 auckland.ac.nz,University of Auckland,Education
 audi.com,Audi,Automotive
+augsburg.edu,Augsburg University,Education
 augusta.edu,Augusta University,Education
 auone-net.jp,KDDI,ISP
 aup.edu.pk,"University of Agriculture, Peshawar",Education
@@ -571,6 +630,7 @@ autodesk.com,Autodesk,SaaS
 automattic.com,Automattic,SaaS
 autoplus.bg,Auto Plus Bulgaria,Automotive
 autotask.net,Kaseya,SaaS
+avagotech.com,Broadcom,Manufacturing
 avalon.hr,cyber_Folks,Web Host
 avanta-telecom.ru,Аванта Телеком,ISP
 avantel.ru,Avantel,ISP
@@ -580,22 +640,27 @@ avatel.es,Avatel,ISP
 avato.com.br,Brasil TecPar,ISP
 avaya.com,Avaya,Technology
 avci.net,Agri-Valley Communications,ISP
+avency.de,avency,MSP
 aveniq.ch,Aveniq,MSP
 aventelfrance.com,Aventel,ISP
 aventelkz.com,Aventel,ISP
 averypartners.net,Avery Partners,Healthcare
+aviel.ru,Aviel Ramenskoye,ISP
 avis.ne.jp,Densan Avis,ISP
 aviso.ci,Orange,ISP
+avk-com.ru,Avk-Computer,ISP
 avnam.net,VPS Argentina,Web Host
 awasr.om,Awasr,ISP
 awm.com.tr,Yöncü Bilişim Çözümleri Limited Şirketi,Web Host
 awn.co.th,AIS Advanced Wireless Network,ISP
 awsapprunner.com,Amazon AWS,PaaS
 awusa.net,All West Communications,ISP
+axa.com,AXA,Finance
 axarnet.es,Axarnet,Web Host
 axelspringer.com,Axel Springer,Publishing
 axera.it,Axera,ISP
 axioma24.ru,Axioma,ISP
+axione.fr,Axione,ISP
 axsbolivia.com,AXS Bolivia,ISP
 axspace.com,AXspase,Web Host
 axtel.mx,Axtel,ISP
@@ -604,9 +669,12 @@ axtelcorp.mx,Axtel,ISP
 ayalaland.com,Ayala Land,Real Estate
 ayalaland.com.ph,Ayala Land,Real Estate
 ayera.com,Ayera,ISP
+ayy.fi,Aalto University Student Union,Education
 azecom.com.br,Azecom Internet,ISP
 azercell.com,Azercell,ISP
 azeronline.com,Azeronline,ISP
+azertelecom.az,AzerTelecom,ISP
+azintelecom.az,AzInTelecom,ISP
 azmoves.com,Coldwell Banker,Real Estate
 azregents.edu,Arizona Board of Regents,Education
 azteca-comunicaciones.com,Aztec Communications Columbia,ISP
@@ -617,6 +685,7 @@ azureedge.net,Microsoft Azure,Technology
 azurestaticapps.net,Microsoft Azure,PaaS
 azurewebsites.net,Microsoft Azure,PaaS
 azza.net.br,Azza,ISP
+b4rn.org.uk,B4RN,ISP
 babilon-t.com,Babilon-T,ISP
 babson.edu,Babson College,Education
 backland.net,Backland Communications,MSP
@@ -635,12 +704,14 @@ bandwidth.co.uk,Bandwidth Technologies,ISP
 bangla.net,ISN Bangla,ISP
 bank-banque-canada.ca,Bank of Canada,Government
 bankofamerica.com,Bank of America,Finance
+banxico.org.mx,Banco de Mexico,Government
 barak-online.net,Netvision,ISP
 barclays.co.uk,Barclays,Finance
 baremetal.co.za,Baremetal,ISP
 barings.com,Barings,Finance
 barracuda.com,Barracuda,Email Security
 barvanet.kz,Barvanet,MSP
+basefarm.com,Orange Business (Basefarm),IaaS
 basf.com,BASF,Industrial
 bashtel.ru,Bashtel,ISP
 basicserver.io,Zitcom,Web Host
@@ -652,16 +723,20 @@ battelle.org,Battelle Memorial Institute,Science
 bausch.com,Bausch and Lomb,Healthcare
 baxetgroup.com,Baxet Group,Web Host
 bayada.com,BAYADA Home Health Care,Healthcare
+baycix.de,BayCIX,Web Host
 bayer.com,Bayer,Healthcare
 bayer.de,Bayer,Healthcare
 baykonur.ru,Baykonur Svyazinform,ISP
 baylor.edu,Baylor University,Education
 baynet.ne.jp,Tokyo Bay Network,ISP
+bayobab.africa,Bayobab (MTN GlobalConnect),ISP
 bayoulandcs.com,Bayouland Computer Solutions,MSP
+bb-niigata.jp,Niigata Communication Service,ISP
 bb.com.br,Banco do Brasil,Finance
 bbbell.it,BBBell,ISP
 bbc.com,BBC,News
 bbemaildelivery.com,BombBomb,Marketing
+bbix.net,BBIX,ISP
 bbned.nl,Odido,ISP
 bbnetup.com,BBNET UP,ISP
 bbnetup.com.br,BBNET UP,ISP
@@ -670,9 +745,13 @@ bbtel.com,BBTEL,ISP
 bbtower.co.jp,BroadBand Tower,Web Host
 bc.edu,Boston College,Education
 bc.net,BCNET,Education
+bc9.ne.jp,Kanuma Cable Television,ISP
 bcbsm.com,Blue Cross Blue Shield of Michigan,Healthcare
+bcbsnc.com,Blue Cross Blue Shield of North Carolina,Healthcare
+bcc.co.ug,Blue Crane Communications Uganda,ISP
 bcdtravelmexico.com.mx,BCD Travel Mexico,Travel
 bcit.ca,British Columbia Institute of Technology,Education
+bclan.ru,BCLan,ISP
 bcm.edu,Baylor College of Medicine,Education
 bcnetsp.com.br,BC Net,ISP
 bcs.org,BCS,Nonprofit
@@ -686,6 +765,8 @@ beanfield.com,Beanfield,ISP
 bearingdepot.com,Bearing Depot & Supply,Retail
 beaumont.org,Corewell Health (Formerly Beaumont),Healthcare
 bec.uk,BE Computing,IaaS
+becfiber.com,BEC Fiber,ISP
+beckman.com,Beckman Coulter,Healthcare
 bedag.ch,Bedag Informatik,MSP
 bedbathandbeyond.com,Bed Bath & Beyond,Retail
 bedge.com,BEDGE,Web Host
@@ -702,12 +783,14 @@ bek.coop,BEK Communications,ISP
 bekkoame.co.jp,BEKKOAME,ISP
 bektel.com,BEK Communications,ISP
 belairinternet.com,Zentro Internet,ISP
+belcloud.net,Belcloud,Web Host
 bell.ca,Bell Canada,ISP
 bell.net,Bell Canada,ISP
 belnet.be,BELNET,Education
 belong.com.au,Belong (Telstra),ISP
 beltelecom.by,Beltelecom,ISP
 belwue.de,BelWü,Education
+benintelecoms.bj,SBIN Benin,ISP
 benkan.co.jp,Benkan,Industrial
 benlomandconnect.com,Ben Lomand Rural Telephone Cooperative,ISP
 beotel.net,BeotelNet,ISP
@@ -716,12 +799,14 @@ berkeley.edu,UC Berkley,Education
 bernco.gov,Bernalillo County,Government
 berneyassocies.com,Berney Associés,Consulting
 bernofarm.com,Bernofarm,Healthcare
+best.net.ua,Best ISP,ISP
 bestbuy.com,Best Buy,Retail
 bestel.com.mx,Bestel,ISP
 bestwestern.com,Best Western,Travel
 bethel.edu,Bethel University,Education
 betterhomeowners.com,InTouch Systems,Marketing
 bevcomm.net,Bevcomm,ISP
+beyond.pl,Beyond.pl,Web Host
 bezeq.co.il,Bezeq,ISP
 bezeqint.net,Bezeq International,ISP
 bfh.ch,Berner Fachhochschule,Education
@@ -731,6 +816,9 @@ bgsu.edu,Bowling Green State University,Education
 bgwan.com,VarnaLan (Geodim),ISP
 bhtelecom.ba,BH Telecom,ISP
 bia.gov,US Bureau of Indian Affairs,Government
+biaman.pl,BIAMAN Poznan,Education
+bics.com,BICS Belgacom International,ISP
+bigbend.net,Big Bend Telephone,ISP
 bigbiz.com,BigBiz Internet Services,Web Host
 bigcommerce.net,BigCommerce,SaaS
 bigleaf.net,Bigleaf Networks,ISP
@@ -758,14 +846,18 @@ bisping.de,Bisping & Bisping,ISP
 bisv.ru,Bisv.ru,ISP
 bit-drive.ne.jp,NURO Biz,ISP
 bit.nl,BIT BV,Web Host
+bitco.co.za,BitCo,ISP
+bitcom.com.br,Bitcom Internet Fibra,ISP
 bite.lt,Bite,ISP
 bite.lv,Bite,ISP
 bitel.com.pe,Bitel,ISP
 bitel.de,BITel Bielefeld,ISP
 biterika.ru,Biterika,Web Host
+bitiora.com,Bitiora,ISP
 bitmail.com.br,Bitmail Telcom,ISP
 biznetgio.com,Biznet Gio,IaaS
 biznetnetworks.com,Biznet Networks,ISP
+bjarekraft.se,Bjare Kraft,Utilities
 bjc.org,BJC HealthCare,Healthcare
 bkm.uz,Uzbektelekom,ISP
 bkup.com.br,Bkup Telecom,ISP
@@ -778,6 +870,8 @@ blacksun.ca,MSP Corp,Web Host
 blanksoft.dev,BlankSoft,MSP
 blazenet.biz,BlazeNet,ISP
 blazingseollc.com,Rayobyte (Blazing SEO),SaaS
+blc.fi,BLC Telecom,ISP
+bledsoe.net,BTC Fiber (Bledsoe),ISP
 bleucloud.fr,Bleu,IaaS
 blic.net,Supernova,ISP
 blickle.com,Blickle,Manufacturing
@@ -789,7 +883,9 @@ bloomberg.com,Bloomberg,Finance
 blowtech.com.tw,Blowplas Technology,Manufacturing
 bls.gov,U.S. Bureau of Labor Statistics,Government
 bluebirdnetwork.com,Bluebird Fiber,ISP
+bluegrassnetwork.com,Bluegrass Network,ISP
 bluehost.com,Bluehost,Web Host
+blueline.mg,Gulfsat (Blueline) Madagascar,ISP
 bluemission.net,Blue Mission,Web Host
 bluesea.org,Blue Sea Foundation,Marketing
 bluestreamfiber.com,Blue Stream Fiber,ISP
@@ -797,9 +893,11 @@ bluetie.com,BlueTie,MSP
 bluevalley.net,Blue Valley,ISP
 bluevps.com,BlueVPS,Web Host
 blueweb.co.kr,BlueWeb,Web Host
+blufibre.ca,BLU Fibre Networks,ISP
 bme.hu,Budapest University of Technology and Economics,Education
 bmhcc.org,Baptist Memorial Health Care,Healthcare
 bmjnet.com.br,BMJ Net,ISP
+bn.by,Business Network Belarus,ISP
 bnehost.com.au,Bnehosting,Web Host
 bnet-bd.com,Business Network,ISP
 bnet.com.br,Bnet Telecom,ISP
@@ -812,6 +910,7 @@ bnymellon.com,BNY Mellon,Finance
 boavistanet.net.br,Boa Vista Net,ISP
 boeing.com,Boeing,Defense
 bof.fi,Bank of Finland,Government
+bofinet.co.bw,Botswana Fibre Networks,ISP
 bohc.co.jp,Benefit One Inc.,Retail
 boisestate.edu,Boise State University,Education
 boku.ac.at,University of Natural Resources and Life Sciences Vienna,Education
@@ -869,21 +968,26 @@ brightok.net,BrightNet Oklahoma,ISP
 brightridge.com,BrightRidge,Utilities
 brightspace.com,D2l Brightspace,SaaS
 brightspeed.com,Brightspeed,ISP
+brightstar.uk,Brightstar,ISP
 brinkster.com,Brinkster,Web Host
 brisanet.com.br,Brisanet,ISP
 brisanet.net.br,Brisianet,ISP
+briteline.de,Bremen Briteline,ISP
 britishairways.com,British Airways,Travel
 briz.ua,BRIZ,ISP
 brking.com.br,Brking,ISP
 brmaster.com.br,BRMaster,ISP
 broadband.hu,One Hungary,ISP
 broadbandidc.com,BROADBANDIDC,Web Host
+broadbandsolutions.com.au,Broadband Solutions Australia,ISP
+broadbandvision.net,Broadband Vision,ISP
 broadcom.com,Broadcom Enterprise Messaging Security,Email Security
 broadridge.com,Broadridge,Finance
 brockport.edu,SUNY Brockport,Education
 brocku.ca,Brock University,Education
 brown.edu,Brown University,Education
 brownrice.com,Brownrice Internet,Web Host
+brsk.co.uk,Brsk,ISP
 brucepower.com,Bruce Power,Utilities
 brynmawr.edu,Bryn Mawr College,Education
 bs-telecom.net,БС-Телеком (BS-Telecom),ISP
@@ -891,12 +995,14 @@ bsc.rw,Broadband Systems Corporation,ISP
 bsconect.com.br,BS Conect,ISP
 bsd.nl,BSD Software Development,Technology
 bsd405.org,Bellevue School District,Education
+bsdnetwork.com.br,MHNET Telecom,ISP
 bse.ch,SolNet,ISP
 bsnews.com.br,BS News,ISP
 bsnl.co.in,BSNL,ISP
 bsnl.in,BSNL,ISP
 bsp.com.bn,Brunei Shell Petroleum,Industrial
 bsu.edu,Ball State University,Education
+bt.bt,Bhutan Telecom,ISP
 bt.com,BT,ISP
 bta.net.cn,China Networks Inter-Exchange,ISP
 btc-net.bg,Viacom,ISP
@@ -905,6 +1011,7 @@ btcbahamas.com,BTC Bahamas Telecommunications,ISP
 btcentralplus.com,BT,ISP
 btcl.com.bd,Bangladesh Telecommunications Company,ISP
 btcl.gov.bd,BTCL Bangladesh Telecommunications,ISP
+btes.net,BTES Bristol Tennessee,Utilities
 btopenworld.com,BT,ISP
 btussel.com,Bug Tussel,ISP
 btvm.ne.jp,BTV,ISP
@@ -914,6 +1021,7 @@ buckeye.com,Buckeye Partners,Utilities
 buckeyebroadband.com,Buckeye Broadband,ISP
 buckeyebusiness.net,Buckeye Business Solutions,MSP
 bucknell.edu,Bucknell University,Education
+buenahosting.com,Buena Hosting,Web Host
 buffalo.edu,University at Buffalo,Education
 buffalostate.edu,Buffalo State College,Education
 bugtusselwireless.com,Bug Tussel,ISP
@@ -922,6 +1030,7 @@ bulloch.net,Bulloch County RTC,ISP
 bulsat.com,Bulsatcom,ISP
 bumblebeelinens.com,Bumbletree Linens,Retail
 bumrungrad.com,Bumrungrad International Hospital,Healthcare
+bund.de,German Federal Government,Government
 bunkaren.or.jp,Japan Culture and Welfare Federation of Agricultural Cooperatives,Agriculture
 bunnycommunications.com,Bunny Communications,ISP
 bunnytechnology.net,Bunny Technology,ISP
@@ -929,6 +1038,7 @@ burlingtontelecom.com,Burlington Telecom,ISP
 burlingtontelecom.net,Burlington Telecom,ISP
 burnhamholdings.com,Burnham Holdings,Industrial
 buroserv.net.au,Brunoserv,ISP
+burstfire.net,Burstfire Networks,ISP
 busse-computer.de,Busse Computertechnik,MSP
 busse.cloud,Busse Computertechnik,MSP
 buysecure.com,Monmouth Internet,Web Host
@@ -968,6 +1078,7 @@ cabq.gov,City of Albuquerque,Government
 cairohost.com,Black Host,Web Host
 caiway.nl,Caiway,ISP
 caiweb.net.br,Caiweb,ISP
+cal.net,Cal.net,ISP
 calero.com,Calero,MSP
 calltower.com,CallTower,SaaS
 calpoly.edu,Cal Poly,Education
@@ -976,13 +1087,18 @@ calvin.edu,Calvin University,Education
 cam.ac.uk,University of Cambridge,Education
 campaigner.com,Campaigner,Marketing
 camtel.cm,Camtel,ISP
+camtel.com,Cameron Communications,ISP
+canaca.com,Canaca,Web Host
 canadianwebhosting.com,Canadian Web Hosting,Web Host
 canalplustelecom.com,Canal+ Telecom,ISP
 canar.sd,Canar Telecom Sudan,ISP
+canbytel.com,DirectLink (Canby Telephone),ISP
 cancer.gov,National Cancer Institute,Government
 cancom.com,CANCOM Austria,MSP
 cancom.de,CANCOM,MSP
+canet.ne.jp,Imizu Cable Network,ISP
 canisius.edu,Canisius University,Education
+canl.nc,CANL New Caledonia,ISP
 canon-its.co.jp,Canon IT Solutions,MSP
 canonet.ne.jp,Canonet,MSP
 canonical.com,Canonical,Technology
@@ -1006,6 +1122,7 @@ cargill.com,Cargill,Agriculture
 carleton.ca,Carleton University,Education
 carleton.edu,Carlton College,Education
 carnet.hr,CARNET,Education
+carnivalcorp.com,Carnival Corporation,Travel
 carrd.co,Carrd,SaaS
 carrierzone.com,carrierzone,Email Security
 carrytel.ca,Carrytel,ISP
@@ -1013,12 +1130,14 @@ carsforkids.org,Cars For Kids,Nonprofit
 cas.org,Chemical Abstracts Service,Publishing
 casablanca.cz,Casablanca INT,Web Host
 case.edu,Case Western Reserve University,Education
+casscomm.com,CassComm,ISP
 castrum.com.br,Castrum Internet,ISP
 cat.com,Caterpillar,Industrial
 cat.net.th,National Telecom (Thailand),ISP
 catawba.edu,Catawba College,Education
 catnet.jp,Honjo Cable,ISP
 catonetworks.com,Cato Networks,SaaS
+catv296.co.jp,296 Broad Net,ISP
 catvmics.ne.jp,Mics Network,ISP
 cau.ac.kr,Chung-Ang University,Education
 cbe.ae,CBE,Construction
@@ -1030,19 +1149,25 @@ cbu.ca,Cape Breton University,Education
 cbwchc.org,Charles B. Wang Community Health,Healthcare
 cc9.jp,Cable TV Tochigi (CC9),ISP
 ccac.edu,Community College of Allegheny County,Education
+ccapcable.com,CCAP Cable,ISP
 ccc-group.com,Canada Colors and Chemicals Limited (CCC),Industrial
 ccc.co.il,Triple C Cloud Computing,Web Host
 cccd.edu,Coast Community College District,Education
 cccoe.k12.ca.us,Contra Costa County Office of Education,Education
 cccs.edu,Colorado Community Colleges System,Education
 ccinternet.cz,CC Internet,ISP
+ccr.net,CCR Solutions,MSP
 ccs.co.kr,CCS,ISP
 ccsd.net,Clark County School District,Education
+ccsleeds.co.uk,CCS Leeds,ISP
 cctv.com,China Central Television,News
 cdbhospital.com,CBD Hospital,Healthcare
 cdc.gov,US Centers for Disease Control and Prevention,Government
 cdkglobal.com,CDK Global,SaaS
+cdlan.it,CDLAN,Web Host
+cdm.com,CDM Smith,Consulting
 cdn77.com,CDN77,Web Host
+cdnetworks.com,CDNetworks,SaaS
 cdnvideo.com,CDNvideo,SaaS
 cdsglobalcloud.com,CDS Global Cloud,Web Host
 cdt.ca,CDT Connexion,MSP
@@ -1051,6 +1176,9 @@ cdu.edu.au,Charles Darwin University,Education
 cdw.com,CDW,MSP
 cea.fr,CEA,Government
 cec-ltd.co.jp,Computer Engineering & Consulting,MSP
+cedia.edu.ec,CEDIA Ecuador R&E Network,Education
+cegecom.lu,Cegecom Luxembourg,ISP
+cegeka.com,Cegeka,MSP
 cei.gov.cn,China eGovNet Information Center,Government
 celcom.com.my,Celcom Axiata,ISP
 celeo.net,Celeonet,Web Host
@@ -1058,10 +1186,13 @@ celerity.ec,Celerity (Puntonet),ISP
 celeste.fr,CELESTE,ISP
 cellc.co.za,Cell C,ISP
 cellcom.co.il,Cellcom Israel,ISP
+cellkabel.hu,Celldomolki Kabeltelevizio,ISP
 cello.co.nz,Cello Group,ISP
 celsiainternet.com,Celsia Internet,ISP
+cenet.catholic.edu.au,CEnet Catholic Education Network,Education
 cenic.org,CENIC,Nonprofit
 cenitex.vic.gov.au,Cenitex,Government
+centene.com,Centene,Healthcare
 centerasecurity.com,Centera Email Defence,Email Security
 centerasecurity.dk,Centera Email Defence,Email Security
 centersquaredc.com,Centersquare (Csquare),Web Host
@@ -1080,23 +1211,30 @@ centrin.net.id,Centrin Utama,ISP
 centurylink.com,CenturyLink,ISP
 centurylink.com.pe,Cirion,MSP
 centurylink.net,CenturyLink,ISP
+cerberusnetworks.co.uk,Cerberus Networks,ISP
 cerebel.com,CereBel Interactive,Marketing
 cerner.com,Cerner,Healthcare
 cernet.edu.cn,CERNET,Education
+cert.lv,CERT.LV,Government
 certh.gr,CERTH Centre for Research and Technology Hellas,Science
 certha.net,Certha.Net,ISP
 certronic.com.ar,Certronic,SaaS
 certronic.io,Certronic,SaaS
 certto.com.br,Certto,ISP
 cesnet.cz,CESNET,Education
+cesop.com.ar,CESOP Argentina,ISP
 cetin.cz,CETIN,ISP
 cetin.hu,CETIN Hungary,ISP
 cetin.rs,CETIN,ISP
+cetinbg.bg,CETIN Bulgaria,ISP
 ceystel.com.ar,CeySTEL,ISP
 ceznet.cz,ČEZNET,ISP
 cfe.mx,CFE,Utilities
+cfec.com,Central Florida Electric Cooperative,Utilities
 cfolks.pl,cyber_Folks,Web Host
+cfu.net,Cedar Falls Utilities,Utilities
 cgates.lt,Cgates,ISP
+cgc.ge,CGC Georgia,ISP
 cgi.com,CGI,Consulting
 cgi.se,CGI,Consulting
 cgwic.com,China Great Wall Industry Corporation,Defense
@@ -1105,6 +1243,7 @@ ch-saintcalais.fr,Centre Hospitalier du Mans,Healthcare
 chaiyohosting.com,Chaiy oHosting,Web Host
 chalmers.se,Chalmers University of Technology,Education
 changethatup.com,Change That Up,Healthcare
+charlottecolo.com,Charlotte Colocation,Web Host
 charter.com,Charter,ISP
 charter.net,Charter,ISP
 chartercom.com,Charter,ISP
@@ -1117,6 +1256,7 @@ checkpoint.com,Check Point Software,Email Security
 cheetahmail.com,Marigold,SaaS
 chello.sk,UPC,ISP
 cherryservers.com,Cherry Servers,Web Host
+chesco.net,Chesconet,Education
 chess.no,Telia Norge,ISP
 chevron.com,Chevron,Industrial
 chiba-u.jp,Chiba University,Education
@@ -1135,7 +1275,9 @@ chinatietong.com,China TieTong,ISP
 chinaunicom.cn,China Unicom,ISP
 chinaunicomglobal.com,China Unicom Global,ISP
 chinaxingye.com,Suzhou Sinye Materials Technology,Industrial
+chl.com,CHL,ISP
 chop.edu,Children's Hospital of Philadelphia,Healthcare
+chosun.ac.kr,Chosun University,Education
 chrobinson.com,C.H. Robinson,Logistics
 chronos.com.tr,Chronos Teknoloji,Technology
 chrysler.com,Stellantis North America,Automotive
@@ -1144,23 +1286,30 @@ chu-lyon.fr,Hospices Civils de Lyon,Healthcare
 chubu.ac.jp,Chubu University,Education
 chukai.co.jp,Chukai Television,ISP
 chula.ac.th,Chulalongkorn University,Education
+chungbuk.ac.kr,Chungbuk National University,Education
 chuo-u.ac.jp,Chuo University,Education
+chupicom.jp,Chupicom,ISP
 churchdev.com,ChurchDev,Web Host
 cibc.com,CIBC,Finance
 ciberlynx.com,CiberLynx,Technology
 cica.es,CICA Centro Informatico Cientifico de Andalucia,Science
 cicese.edu.mx,CICESE,Education
+cigna.com,Cigna,Healthcare
 ciktel.com,CIK Telecom,ISP
 cilio.io,Cilio,SaaS
 ciliotech.com,Cilio,SaaS
 cimcorp.com,Cimcorp,Industrial
 cincinnatibell.com,altafiber,ISP
+cineca.it,CINECA,Science
+cinia.fi,Cinia,ISP
 cinternetbycat.com,National Telecom,ISP
+cinvestav.mx,Cinvestav,Education
 cipherwave.co.za,Cipherwave,ISP
 circit.de,CircIT,MSP
 circleamedical.com,Circle A Medical,Healthcare
 cirrushosting.com,Cirrus Hosting,Web Host
 cisco.com,Cisco,Technology
+cisp.com,CISP Community ISP,ISP
 citadel.edu,The Citadel,Education
 citec.com.au,CITEC (Queensland Government),Government
 citic.com,CITIC,Conglomerate
@@ -1171,6 +1320,7 @@ citycable.ch,Lausanne SiL Multimedia,ISP
 citycom-austria.com,Citycom Austria,ISP
 cityemail.com,CityEmail,Email Provider
 cityfibre.com,CityFibre,ISP
+citylink.pro,CityLink Petrozavodsk,ISP
 citynet.kg,Citynet KG,ISP
 citynet.net,Citynet,ISP
 cityoftacoma.org,City of Tacoma,Government
@@ -1179,15 +1329,18 @@ cityu.edu.hk,City University of Hong Kong,Education
 citywest.ca,CityWest,ISP
 ciu.com.uy,Cámara de Industrias del Uruguay,Nonprofit
 cizgi.net.tr,Cizgi Telekomunikasyon,ISP
+cj2.nl,CJ2 Hosting,Web Host
 cjas.org,Cornell Anime Club,Education
 ckt.net,Craw-Kan Telephone Cooperative,ISP
 clackesd.k12.or.us,Clackamas Education Service District,Education
+clara.co.jp,CLARA Group,MSP
 claranet.co.uk,Claranet,Web Host
 claranet.com,Claranet,Web Host
 claremont.edu,Claremont University Consortium,Education
 clarix.com,Clarix,MSP
 clarkson.edu,Clarkson University,Education
 clarksvillede.com,Clarksville Department of Electricity,Utilities
+clarku.edu,Clark University,Education
 claro.com.ar,Claro,ISP
 claro.com.br,Claro,ISP
 claro.com.co,Claro,ISP
@@ -1217,13 +1370,17 @@ clientes-zap-izzi.mx,Izzi Telecom,ISP
 climaideal.com,Clima Ideal,Retail
 clinicamedellin.com,Clínica Medellín,Healthcare
 clinique-saint-george.com,Polyclinique Saint George,Healthcare
+clio.it,Clio (CLIOCOM),ISP
+clodocloud.com,CLODO Cloud Service,Web Host
 clonix.srv.br,Clonix Telecom,ISP
 cloud-mail.jp,CloudMail,Email Provider
 cloud-sec-av.com,Check Point Avanan,Email Security
 cloud.ru,Cloud.ru,IaaS
 cloudaccess.net,CloudAccess.net,Web Host
 cloudapp.net,Microsoft Azure,IaaS
+cloudddos.com,CloudDDoS,Web Host
 cloudezapp.io,EmailHeads.NET,Marketing
+cloudferro.com,CloudFerro,IaaS
 cloudfilter.net,Proofpoint Cloudmark,Email Security
 cloudfirst.host,CloudFirst,Web Host
 cloudflare-email.com,Cloudflare,Email Security
@@ -1238,10 +1395,13 @@ cloudfront.net,Amazon AWS,Technology
 cloudfunctions.net,Google,PaaS
 cloudhost.web.id,PT Cloud Hosting Indonesia,Web Host
 cloudhosting.rs,SBB,ISP
+cloudie.hk,Cloudie HK,Web Host
+clouding.io,Clouding.io,Web Host
 clouditalia.com,Retelit,Web Host
 cloudmark.com,Proofpoint Cloudmark,Email Security
 cloudsite.builders,Rad Web Hosting,Web Host
 cloudsouth.com,Cloud South,Web Host
+cloudvpn.io,Oxylabs (CloudVPN),SaaS
 cloudwaysapps.com,Cloudways,Web Host
 cloudwebhosting.com,NameHero,Web Host
 cloudwm.com,Kamatera (CloudWM),Web Host
@@ -1261,13 +1421,16 @@ cmorlando.com.ar,Carpintería Metálica Orlando,Manufacturing
 cmsinter.net,CMS Internet,ISP
 cmtietong.com,China TieTong,ISP
 cmu.edu,Carnegie Mellon University,Education
+cmvas.co.za,CMVAS,MSP
 cn.at,Cablevision Nöhmer,ISP
 cn.ca,Canadian National Railway,Logistics
+cn.zp.ua,Tvoi Net Zaporizhzhia,ISP
 cn4e.com,35.com,Web Host
 cna.ne.jp,Cable Networks Akita,ISP
 cnci.co.jp,Community Network Center,ISP
 cncm.ne.jp,Nagasaki Cable Media,ISP
 cndata.com,China Telecom,ISP
+cni.net.id,Cyber Network Indonesia,ISP
 cnic.cn,CNIC,Education
 cniteam.com,CNI,ISP
 cnnet.com.br,Conexao Networks,ISP
@@ -1314,6 +1477,7 @@ collascrill.com,Collas Crill,Legal
 collectivhosting.com,Collectiv,Web Host
 collectorsaddition.com,The Collector's Addition,Retail
 collinsaerospace.com,Collins Aerospace,Defense
+colo4jax.com,colo4jax,Web Host
 coloblox.com,Coloblox Data Centers,Web Host
 colocationamerica.com,Colocation America,Web Host
 colocrossing.com,ColoCrossing,ISP
@@ -1323,12 +1487,15 @@ colorado.edu,University of Colorado Boulder,Education
 colorkrew.com.br,Colorkrew,SaaS
 colos.kz,IFC COLOS,Logistics
 colostate.edu,Colorado State University,Education
+colsecor.com.ar,Colsecor,ISP
 colt.net,Colt,ISP
 columbia.edu,Columbia University,Education
+columbus-networks.hn,Liberty Networks Honduras,ISP
 columbus.k12.oh.us,Columbus Public Schools,Education
 columbus.te.ua,MAXNET,ISP
 combell.com,Combell,Web Host
 combolivre.net.br,Connection Multimidia,ISP
+comcap.nl,WorldStream LATAM (Comcap),Web Host
 comcare.gov.au,Comcare,Government
 comcast.com,Comcast,ISP
 comcast.net,Comcast,ISP
@@ -1341,7 +1508,10 @@ comfortel.pro,Comfortel,ISP
 comline.com,West Coast Internet (WCI),ISP
 commbank.com.au,Commonwealth Bank of Australia,Finance
 commerce.gov,US Department of Commerce,Government
+commerzbank.com,Commerzbank,Finance
+commnetwireless.com,Commnet Wireless,ISP
 commonwealthu.edu,Commonwealth University of Pennsylvania,Education
+comms365.com,Comms365,ISP
 communilink.com,CommuniLink,Web Host
 communilink.net,CommuniLink,Web Host
 communitect.com,Solutionreach,SaaS
@@ -1350,6 +1520,7 @@ communitymedical.org,Community Medical Centers,Healthcare
 comnet.bg,Comnet Bulgaria,ISP
 comnet.net.id,Comtronics Systems,MSP
 comnett.com.br,Comnett Provedor de Internet,ISP
+compass.net.nz,Compass NZ,ISP
 complemar.com,Complemar,Logistics
 completecomputers.cc,Complete Computers,MSP
 compliancearchitects.net,Compliance Aarchitects,Healthcare
@@ -1363,14 +1534,17 @@ computerguyz.ca,Computer Guyz,MSP
 computerstlouis.com,Computer St. Louis,MSP
 computronics.com,Computronics,Technology
 comteco.com.bo,Comteco,ISP
+comtrance.net,comtrance,Web Host
 comune.livorno.it,Città di Livorno,Government
 comunitel.net,Vodafone,ISP
 comwave.net,Comwave (Rogers),ISP
+concentrix.com,Concentrix,MSP
 concordia.ca,Concordia University,Education
 concurcompleat.com,Concur Compleat,SaaS
 concursolutions.com,SAP Concur,SaaS
 condosites.com,CondoSites,SaaS
 condosites.net,CondoSites,SaaS
+conduent.com,Conduent,MSP
 conecta.psi.br,Conecta Net,ISP
 conectainternetbandalarga.net.br,Conecta Soluções,ISP
 conectetelecomba.com.br,Conecte Telecom,ISP
@@ -1396,6 +1570,7 @@ connectsul.com.br,Connectsul,ISP
 connectwave.co.kr,ConnectWave,SaaS
 connectworld.psi.br,Connect World Telecom,ISP
 connectzone.in,Connect Broadband,ISP
+connesi.it,Connesi,ISP
 connextelecom.com.br,Connex Fibra,ISP
 conoha.ne.jp,ConoHa,Web Host
 consideredcreative.com,Considered Creative,Marketing
@@ -1411,6 +1586,7 @@ consumeroptions.co.ke,Consumer Options,Consulting
 contabo.com,Contabo,Web Host
 contaboserver.net,Contabo,Web Host
 contato.net,Contato Internet,ISP
+contegix.com,Contegix,Web Host
 continent8.com,Continent 8,Web Host
 convention.co.jp,Japan Convention Services,Marketing
 convergeict.com,Converge,ISP
@@ -1422,6 +1598,7 @@ convergenze.it,Convergenze,ISP
 convergeone.com,C1 (ConvergeOne),MSP
 conwaycorp.com,Conway Corp,ISP
 coolideas.co.za,Cool Ideas,ISP
+coolwavecom.com,Coolwave Communications,ISP
 cooolbox.bg,Cooolbox,ISP
 coopenet.com.ar,Coopenet,ISP
 cooperatelecom.com.br,Coopera Telecom,ISP
@@ -1437,6 +1614,7 @@ corblock.com,Corblock,Industrial
 cordialmail.net,Cordial,Marketing
 core-backbone.com,Core-Backbone,ISP
 coreix.net,Coreix,Web Host
+corenetcloud.com,CORENETCLOUD,Web Host
 corephp.com,corePHP,Marketing
 coreserver.jp,CORESERVER,Web Host
 coresite.com,CoreSite,Web Host
@@ -1457,6 +1635,7 @@ cotas.com,Cotas,ISP
 cotas.com.bo,Cotas,ISP
 cotea.com.ar,COTEA,ISP
 cotecal.com.ar,Cotecal,ISP
+cotelcam.com.ar,Cotelcam Argentina,ISP
 cotton-warehouse.com,Cotton Warehouse Classic Cars,Automotive
 coucou-networks.fr,Free Mobile,ISP
 countyofriverside.us,County of Riverside,Government
@@ -1479,6 +1658,7 @@ cra.cz,České Radiokomunikace,Web Host
 crawkan.net,Craw-Kan Telephone Cooperative,ISP
 crc.ca,Communications Research Centre Canada,Government
 crd.co,Carrd,SaaS
+creanova.org,Creanova,Web Host
 creatingpossibilities.co.uk,Creating Possibilities,Marketing
 creaworld.com.sg,Creative eWorld,Marketing
 credit-agricole.com,Crédit Agricole,Finance
@@ -1502,6 +1682,7 @@ csf.ne.jp,Cable Station Fukuoka (CSF),ISP
 cshl.edu,Cold Spring Harbor Laboratory,Education
 csipiemonte.it,CSI Piemonte,Government
 csiro.au,CSIRO,Science
+csiweb.com,Computer Services Inc (CSI),SaaS
 csl.de,CSL Computer Service Langenbach,ISP
 cslox.com,CS LoxInfo,ISP
 csloxinfo.com,CSL,MSP
@@ -1511,6 +1692,7 @@ csod.com,Cornerstone,SaaS
 cspire.com,C Spire,ISP
 cspirefiber.com,C Spire,ISP
 csr24.com,Applied Systems,SaaS
+css.edu,College of St. Scholastica,Education
 csu.edu.au,Charles Sturt University,Education
 csuc.cat,CSUC,Education
 csufresno.edu,California State University Fresno,Education
@@ -1525,6 +1707,7 @@ ctc-g.co.jp,ITOCHU Techno-Solutions (CTC),MSP
 ctc.co.jp,Chubu Telecommunications,ISP
 ctctel.com,Consolidated Telcom,ISP
 ctedunet.net,Connecticut Education Network,Education
+ctenterprises.org,Tri-Co Connections,ISP
 ctgserver.com,CTG Server,Web Host
 cthosp.org,Connecticut Hospital Association,Nonprofit
 cti.gr,CTI Diophantus Greek Research Institute,Science
@@ -1536,9 +1719,11 @@ ctstelecom.com,CTS Communications,ISP
 ctt.ne.jp,Cable Television Toyama,ISP
 ctvbeam.com,Beam Broadband,ISP
 cty-cns.jp,Suzuka Cable,ISP
+cu.ac.kr,Catholic University of Daegu,Education
 cubiespot.net.id,Cubiespot,ISP
 cuenote.jp,Cuenote,SaaS
 cuhk.edu.hk,Chinese University of Hong Kong,Education
+cullmanec.com,Cullman EC,Utilities
 cultureamp.com,Culture Amp,SaaS
 cumberlandconnect.org,Cumberland Connect,ISP
 cuny.edu,City University of New York,Education
@@ -1552,14 +1737,19 @@ cvtelecom.cv,Cabo Verde Telecom,ISP
 cvtsv.com,Cvent,SaaS
 cw-e.ca,Connecting Windsor-Essex,Nonprofit
 cwc.com,Cable and Wireless Turks and Caicos,ISP
+cwcbusiness.com,Liberty Business Caribbean,ISP
 cwdom.dm,Cable & Wireless Dominica,ISP
 cwmc.com.br,CWMC,ISP
 cwnetworks.com,Liberty Networks,ISP
 cwpanama.net,Cable & Wireless Panama,ISP
 cwru.edu,Case Western Reserve University,Education
+cwseychelles.com,Cable and Wireless Seychelles,ISP
+cwu.edu,Central Washington University,Education
+cy.net,Logosnet Cyprus,ISP
 cybasp.com,CyberlinkASP,Web Host
 cyber-folks.pl,cyber_Folks,Web Host
 cyber.net.pk,Cybernet,ISP
+cybera.ca,Cybera Alberta,Education
 cybera.net,Cybera,ISP
 cybercon.com,Digital Space (Cybercon),Web Host
 cyberfolks.hr,cyber_Folks,Web Host
@@ -1575,6 +1765,7 @@ cybermesa.com,Cyber Mesa,ISP
 cybernextech.co.th,CYBER NEXTECH,Web Host
 cybernextech.com,CYBER NEXTECH,Web Host
 cybersmart.co.za,Cybersmart,ISP
+cyberspace.net.ng,Cyberspace Nigeria,ISP
 cybertelecom.com.br,Cyber Telecom,ISP
 cybertelecom.net.br,Cyber Telecom,ISP
 cybertrails.com,CyberTrails,Web Host
@@ -1592,26 +1783,32 @@ cyon.site,cyon,Web Host
 cyrusone.com,CyrusOne,IaaS
 cyta.com.cy,Cyta,ISP
 d-hosting.de,d-hosting,Web Host
+d-pcomm.com,D and P Communications,ISP
 d2l.com,D2l Brightspace,SaaS
 d2s.cloud,d2s.cloud,Web Host
 daakbabu.com,Daak Babu,Email Provider
 dacor.de,suc dacor,ISP
 dadabroadband.com,DaDa Broadband,ISP
+daegu.ac.kr,Daegu University,Education
 daemonmail.ner,DaemonMail,Email Provider
 daemonmail.net,TierraNet,Web Host
 dailyinvesthub.com,Daily Invest Hub,Finance
 dailyrazor.com,DailyRazor,Web Host
+dakotacarrier.com,Dakota Carrier Network,ISP
 dakotapro.biz,DakotaPro,ISP
+daktel.com,Dakota Central Telecommunications,ISP
 dal.ca,Dalhousie University,Education
 dal.net.tr,DALNET,Web Host
 dallascollege.edu,Dallas College,Education
 dalnet.tr,DALNET,Web Host
+damamax.jo,Damamax,ISP
 damcogroup.com,Damco Solutions,MSP
 damel.com,Damel Group,Food
 danskkabeltv.dk,DKTV,ISP
 daou.co.kr,Daou Technology,Technology
 daouoffice.com,Dooray,SaaS
 daraju.com,Daraju,Healthcare
+darientel.net,Darien Telephone,ISP
 darpa.mil,DARPA,Defense
 dartmouth-hitchcock.org,Dartmouth-Hitchcock,Healthcare
 dartmouth.edu,Dartmouth College,Education
@@ -1624,15 +1821,20 @@ datacamp.co.uk,CDN77,Web Host
 datacentrum.sk,DataCentrum Slovakia,Government
 datacom.com,Datacom,MSP
 datacom.com.au,Datacom,MSP
+datacorpore.com.br,DataCorpore,Web Host
+datafabrik.de,meerfarbig (datafabrik),Web Host
 dataforest.net,dataforest,Web Host
 datagroup.ua,Datagroup,ISP
 datak.ir,Datak,ISP
 datanat.com,Datanational Corporation,MSP
+datapark.ch,Datapark,ISP
 datapipe.com,Rackspace,Web Host
+dataplace.com,Eurofiber Cloud Infra,IaaS
 dataport.de,Dataport,Government
 datawagon.com,DataWagon,Web Host
 datawagon.net,DataWagon,Web Host
 datayard.us,DataYard,MSP
+datazonenetworks.net,DataZone Networks,ISP
 datev.de,DATEV,SaaS
 dattar.com.ar,Dattar,MSP
 dattaweb.com,HostMar,Web Host
@@ -1648,10 +1850,13 @@ dbug.com.br,DBUG Telecom,ISP
 dc.gov,District of Columbia Government,Government
 dc37.net,District Council 37,Nonprofit
 dca.net,DCANet,ISP
+dcblox.com,DC BLOX,Web Host
+dcboces.org,Dutchess BOCES,Education
 dcc.bg,Cifrova Kabelna Korporacia,ISP
 dcceew.gov.au,Australian Department of Climate Change Energy Environment Water,Government
 dcdi.net,Direct Communications Rockland (DCDI),ISP
 dcfa.net,Douglas College,Education
+dcn.to,DCN Corporation,ISP
 dcsmanage.com,DCS Pacific Star,MSP
 dcta.mil.br,DCTA Brazil Aerospace Science and Technology,Defense
 dctv.net.tw,Digidom CableTV,ISP
@@ -1668,6 +1873,7 @@ deadline.com,Deadline,News
 deakin.edu.au,Deakin University,Education
 dealerscloud.com,DealersCloud,SaaS
 deanza.edu,Foothill-DeAnza Community College District,Education
+deasil.works,Deasil Networks,MSP
 dec.net.ua,Donbass Electronic Communications,ISP
 dec.nsw.edu.au,NSW Department of Education,Education
 dedicado.com,Dedicado Uruguay,ISP
@@ -1684,6 +1890,7 @@ deliverychain.io,Delivery Chain,SaaS
 dell.com,Dell,Technology
 deloitte.com,Deloitte,Consulting
 delska.com,Delska,Web Host
+delta-comm.ge,Delta Comm Georgia,ISP
 delta-telecom.net,Delta Telecom Azerbaijan,ISP
 delta.com,Delta Air Lines,Travel
 delta.nl,DELTA Fiber,ISP
@@ -1693,14 +1900,17 @@ deltahost-ptr,DeltaHost,Web Host
 deltainternet.net.br,Ired Internet,ISP
 demandware.net,Salesforce Commerce Cloud,SaaS
 democrats.com,Democrats.com,Nonprofit
+denonline.in,DEN Networks India,ISP
 denvergov.org,City and County of Denver,Government
 depaul.edu,DePaul University,Education
 deshaw.com,D. E. Shaw,Finance
 designerstudio.it,Designer Studio,Marketing
+desjardins.com,Desjardins,Finance
 desktop.com.br,Desktop,ISP
 deskwing.net,DESKWING,Email Provider
 desy.de,DESY,Government
 detroitedison.com,DTE Energy,Utilities
+deu.ac.kr,Dong-Eui University,Education
 deutsche-glasfaser.de,Deutsche Glasfaser,ISP
 deutschepost.de,Deutsche Post,Logistics
 devoli.com,Devoli,ISP
@@ -1710,7 +1920,9 @@ deztelecom.net.br,Dez Telecom,ISP
 dfn.de,DFN,Education
 dfn.net,Douglas Fast Net,ISP
 dfn.nl,DELTA Fiber,ISP
+dfw-datacenter.com,DFW Datacenter,Web Host
 dgeduf.or.kr,Daegu Dong-gu Education Foundation,Education
+dgnteknoloji.com,DGN Teknoloji,Web Host
 dgsys.es,DGsys,Web Host
 dgtelecom.com.br,DG Telecom,ISP
 dh.bytemark.co.uk,Bytemark,Web Host
@@ -1758,14 +1970,18 @@ digsys.bg,Digital Systems Bulgaria,ISP
 diltechnology.com,DIL Technology,ISP
 dimenoc.com,HostDime.com,Web Host
 dimensiondata.com,NTT DATA,Consulting
+dimensione.com,Dimensione Italy,ISP
 dimensionet.com,Dimension Network and Communication,ISP
+dinahosting.com,Dinahosting,Web Host
 dinamichosting.com,Dinamic Hosting,Web Host
 dinaserver.com,Dinahosting,Web Host
 dipelnet.com.br,Dipelnet,ISP
 direct-booker.com,Direct Booker,Travel
+directcomfiber.com,Direct Communications Cedar Valley,ISP
 directnic.com,Directnic,Web Host
 directnic.net,Directnic.com,Web Host
 directnode.nl,DirectNode,Web Host
+directv.com,DIRECTV Latin America,Entertainment
 directwifi.com.br,Direct Internet,ISP
 discoverflow.co,Flow,ISP
 discovergreene.com,"Greene County, New York",Government
@@ -1777,6 +1993,7 @@ dito.ph,DITO Telecommunity,ISP
 ditscloud.com,DITSCloud,MSP
 divdav.com,DIV DAV,Marketing
 divide0.net,Divide Zero Networks,Web Host
+dixieepa.com,Dixie EPA,Utilities
 djaweb.dz,Telecom Algeria,ISP
 dji.com,DJI,Technology
 djiboutitelecom.dj,Djibouti Telecom,ISP
@@ -1792,6 +2009,7 @@ dmit.com,DMIT Cloud Services,Web Host
 dmmhosts.com,DMM Hosts,Web Host
 dna.fi,DNA,ISP
 dnchosting.com,Directnic,Web Host
+dnet.net.id,DNET Indonesia,ISP
 dnetprovider.id,D~NET,ISP
 dnetsurabaya.id,D~NET,ISP
 dnns.net,No-IP Dynamic DNS,Web Host
@@ -1812,6 +2030,7 @@ docusign.net,Docusign,SaaS
 dodea.edu,U.S. Department of Defense Education Activity,Education
 dogado.de,dogado,Web Host
 dokom21.de,DOKOM21,ISP
+dolphinsoft.com,Dolphin Soft,Web Host
 dolsat.pl,Dolsat,ISP
 dom.ru,ER-Telecom,ISP
 domaincentral.com.au,Domain Central,Web Host
@@ -1824,9 +2043,13 @@ domeneshop.no,Domeneshop,Web Host
 domru.ru,ER-Telecom,ISP
 domtel.com.pl,DOMTEL,ISP
 donga.ac.kr,Dong-A University,Education
+dongguk.edu,Dongguk University,Education
 donotspam.de,indevis,MSSP
 donpac.ru,Rostelecom,ISP
+donweb.com,DonWeb (Dattatec),Web Host
+doosan.com,Doosan,Conglomerate
 doruk.net.tr,DorukNet,Web Host
+doshisha.ac.jp,Doshisha University,Education
 dosscloudservices.com,Doss Business Systems,MSP
 dot.asia,DotAsia,Nonprofit
 dot.gov,U.S. Department of Transportation,Government
@@ -1835,9 +2058,12 @@ dotdigital.com,Dotdigital,Marketing
 doteasy.com,Doteasy,Web Host
 dotinternetbd.com,DOT Internet,ISP
 dotmailer.com,Dotdigital,Marketing
+dotname.co.kr,Dotname Korea,Web Host
 dotroll.com,DotRoll,Web Host
+douzone.com,Douzone Bizon,SaaS
 downloaddatarecovery.com,KernelApps,Technology
 dqecom.com,DQE Communications,ISP
+dragon.cz,Dragon Internet,ISP
 draminski.com,Dramiński Technology,Healthcare
 draper.com,Draper Laboratory,Defense
 dravanet.hu,Dravanet,ISP
@@ -1861,10 +2087,15 @@ drjapan-jp.com,"Dr. Japan Co., Ltd.",Healthcare
 dropboxinc.com,Dropbox,SaaS
 drpeng.com.cn,Dr. Peng,ISP
 drreddys.ro,Dr. Reddy's,Healthcare
+dscga.com,Digital Service Consultants,Web Host
+dsi.net.br,DSI Defferrari,ISP
+dsidata.sk,DSI DATA Slovakia,ISP
+dslmobil.de,DSLmobil,ISP
 dslon.ws,Dslon Wireless,ISP
 dsmc.or.kr,Keimyung University Dongsan Medical Center,Healthcare
 dstl.gov.uk,Defence Science and Technology Laboratory,Defense
 dstny.com,Dstny,SaaS
+dstsystems.com,SS&C Technologies (DST),SaaS
 dsu.edu,Dakota State University,Education
 dsv.com,DSV,Logistics
 dsw.com,DSW,Retail
@@ -1874,6 +2105,7 @@ dtel.com.br,Dtel Telecom,ISP
 dtel.ru,Dagomys Telecom (Dtel),ISP
 dtln.ru,Data Storage Center,Web Host
 dtmicro.com,DT Micro,Web Host
+dtp.net.id,DTPNET,ISP
 dts-security.de,DTS,MSP
 dts.de,DTS,MSP
 du.ae,du,ISP
@@ -1882,6 +2114,7 @@ dubaistdclinic.com,STD Clinic Dubai,Healthcare
 duck.com,DuckDuckGo,Search Engine
 duckdns.org,DuckDNS,Web Host
 duckduckgo.com,DuckDuckGo,Search Engine
+duke-energy.com,Duke Energy,Utilities
 duke.edu,Duke University,Education
 dunyakatilim.com.tr,Dünya Katılım,Finance
 duo-county.com,DUO Broadband,ISP
@@ -1890,6 +2123,7 @@ duocast.nl,Duocast,Web Host
 duplexcleaning.au,Duplex Cleaning Machines,Manufacturing
 duq.edu,Duquesne University,Education
 durand.com.br,Durand do Brasil,ISP
+dustin.com,Dustin,Retail
 dvcotechnology.com,Cision,Marketing
 dvois.com,D-VoiS,ISP
 dvusd.org,Deer Valley Unified School District,Education
@@ -1916,9 +2150,11 @@ dynv6.net,dynv6,Web Host
 dyspatchit.net,Dyspatchit,Marketing
 dyx-tech.com,DYXnet,ISP
 dyxnet.com,DYXnet,MSP
+dzcrd.net,DZCRD Networks,Web Host
 e-catv.ne.jp,Ehime CATV,ISP
 e-i.com,Euro-Information,MSP
 e-kei.pl,Kei,Web Host
+e-know.net,TRAVCHIS (E-Know),Web Host
 e-mmunity.net,VIPRE,Email Security
 e-quest.nl,e-Quest,MSP
 e1b.org,Erie 1 BOCES,Education
@@ -1936,6 +2172,7 @@ eastern.com.ph,Eastern Telecoms,ISP
 easterndsl.com.ph,Eastern Communications,ISP
 eastex.com,Eastex Telephone Cooperative,ISP
 eastlink.ca,Eastlink,ISP
+eastmsconnect.com,East Mississippi Connect,ISP
 eastwest.com.pl,East&West,ISP
 easy-hebergement.fr,Easy-Hébergement,Web Host
 easy-hebergement.net,Easy-Hébergement,Web Host
@@ -1959,10 +2196,16 @@ ebsco.com,EBSCO Industries,Publishing
 ec.com.cn,CIETNET China International Electronic Commerce,SaaS
 ec2software.com,ec² Software Solutions,Healthcare
 echolabs.net,Echo Labs,MSP
+echosp.co.za,Echotel South Africa,ISP
 echoworx.net,Echoworx,Email Security
+eci.com,ECI,MSP
 ecm8.com,Campaign Master (UK),Marketing
 ecmc.edu,Erie County Medical Center,Healthcare
+ecmwf.int,ECMWF European Centre for Medium-Range Weather Forecasts,Government
+ecn.co.za,ECN South Africa,ISP
+ecn.net.au,ECN Internet,ISP
 ecohost.la,ecohost Latinoamerica,Web Host
+ecolink.com,Ecolink,Manufacturing
 econsave.com.my,Econsave,Retail
 ecosoft.com,Ecosoft,Industrial
 ecotech.cy,Ecotech,ISP
@@ -1972,6 +2215,7 @@ ecounterp.com,Ecount ERP,SaaS
 ecritel.fr,Ecritel,MSP
 ecritel.net,Ecritel,MSP
 ecu.edu,East Carolina University,Education
+edera.cz,Edera Group,ISP
 edge.uol,Edge UOL,IaaS
 edgecenter.ru,EdgeCenter,IaaS
 edgecompute.app,Fastly,Technology
@@ -2002,6 +2246,7 @@ egate.net,E-Gate Communications,ISP
 ege.edu.tr,Ege University,Education
 egihosting.com,EGIHosting,Web Host
 egov.com,Tyler Technologies,SaaS
+egregistry.eg,EUN Egyptian Universities Network,Education
 egress.cloud,Egress Software,Email Security
 egress.com,"Egress, a KnowBe4 Company",Email Security
 egrisi.ge,System Net,ISP
@@ -2022,6 +2267,7 @@ eisenhowercareers.com,Eisenhower Health,Healthcare
 eiu.edu,Eastern Illinois University,Education
 ejmnet.com.br,ILogNet,ISP
 ejpress.com,eJournalPress,SaaS
+ek.co,Ekco,MSP
 ekoline.net.pl,Eko-Line,ISP
 eku.edu,Eastern Kentucky University,Education
 elasticbeanstalk.com,Amazon AWS,PaaS
@@ -2032,6 +2278,7 @@ electric.coop,NRECA,Nonprofit
 electric.net,VIPRE,Email Security
 electriclightwave.com,Allstream,ISP
 elementa.com,Elementa,MSP
+elementcritical.com,Element Critical,Web Host
 elementmedia.com,ElementMedia,Web Host
 elevartelecom.com.br,Elevar Telecom,ISP
 elevate.uk,Elevate (Telcom Networks),ISP
@@ -2048,11 +2295,13 @@ elive.net,Elive,Web Host
 elkdata.ee,Elkdata,Web Host
 elkem.com,Elkem,Manufacturing
 ellipse.net,Ellipse,MSP
+ello.ch,Ello Communications,ISP
 elmecnet.net,Elmec Informatica,MSP
 elnk.net,Earthlink,ISP
 elntelecom.com.br,ELN Telecom,ISP
 elon.edu,Elon University,Education
 elte.hu,Eötvös Loránd University,Education
+eltele.no,Serit Eltele,ISP
 email-od.com,SocketLabs,SaaS
 emailarray.com,Emailarray,Email Provider
 emaildodo.com,eMailDodo,Email Provider
@@ -2068,6 +2317,7 @@ emcali.com.co,EMCALI,Utilities
 emeraldonion.net,Emerald Onion,Nonprofit
 emeraldonion.org,Emerald Onion,Nonprofit
 emerson.com,Emerson,Manufacturing
+emerytelcom.net,Emery Telcom,ISP
 emexinternet.com.br,Emex Internet,ISP
 emirates.net.ae,Etisalat,ISP
 emma-solutions.nl,Emma Solutions (Formerly Wylance),MSP
@@ -2081,9 +2331,11 @@ emsend2.com,ActiveCampaign,Marketing
 emtel.com,Emtel,ISP
 enagroup.net,ENA Group,Construction
 encrypttitan.net,EncryptTitan,Email Security
+endoffice.com,EndOffice,Web Host
 endurance.com,Newfold Digital,Web Host
 enduranceinternational.com,Newfold Digital,Web Host
 enecom.co.jp,Enecom,ISP
+enegan.it,Enegan,Utilities
 enel.com,Enel,Utilities
 energieag.at,Energie AG,Utilities
 energotel.sk,Energotel,ISP
@@ -2121,6 +2373,7 @@ enviatel.de,envia TEL,ISP
 enzu.com,Enzu,Web Host
 eodatacenter.com,EO Data Center,IaaS
 eolo.it,EOLO,ISP
+eon.com,E.ON,Utilities
 eonemedia.com,eOneMedia,Photography
 eons.cloud,Eons Data Communications,Web Host
 eop.gov,Executive Office of the President,Government
@@ -2137,28 +2390,37 @@ epicpc.com,Epic Health,Healthcare
 epicura.be,EpiCURA,Healthcare
 epldt.com,ePLDT,IaaS
 epmltd.com,Express Publications,Publishing
+epri.com,Electric Power Research Institute,Science
+epsilon.com,Epsilon,Marketing
 epsl1.com,Publicis Groupe,Marketing
 epsm-marne.fr,EPSM de la Marne,Healthcare
+eptc.co.sz,Eswatini PTC,ISP
 eqservers.com,EqServers,Web Host
 equinix.com,Equinix,IaaS
+equinix.de,Equinix Germany,IaaS
 equinor.com,Equinor,Industrial
 eranyacloud.com,Eranyacloud,IaaS
 erau.edu,Embry-Riddle Aeronautical University,Education
+ercwnc.org,ERC Broadband,Education
 ereline.com.br,Ereline,ISP
 ericsson.com,Ericsson,Technology
 erie.gov,"Erie County, New York",Government
 erlabrunn.de,Kliniken Erlabrunn,Healthcare
+ert.com.co,ERT Colombia,ISP
 ertelecom.ru,ER-Telecom,ISP
 es.net,ESnet,Education
+esa.int,European Space Agency,Government
 esavezone.co.kr,SaveZone,Retail
 esc.net.au,EscapeNet,ISP
 escom.bg,Escom Bulgaria,ISP
 esited.com,eSited,Web Host
 eskerondemand.com,Esker,SaaS
 eskom.co.za,Eskom,Utilities
+eso.org,European Southern Observatory,Science
 esolutionsgroup.ca,Govstack (eSolutions Group),Technology
 esosoft.net,EcoSoft,Web Host
 esqsites123.com,ESQ Sites 123,Web Host
+estraspa.it,Estra,Utilities
 estruxture.com,eStruxture Data Centers,IaaS
 esuhsd.org,East Side Union High School District,Education
 esvacloud.com,Libraesva,Email Security
@@ -2188,8 +2450,10 @@ etsu.edu,East Tennessee State University,Education
 eudonet.com,Eudonet,SaaS
 eunetworks.com,euNetworks,ISP
 euro-net.pl,Euronet Bialystok,ISP
+eurobyte.ru,EuroByte,Web Host
 eurocontrol.int,EUROCONTROL,Government
 eurofiber.com,Eurofiber,ISP
+euronet.net.tr,Euronet Turkey,ISP
 europa.eu,European Union,Government
 europarl.eu.int,European Parliament,Government
 eurotelbd.net,EuroTel BD,ISP
@@ -2208,6 +2472,7 @@ eversource.com,Eversource Energy,Utilities
 evertecinc.com,Evertec,Finance
 evertecpr.com,Evertec,Finance
 everythere.com.au,Everythere,SaaS
+everyware.ch,EveryWare,IaaS
 evicertia.com,Evicertia,SaaS
 eviden.com,Eviden,Consulting
 eviny.no,Eviny,Utilities
@@ -2237,6 +2502,7 @@ excitel.com,Excitel Broadband,ISP
 excom.es,Excom,ISP
 execulink.ca,Execulink Telecom,ISP
 execulink.net,Execulink Telecom,ISP
+exelera.net,Exelera Telecom,ISP
 exeloncorp.com,Exelon,Utilities
 exepto.ru,Exepto,ISP
 exetel.com.au,Exetel,ISP
@@ -2267,6 +2533,7 @@ ezeefiber.com,Ezee Fiber,ISP
 ezhostingserver.com,Hostek,Web Host
 ezinternetsolutions.com,EZ Internet Solutions,Web Host
 ezorg.nl,E-Zorg,Healthcare
+ezzi.net,EZZI.net,Web Host
 f-i.de,Finanz Informatik,MSP
 f-integra.org,Fundacion Integra,Nonprofit
 f2x.nl,F2X Fiber Services,ISP
@@ -2284,8 +2551,10 @@ fanava.net,Fanava Group,ISP
 fao.org,Food and Agriculture Organization of the United Nations,Government
 fap.mil.pe,La Fuerza Aérea del Perú (FAP),Government
 fapesc.sc.gov.br,FAPESC Santa Catarina Research Foundation,Government
+farahoosh.ir,Farahoosh Dena,ISP
 fareastone.com.tw,FarEasTone,ISP
 farlep.net,Farlep-Invest,ISP
+farline.net,Farline Simferopol,ISP
 farmerstel.com,Farmers Telecommunications Cooperative,ISP
 farmerstelcom.com,Farmers Telephone (FTI),ISP
 farmingdale.edu,Farmingdale State College,Education
@@ -2293,19 +2562,23 @@ farmside.co.nz,Farmside,ISP
 fast.net.id,Linknet-Fastnet,ISP
 fast.net.kg,Skynet Telecom,ISP
 fast.net.uk,FASTNET,ISP
+faster.cz,Faster CZ,ISP
 fasternet.com.br,Desktop,ISP
 fastfortechnologies.com,FastForTechnologies,ISP
 fastinternet.inf.br,Fast Web,ISP
 fastly.com,Fastly,SaaS
 fastlylb.net,Fastly,Technology
 fastmail.com,Fastmail,Email Provider
+fastnet.co.uk,FastNet International,ISP
 fastnet.kg,FastNet,ISP
 fastnetdata.com,FASTNET DATA,Web Host
 fastspeed.dk,Fastspeed,ISP
 fasttelco.com,FASTtelco,ISP
 fasttrackcomm.net,FastTrack Communications,ISP
 fastvps-server.com,P.A.G.M. OU,Web Host
+fastvps.ee,FastVPS,Web Host
 fastweb.it,Fastweb,ISP
+fastwyre.com,Fastwyre,ISP
 fatbeam.com,Fatbeam Fiber,ISP
 fatum.ru,Fatum,ISP
 fau.edu,Florida Atlantic University,Education
@@ -2332,12 +2605,14 @@ fetnet.net,FETNet,ISP
 fgl.com.mx,Francisco Garcia Lopez,Healthcare
 fhcrc.org,Fred Hutchinson Cancer Research Center,Healthcare
 fhptelecom.com.br,FHP Telecom,ISP
+fiber-operator.nl,Fiber Operator,ISP
 fiber.net,Fibernet Utah,Web Host
 fiber.net.id,Fiber Networks Indonesia,ISP
 fibercop.it,FiberCop,ISP
 fibergrid.net,Fiber Grid,ISP
 fiberhub.com,FiberHub,ISP
 fiberinternet.com.br,SpeedNet Telecom,ISP
+fiberlight.com,FiberLight,ISP
 fibernetics.ca,Fibernetics,ISP
 fibernetms.com.br,Fibernet,ISP
 fibertel.com.ar,Personal,ISP
@@ -2348,12 +2623,16 @@ fibia.dk,Fibia,ISP
 fibralider.com.br,Lider Fibra,ISP
 fibralink.net.br,Fibralink,ISP
 fibramax.ec,Fibramax,ISP
+fibranet.tv,Fibranet,ISP
 fibranetdqx.com.br,Fibranet Telecom,ISP
 fibranett.net.br,Fibranett,ISP
 fibrativainternet.com.br,FibrAtiva,ISP
 fibrenoire.ca,fibrenorie,ISP
+fibrion.com.br,Fibrion,ISP
 fibrlink.com,Beijing FibrLINK Networks,ISP
 fibron.com.br,Fibron Telecom,ISP
+fibrus.com,Fibrus,ISP
+fidelity.com,Fidelity Investments,Finance
 fidelitycommunications.com,Fidelity Communications,ISP
 fidium.com,Fidium Fiber,ISP
 fidiumfiber.com,Fidium Fiber,ISP
@@ -2361,9 +2640,12 @@ figma.com,Figma,SaaS
 figma.site,Figma,SaaS
 figueiredoprovedores.com.br,COMNET,ISP
 filanco.ru,Citytelecom (Filanco),ISP
+filibe.net,Angelsoft (Filibe),ISP
 finanzaworld.it,FinanzaWorld,Finance
 finanzaworld.net,FinanzaWorld,Finance
+finegroupservers.com,Fast Servers (FineGroup),Web Host
 fiocruz.br,Fiocruz Oswaldo Cruz Foundation,Education
+fiord.ru,NTC FIORD,ISP
 firebaseapp.com,Google,PaaS
 fireeyecloud.com,FireEye,Email Security
 fireeyegov.com,FireEye (Government),Email Security
@@ -2382,6 +2664,7 @@ firstsourceweb.com,1st Source Web,Marketing
 firsttrust.cm,First Trust,Finance
 firsttrust.online,First Trust,Finance
 fiserv.com,Fiserv,Finance
+fisglobal.com,FIS Fidelity National Information Services,SaaS
 fisherpaykel.com,Fisher & Paykel,Retail
 fisquare.com,Infince,SaaS
 fit.edu,Florida Institute of Technology,Education
@@ -2390,6 +2673,7 @@ fiu.edu,Florida International University,Education
 fixnet.com.tr,FixNet,ISP
 fiz-karlsruhe.de,FIZ Karlsruhe,Science
 fl.gov,State of Florida,Government
+flagman.zp.ua,Flagman Telecom,ISP
 flagtel.com,Flag Telecom,ISP
 flashmaistelecom.com.br,Flash + Telecom,ISP
 flashnete.com.br,Flash Net,ISP
@@ -2399,11 +2683,15 @@ fleetviolations.com,ATS Processing Services,Logistics
 flemingcollege.ca,Fleming College,Education
 flexanet.com.br,Flexa Internet,ISP
 flexential.com,Flexential,Web Host
+flexnetwork.fr,Flex Network,ISP
 flexnetworks.co.kr,Flex Networks,MSP
+flextronics.com,Flex (Flextronics),Manufacturing
+flhsi.com,FLHSI Florida High Speed Internet,ISP
 flinnsci.com,Flinn Scientific,Healthcare
 floridablue.com,Florida Blue,Finance
 floridaurologypartners.com,Florida Urology Partners,Healthcare
 flroofingcompany.com,Florida Roofing Company,Construction
+fluency.net.uk,Commsworld (Fluency),ISP
 fluidone.com,FluidOne,ISP
 fluke.com,Fluke,Manufacturing
 flutech.co.th,Flu Tech,Manufacturing
@@ -2421,6 +2709,7 @@ fmv.se,FMV / Forsvarets Materielverk,Defense
 fnal.gov,Fermi National Accelerator Laboratory,Government
 fnb.co.za,First National Bank,Finance
 fnetpe.com.br,FNET,ISP
+fngp.com,Freudenberg-NOK,Manufacturing
 fnj.co.jp,Family Net Japan,ISP
 fns-holdings.com,F.N.S. Holdings,Web Host
 foaaa.com,Federal Online Group,Web Host
@@ -2430,15 +2719,20 @@ fogel-group.cr,Fogel Group,Industrial
 fonabosque.gob.bo,FONABOSQUE,Government
 fonacit.gob.ve,Fonacit,Government
 foodtecsolutions.com,FoodTec Solutions,SaaS
+foothills.net,Foothills Communications,ISP
 forcepoint.com,Forcepoint,Email Security
+ford.com,Ford,Automotive
 fordham.edu,Fordham University,Education
 fordperformanceracingschool.com,The Ford Performance Racing School,Automotive
 foreupwebsites.com,foreUP,SaaS
+forked.net,Fork Networking,Web Host
 formassembly.com,FormAssembly,SaaS
 format24.ua,Format 24,ISP
+fornex.com,Fornex Hosting,Web Host
 forpsi.com,Forpsi,Web Host
 forsakringskassan.se,Forsakringskassan,Government
 fortetelecom.com.br,Forte Telecom,ISP
+fortex.ru,Fortex Russia,ISP
 forth.gr,Foundation for Research and Technology Hellas,Science
 forthnet.gr,Nova,ISP
 fortimail.com,Fortinet FortiMail,Email Security
@@ -2446,6 +2740,7 @@ fortimailcloud.com,Fortinet FortiMail Cloud,Email Security
 fortinet.com,Fortinet,Email Security
 fortressitx.com,FortressITX,Web Host
 forwardemail.net,ForwardEmail.net,Email Provider
+fotbo.com,Fotbo,Web Host
 fourseasonspediatrics.com,Four Seasons Pediatrics,Healthcare
 foxconn.com.cn,Foxconn,Manufacturing
 foxinfo.net.br,FOXINFO Telecom,ISP
@@ -2456,6 +2751,7 @@ foxtrotmedia.com,Foxtrot Media,Web Host
 fpb.cc,Frankfort Plant Board,Utilities
 fphonline.com,Family Pet Hospital,Healthcare
 fpl.com,Florida Power & Light,Utilities
+fpt.com,FPT Telecom,ISP
 fpt.vn,FPT Telecom,ISP
 fr.ch,Canton of Fribourg,Government
 francedns.com,Eurofiber France,ISP
@@ -2473,6 +2769,7 @@ free.re,Free Reunion,ISP
 freebit.com,FreeBit,ISP
 freeddns.us,Now-DNS,Web Host
 freedom-vrn.ru,Freedom (Informsvyaz Chernozemye),ISP
+freedom.nl,Freedom Internet,ISP
 freedom1.ru,Freedom,ISP
 freehostia.com,Freehostia,Web Host
 freehosting.com,FreeHosting.com,Web Host
@@ -2518,6 +2815,7 @@ fusionet.srv.br,Fusion Telecom,ISP
 fusionnetworks.net,Fusion Networks,ISP
 future-bridge.eu,Future Bridge Events,Marketing
 fxclickinsight.co.za,FXClick Insight,Finance
+fybercom.net,FyberCom,ISP
 fyfeweb.com,FyfeWeb,Web Host
 fyfeweb.uk.net,FyfeWeb,Web Host
 fzi.de,FZI Forschungszentrum Informatik,Science
@@ -2535,22 +2833,31 @@ galanet.com.ve,Galanet,ISP
 galizanet.com.br,GalizaNET,ISP
 gallerycollection.com,The Gallery Collection,Retail
 galls.com,Galls,Retail
+gamania.com,Gamania,Entertainment
 gamma.co.uk,Gamma,ISP
 gammagroup.co,Gamma,ISP
 gandi.net,Gandi.net,Web Host
+gannett.com,Gannett (USA Today),News
 gaoland.net,SFR,ISP
 garantia.tv,Kolomna-Sviaz TV,ISP
 gardentelecom.com.br,Garden Telecom,ISP
+garena.com,Garena,Entertainment
+garlic.com,South Valley Internet,ISP
 garr.it,GARR,Education
 garratelecom.net.br,Garra Fibra,ISP
+garstelecom.ru,MegaFon (GarsTelecom),ISP
 gastrogainesville.com,Gastroenterology Associates of Gainesville,Healthcare
 gatech.edu,Georgia Institute of Technology,Education
 gatespeed.com,Cruzio,ISP
+gateway.com,Gateway,Manufacturing
 gatewayfiber.com,Gateway Fiber,ISP
 gatormail.co.uk,Spotler,Marketing
 gavleenergi.se,Gavle Energi,Utilities
 gawex.pl,Gawex Media,ISP
 gazella.es,Orix Systems,MSP
+gazonfiber.com,Gazon Communications,ISP
+gazprom-spacesystems.ru,Gazprom Space Systems,Defense
+gazprom.ru,Gazprom Telecom,ISP
 gba.gob.ar,Provincia de Buenos Aires,Government
 gbic.mx,GBIC Comunicaciones,ISP
 gblnet.net,Global Network Management,MSP
@@ -2561,6 +2868,7 @@ gci.net.br,GCI Net,ISP
 gcicom.net,Nasstar,MSP
 gciservicios.com.ar,Merco Comunicaciones,ISP
 gcmcomputers.com,GCM Computers,MSP
+gcn.bg,Global Communication Net Bulgaria,ISP
 gcore.com,Gcore,Web Host
 gcrcompany.com,GCR Company,MSP
 gcs.co.kr,Green Cable Television Station,ISP
@@ -2582,6 +2890,7 @@ gene.com,Genentech,Healthcare
 generali.de,Generali Deutschland,Finance
 generalinformatix.net,General Informatix,Technology
 generalmills.com,General Mills,Food
+geneseo.com,Geneseo Communications,ISP
 geneseo.edu,SUNY Geneseo,Education
 genie-networks.com,Genie Networks,Technology
 genoray.com,GENORAY,Healthcare
@@ -2594,6 +2903,7 @@ gerberlife.com,Gerber Life Insurance,Finance
 getkeepsafe.com,Keepsafe Software,SaaS
 getordained.org,Universal Life Church,Religion
 getresponse.com,GetResponse,Marketing
+getronics.com,Getronics,MSP
 getty.edu,J. Paul Getty Trust,Education
 gettysburg.edu,Gettysburg College,Education
 getunwired.com,unWired Broadband,ISP
@@ -2605,8 +2915,11 @@ ghnet.com.br,GHNet,ISP
 ghostnet.de,GHOSTnet,Web Host
 giantpartners.com,Giant Partners,Marketing
 gib-solutions.ch,GIB Solutions,ISP
+gibir.net.tr,GIBIRNet,ISP
 gibsonemc.com,Gibson Connect (Gibson EMC),Utilities
+gibtele.com,Gibtelecom,ISP
 gifu-u.ac.jp,Gifu University,Education
+giga.ly,Giga Libya,ISP
 gigabytetelecom.com.br,Gigabyte Telecom,ISP
 gigaclear.com,Gigaclear,ISP
 gigahost.dk,GigaHost,Web Host
@@ -2617,17 +2930,23 @@ gigared.com.ar,Gigared,ISP
 gigas.com,Gigas Hosting,Web Host
 gigatel.com.ua,Lanet (Gigatel),ISP
 gigenet.com,GigeNET,Web Host
+gigglefiber.com,Giggle Fiber,ISP
+gigstreem.com,Gigstreem,ISP
+gijima.com,Gijima,MSP
 gilat.net,Gilat Telecom,ISP
+gipnetworks.com,Global IP Networks,Web Host
 git-repos.de,LCube,Web Host
 github.com,GitHub,SaaS
 github.io,GitHub,SaaS
 githubusercontent.com,GitHub,SaaS
 gitlab.com,GitLab,SaaS
 gitlab.io,GitLab,SaaS
+glasfaser-ruhr.de,Glasfaser Ruhr,ISP
 glasgow-ky.com,Glasgow EPB,ISP
 glasgowepb.com,Glasgow EPB,ISP
 glbb.jp,GLBB Japan,ISP
 glcom.net,Great Lakes Comnet,ISP
+glenten.dk,Glenten Odense,ISP
 glesys.com,Glesys,Web Host
 glesys.net,GleSYS,Web Host
 glidegroup.co.uk,Glide,ISP
@@ -2651,6 +2970,10 @@ globaltelecom-mt.com.br,Global Telecom,ISP
 globalways.net,Globalways,ISP
 globconnex.com,Global Connectivity Solutions,ISP
 globe.com.ph,Globe Telecom,ISP
+globo.com,Globo,News
+globo.tech,GloboTech,Web Host
+globus-telecom.com,Globus-Telecom,ISP
+gloworld.com,Globacom (Glo),ISP
 gm.com,General Motors,Automotive
 gmailify.com,Gmailify,Email Provider
 gmdp.net.id,GMDP,ISP
@@ -2662,6 +2985,7 @@ gmu.edu,George Mason University,Education
 gmx.com,GMX,ISP
 gmx.net,GMX,ISP
 gn-server.de,Greatnet.de,Web Host
+gn.gov.ie,Irish Government,Government
 gnb.ca,Government of New Brunswick,Government
 gnc.am,GNC-Alfa,ISP
 gnet.cc,GNET,Web Host
@@ -2674,9 +2998,11 @@ go.com.sa,GO Telecom,ISP
 gobertram.com,Bertram Communications,ISP
 goco.ca,TELUS,ISP
 godaddy.com,GoDaddy,Web Host
+goetel.de,Goetel,ISP
 goip.de,GoIP,Web Host
 goknet.com.tr,GÖKNET,ISP
 gol.com,Gol,Travel
+golddata.net,Gold Data,ISP
 goldenwest.com,Golden West Telecommunications,ISP
 goldmedimport.com.br,Goldmed import,Healthcare
 gom.co.za,Graytown Office Machines,MSP
@@ -2707,6 +3033,7 @@ gov.hu,Government of Hungary,Government
 gov.in,Indian government,Government
 gov.nt.ca,Government of Northwest Territories,Government
 gov.pf,The Government of French Polynesia,Government
+gov.ru,Russian Government,Government
 gov.si,Slovenia Government Portal,Government
 govdelivery.com,Granicus,SaaS
 govst.edu,Governors State University,Education
@@ -2714,13 +3041,16 @@ govstack.com,Govstack (eSolutions Group),Technology
 gpcom.com,Great Plains Communications,ISP
 gpo.gov,US Government Publishing Office,Government
 gpphosted.com,Proofpoint (Government),Email Security
+grainconnect.com,Grain Connect,ISP
 grainger.ca,Grainger Industrial Supply,Industrial
 grainger.com,Grainger Industrial Supply,Industrial
+grameenphone.com,Grameenphone,ISP
 granicus.com,Granicus,SaaS
 granitenet.com,Granite Telecommunications,ISP
 graysmark.net,Graysmark Business Systems,MSP
 greatforti.com,Anpple Tech,Web Host
 greatmail.com,Greatmail,Email Provider
+gree.co.jp,GREE,Entertainment
 green.ch,green.ch,ISP
 greenarrowemail.com,GreenArrow,SaaS
 greenarrowmail.com,GreenArrow,SaaS
@@ -2732,14 +3062,18 @@ greengeeks.com,GreenGeeks,Web Host
 greengeeks.net,GreenGeeks,Web Host
 greenhousedata.com,Lunavi (Greenhouse Data),Web Host
 greenlightnetworks.com,Greenlight Networks,ISP
+greenlighttek.com,Greenlight Tek,MSP
 greenmountainpower.com,Green Mountain Power,Utilities
 greentelecom.net.br,Green Telecom,ISP
 greenviewdata.com,Greenview Data,Email Security
+grid4.com,Grid4 Communications,ISP
 grinnell.edu,Grinnell College,Education
+grm.net,GRM Networks,ISP
 grnet.gr,GRNET,Education
 group.bnpparibas,BNP Paribas,Finance
 group.ntt,NTT Group,ISP
 groupe-asten.fr,Groupe Asten,MSP
+groupe-convergence.com,Groupe Convergence,MSP
 groupon.com,Groupon,Retail
 grsolucoestelecom.com.br,GR Soluções Telecom,ISP
 gru.com,Gainesville Regional Utilities,Utilities
@@ -2753,6 +3087,7 @@ gruposalinas.com.mx,Groupo Salinas,Conglomerate
 grupotelecompe.com.br,Grupo Telecom,ISP
 gruppoiren.it,Iren Group,Utilities
 grvfibra.com.br,GRV Fibra,ISP
+gs.com,Goldman Sachs,Finance
 gsbridge.com,Golden State Bridge,Industrial
 gsi.de,GSI Helmholtzzentrum für Schwerionenforschung,Education
 gss-security.ca,GSS Security,Physical Security
@@ -2761,6 +3096,7 @@ gta.net,GTA Teleguam,ISP
 gtd.cl,Gtd,ISP
 gtdcolombia.com,GTD Colombia,ISP
 gtdmanquehue.com,Gtd,ISP
+gtel.in,Gigantic Infotel,ISP
 gthost.com,GTHost,Web Host
 gtnexus.com,Infor Nexus (Formerly GT Nexus),SaaS
 gtpl.net,GTPL,ISP
@@ -2771,6 +3107,7 @@ gturbo.com.br,G Turbo Telecom,ISP
 gtxnet.com.br,GTXNET,ISP
 gu.se,University of Gothenburg,Education
 guardedhost.com,Omnis Network,Web Host
+guj.de,Gruner + Jahr (RTL Deutschland),Publishing
 gulfstreamaircraft.com,Gulfstream Aerospace,Manufacturing
 gunma-u.ac.jp,Gunma University,Education
 gustavus.edu,Gustavus Adolphus College,Education
@@ -2796,11 +3133,13 @@ hamilton.edu,Hamilton College,Education
 hamline.edu,Hamline University,Education
 hammacher.com,Hammacher Schlemmer,Retail
 hamwan.org,HamWAN,Nonprofit
+hamyar.net,Hamyar,ISP
 han-solo.net,hostNET,Web Host
 hanami.run,Mailwip (Formerly Hanami),Email Provider
 hanastar.net.id,HSnet,ISP
 handynetworks.com,Summit Hosting (Handy Networks),Web Host
 hankyu-hanshin.co.jp,Hankyu Hanshin,Conglomerate
+hanwha.com,Hanwha,Conglomerate
 hanyang.ac.kr,Hanyang University,Education
 hap.be,CHU Ambroise Paré,Healthcare
 hargray.com,Hargray,ISP
@@ -2821,6 +3160,7 @@ hathway.com,Hatchway,ISP
 hathway.net,Hathway,ISP
 haverford.edu,Haverford College,Education
 hawaii.edu,University of Hawaii,Education
+hawaiian.net,Sitestar (Hawaiian),ISP
 hawaiiantel.com,Hawaiian Telcom,ISP
 hawetelekom.com,Hawe Telekom,ISP
 hay.net,Hay Communications,ISP
@@ -2831,6 +3171,7 @@ hccs.edu,Houston Community College,Education
 hcg.gr,Greek Coast Guard,Government
 hchdfoundation.org,Harris Health System,Healthcare
 hcinet.net,Hanson Communications,ISP
+hcltech.com,HCLTech,MSP
 hcltechnologies.com,HCL Technologies,MSP
 hcn.co.kr,Hyundai HCN,ISP
 hctc.net,Hill County Telephone Cooperative (HXTC),ISP
@@ -2868,6 +3209,8 @@ herbion.com,Herbion,Healthcare
 herbion.us,Herbion,Healthcare
 here.com,HERE Technologies,PaaS
 herefordshire.gov.uk,Herefordshire Council,Government
+hermes-telecom.net,Hermes Telecom Belgium,ISP
+herning.dk,Herning Municipality,Government
 herokuapp.com,Heroku,PaaS
 herotel.com,Herotel,ISP
 heteml.jp,GMO,Web Host
@@ -2878,13 +3221,17 @@ heyflow.page,Heyflow,Marketing
 heyflow.site,Heyflow,Marketing
 heywoodhill.com,Heywood Hill,Retail
 hgc-intl.com,HGC,ISP
+hged.com,Holyoke Gas and Electric,Utilities
 hh.nm.cn,China Unicom,ISP
 hhs.gov,U.S. Department of Health & Human Services,Government
 hhsys.org,Huntsville Hospital,Healthcare
 hiab.com,Hiab,Manufacturing
 hickorytech.net,Consolidated Communications,ISP
+highland.net,Highland Connection,ISP
+highlandnet.se,Highlandnet Sweden,ISP
 highlinefast.com,Highline,ISP
 highmark.com,Highmark,Healthcare
+highnet.com,HighNet (Focus Group),ISP
 highradiuscorp.com,HighRadius,Finance
 highspeed2.net.br,High Speed,ISP
 highspot.com,Highspot,Marketing
@@ -2897,8 +3244,11 @@ hiper.dk,Hiper,ISP
 hiss.co.jp,HISS Hokuden Information System Service,MSP
 hissm.com,Hiss Media,Marketing
 hit.ac.kr,Daejon Health Sciences College,Education
+hitachi-cloud.com,Hitachi Cloud,IaaS
 hitachi-pt.co.jp,Hitachi,Conglomerate
+hitc.vn,Hanoi Telecom HCMC,ISP
 hitmedios.com,HT Medios,MSP
+hitrontech.com,Hitron Technologies,Manufacturing
 hivelocity.net,Hivelocity,Web Host
 hiwaay.net,HuWAAY,ISP
 hiworks.co.kr,hiworks,SaaS
@@ -2907,7 +3257,11 @@ hkbn.net,HKBN,ISP
 hkbnes.com,HKBN Enterprise,ISP
 hkbnes.net,HKBN Enterprise,ISP
 hkbu.edu.hk,Hong Kong Baptist University,Education
+hkcable.com,Hong Kong Cable TV,ISP
+hkcix.com,IXTech HKCIX,Web Host
+hkcloudx.com,HKCloudX (VpsQuan),Web Host
 hkcsl.com,csl HKCSL,ISP
+hkdns.hk,West263 (HKDNS),Web Host
 hkglobalnetwork.com,Global Communication Network,ISP
 hkn.de,HKN,ISP
 hkt-enterprise.com,HKT Enterprise,ISP
@@ -2916,6 +3270,7 @@ hku.hk,The University of Hong Kong,Education
 hmall.com,Hyundai Home Shopping,Retail
 hmcaguas.com,Puerto Rico Telephone Company,ISP
 hmu.gr,Hellenic Mediterranean University,Education
+hns.com,Hughes Network Systems,ISP
 hoaspace.com,HOA Space,SaaS
 hofstra.edu,Hofstra University,Education
 hokudai.ac.jp,Hokkaido University,Education
@@ -2941,23 +3296,32 @@ homesklep.pl,home.pl,Web Host
 homesteadhealthcareservices.com,Homestead Health Care Services,Healthcare
 homeunix.net,DynDNS,Web Host
 homeunix.org,DynDNS,Web Host
+homeworks.org,HomeWorks Tri-County Electric,Utilities
 honda.com,Honda,Automotive
 hondutel.hn,Hondutel,ISP
+honest.net,Honest Networks,ISP
+honeycomb.net,Honeycomb Internet,ISP
 honeycrm.com,HoneyCRM,SaaS
+hongik.ac.kr,Hongik University,Education
 hongkongserver.net,Hong Kong Server,Web Host
 hood.edu,Hood College,Education
+hop-electric.com,Hopkinsville Electric (EnergyNet),Utilities
 hopitaleuropeendeparis.fr,Hôpital Européen de Paris,Healthcare
 hopone.net,HopOne Internet,Web Host
 hopto.me,No-IP,Web Host
 hopto.org,No-IP,Web Host
+horizonscope.com,Horizon Scope Telecom,ISP
 horizonstelecom.com,Horizons Telecom,ISP
+horizontel.com,Horizon Telcom,ISP
 horizontes.net.br,Horizontes Fibra,ISP
 hornetsecurity.com,Hornetsecurity,MSSP
 hosei.ac.jp,Hosei University,Education
 hosp.kaizuka.osaka.jp,Kaizuka City Hospital,Healthcare
 hospedagemweb.com.br,Central Server,Web Host
 host-it.co.uk,Host-IT,Web Host
+hostasaurus.com,Miva (Hostasaurus),SaaS
 hostatom.com,hostatom,Web Host
+hostcenter.co.kr,Hostcenter Korea,Web Host
 hostcrew.net,HostCrew,Web Host
 hostdent.com,HostNDent,Healthcare
 hostdepot.net,Host Depot,Web Host
@@ -2968,6 +3332,7 @@ hostedemail.com,HostedEmail.com,Email Provider
 hostedexchange.asia,Hosted Exchange Asia,Web Host
 hostedpi.com,Mythic Beasts,Web Host
 hostek.com,HOSTEK,Web Host
+hoster.kz,Hoster.KZ,Web Host
 hosteurope.de,Host Europe,Web Host
 hostgate.ro,Hostgate.ro,Web Host
 hostglobal.plus,HOSTGLOBAL.PLUS,Web Host
@@ -2977,20 +3342,24 @@ hosthatch.com,HostHatch,Web Host
 hostico.ro,HOSTICO,Web Host
 hosting-advantage.com,Hosting Advantage,Web Host
 hosting-cluster.nl,Combell,Web Host
+hosting-links.com,Digital Network (Hosting-Links),Web Host
 hosting-mexico.net,Hosting-Mexico,Web Host
 hosting-universal.com,Hosting Universal,Web Host
 hosting.com,A2 Hosting,Web Host
+hosting.de,hosting.de,Web Host
 hosting.ie,Irish Domains Limited,Web Host
 hostingbusinesses.com,Hosting Businesses,Web Host
 hostingcare.net,Server Sea Hosting,Web Host
 hostinger.com,Hostinger,Web Host
 hostinger.io,Hostinger,Web Host
+hostingindustry.pro,Hosting Industry,Web Host
 hostingraja.in,HostingRaja,Web Host
 hostings.com.sg,Web Commerce Communications,Web Host
 hostingspeed.net,Hosting Speed,Web Host
 hostingturkiye.com.tr,Hosting Turkiye,Web Host
 hostinguk.net,Hosting UK,Web Host
 hostkey.com,HOSTKEY,Web Host
+hostkey.ru,HostKey,Web Host
 hostland.ru,HostLand,Web Host
 hostlegends.com,HostLegends,Web Host
 hostlife.net,HOSTLIFE,Web Host
@@ -3013,6 +3382,8 @@ hostsevenplus.com,HostSevenPlus,Web Host
 hostsg.com,HostSG,Web Host
 hostspeedy.com,Host Speedy,Web Host
 hosttook.com,Hosttook,Web Host
+hostuniversal.com.au,Host Universal Australia,Web Host
+hostus.us,HostUS,Web Host
 hostvds.com,HostVDS,Web Host
 hostway.co.kr,Hostway IDC,Web Host
 hostway.com,Hostway,Web Host
@@ -3045,9 +3416,11 @@ htc.net,HTC,ISP
 htcinc.net,HTC,ISP
 htdc.org,HTDC Hawaii Technology Development Corporation,Government
 htmlservices.it,HTMLServices.it,MSP
+htnet.co.jp,Hokuriku Telecommunication Network,ISP
 htp.net,htp,ISP
 htuidc.com,Dianliantongxin,Web Host
 huaweicloud.com,Huawei Cloud,IaaS
+hubone.fr,Hub One,ISP
 hubspotemail.net,HubSpot,Marketing
 hugel-inc.com,Hugel,Healthcare
 hugetns.com,Huge TNS,ISP
@@ -3057,8 +3430,11 @@ hughston.com,Hughston Clinic,Healthcare
 hugstelecom.com,Hugs Telecom,ISP
 hull.ac.uk,University of Hull,Education
 hulum.iq,Hulum Almustakbal,ISP
+humanservices.gov.au,Services Australia,Government
+huntercomm.net,Hunter Communications,ISP
 huntington.com,Huntington Bancshares,Finance
 huntsvillehospital.org,Huntsville Hospital,Healthcare
+hurontel.on.ca,HuronTel,ISP
 hushmail.com,Hushmail,Email Provider
 hut8.com,Hut 8,IaaS
 hut8mining.com,Hut 8,IaaS
@@ -3072,6 +3448,8 @@ hyosung.com,Hyosung,Conglomerate
 hypernode.com,Hypernode,Web Host
 hypernode.io,Hypernode,Web Host
 hyperoptic.com,Hyperoptic,ISP
+hytron.io,Hytron Network,Web Host
+hyundai-autoever.com,Hyundai Autoever,MSP
 i-cable.com,i-Cable,ISP
 i2ts.ne.jp,i2ts,Web Host
 i3d.net,i3D.net,IaaS
@@ -3084,6 +3462,8 @@ iastate.edu,Iowa State University,Education
 ibindley.com,Cardinal Health,Healthcare
 ibm.com,IBM,Technology
 iboss.com,iboss,SaaS
+ibrowse.com,iBrowse,ISP
+ibw.com.ni,IBW Nicaragua,ISP
 ibx.com,Independence Blue Cross,Healthcare
 icc-media.co.jp,ICC Corporation,ISP
 ice.co.cr,Grupo ICE,Industrial
@@ -3093,18 +3473,24 @@ icewarpcloud.in,IceWrap,Email Provider
 icfre.org,Indian Council of Forestry Research and Education,Government
 ici.ro,ICI București,Government
 iclicktelecom.net.br,iClick Telecom,ISP
+iclix.co.za,Iclix,ISP
 icloud.com,Apple iCloud,Email Provider
+ico.net,ICOnetworks,ISP
 icomtex.ru,Intercomtex,ISP
+iconnectsa.co.za,iConnect SA,ISP
 iconnecttelecom.com.br,Connect Telecom,ISP
 iconz.net,ICONZ,ISP
 icoremail.net,Coremail,Email Provider
 icosnet.com,ICOSNET,ISP
 icostelecom.com.br,ICOS Telecom,ISP
+ict.jp,IGAUENO Cable Television,ISP
+ictglobe.com,ICTGlobe,ISP
 ictk.com,ICTK,Technology
 icuk.net,ICUK,Web Host
 ida.org,Institute for Defense Analyses,Defense
 idaho.gov,State of Idaho,Government
 idcf.jp,IDC Frontier,Web Host
+idcloudhost.com,IDCloudHost Indonesia,Web Host
 idealinsurancebrokersng.com,Ideal Insurance Brokers,Finance
 idealwebpiaui.com.br,Ideal Web,ISP
 ideaservers.net,Hetzner,Web Host
@@ -3114,9 +3500,11 @@ identity.digital,Identity Digital (Afilias),Technology
 idig.net,Canadian Web Hosting,Web Host
 idknet.com,Interdnestrcom,ISP
 idm.net.lb,IncoNet IDM,ISP
+idnet.net,IDNet,ISP
 idodns.com,IDO DNS,MSP
 idt.net,IDT Corporation,ISP
 ieee.org,IEEE,Nonprofit
+ielo.net,ielo,ISP
 ientc.com,IENTC Telecom,ISP
 ieso.ca,Independent Electricity System Operator (Ontario),Utilities
 ifeelfree.co.nz,I Feel Free,MSP
@@ -3131,18 +3519,23 @@ iglou.com,IgLou Internet Services,ISP
 ignitedigital.com,Ignite Digital,Marketing
 igpfibra.com.br,IGP Fibra,ISP
 ihc.com,Intermountain Health,Healthcare
+ihnetworks.com,IHNetworks,Web Host
 ihor-hosting.ru,IHOR Hosting,Web Host
 ihor.online,IHOR Hosting,Web Host
+ihs.com,S&P Global (IHS),SaaS
 ihs.gov,Indian Health Service,Government
 ihug.co.nz,ihug,ISP
 iiasa.ac.at,IIASA International Institute for Applied Systems Analysis,Science
 iij.ad.jp,Internet Initiative Japan,ISP
 iij4u.or.jp,Internet Initiative Japan,ISP
 iinet.net.au,iiNet,ISP
+iit.edu,Illinois Institute of Technology,Education
 iitb.ac.in,Indian Institute of Technology Bombay,Education
 iitr.ac.in,Indian Institute of Technology Roorkee,Education
 ik2.com,Spamflare,Email Security
+ikb.at,IKB Innsbrucker Kommunalbetriebe,Utilities
 ikoula.com,Ikoula,Web Host
+iks.ru,InterKamService,ISP
 ilap.com,ILAP,ISP
 iliad.it,Iliad,ISP
 ilight.net,I-Light (Indiana University),Education
@@ -3162,6 +3555,7 @@ imicro.com.br,IMICRO Telecom,ISP
 immedion.com,Immedion (Centersquare),Web Host
 immomeister.com,Immomeister,Real Estate
 imnet.com.br,Imnet,ISP
+imobi.co.kr,imobi,ISP
 imon.net,ImOn Communications,ISP
 imp.ch,ImproWare,ISP
 impa.br,IMPA,Education
@@ -3175,7 +3569,10 @@ imsnetworks.com,IMS Networks,ISP
 in.net.pl,INFO-NET grupa ZICOM,ISP
 in2net.com,In2net Network,ISP
 inalan.gr,Inalan,ISP
+inasset.it,Retelit (InAsset),ISP
 incapsula.com,Imperva,Email Security
+incheon.ac.kr,University of Incheon,Education
+incl.ne.jp,Ishikawa Computer Center,ISP
 incomcloud.com,InCom,MSP
 incontact.com,NICE CX,SaaS
 indanet.com.br,Indanet,ISP
@@ -3184,6 +3581,7 @@ indevis.de,indevis,MSSP
 indiaaccess.com,IndiaAccess,Web Host
 indiana.edu,Indiana University Bloomington,Education
 indianapolis.in.us,City of Indianapolis,Government
+indinet.co.in,Indinet,ISP
 indo.net.id,Indonet,ISP
 indonet.co.id,Indonet,ISP
 indonet.id,Indonet,ISP
@@ -3199,6 +3597,7 @@ ines.co.jp,INES,MSP
 ines.ro,iNES Group Romania,ISP
 inesc.pt,INESC,Science
 inet.co.th,INET,ISP
+inet.de,INTERNET AG,Web Host
 inet.vn,INET,Web Host
 inetcom.ru,Inetcom,ISP
 inettech.co.kr,iNet Technologies,ISP
@@ -3206,11 +3605,13 @@ inetvl.ru,AlianceTelecom,ISP
 inexa.com.br,Inexa,ISP
 inexio.net,inexio,ISP
 inext.co.th,INET,ISP
+inf.com,Infosys,MSP
 infinityfiber.com.br,Infinity Fibra,ISP
 infinivan.com,InfiniVAN,ISP
 infixnet.com.br,Infix Telecom,ISP
 info-trade.gr,INFO-TRADE,Technology
 infobarranet.com.br,Infobarra,ISP
+infocom.ua,Infocom Ukraine,ISP
 infolada.ru,InfoLada,ISP
 infolinebandalarga.com.br,Infoline,ISP
 infolink.com,Infolink Global,ISP
@@ -3231,6 +3632,8 @@ infornetnetwork.net.br,I3 Telecomunicações,ISP
 infoservic.com.br,InfoServic Telecom,ISP
 infosetetelecom.com.br,Info Sete,ISP
 infosi.gov.ao,INFOSI Angola Information Society,Government
+infosys.com,Infosys,MSP
+infotec.com.mx,INFOTEC Mexico,Government
 infotec.psi.br,Infotec,ISP
 infotrade.gr,INFO-TRADE,Technology
 infowest.com,InfoWest,ISP
@@ -3253,6 +3656,8 @@ inno.com.ec,Inno,ISP
 innova-red.net,InnovaT,Education
 innova.puglia.it,InnovaPuglia,Government
 innovasur.com,Innovasur,MSP
+innsys.ca,InnSys,ISP
+inoc.com,INOC,MSP
 inovalon.com,inovalon,Healthcare
 inovanettelecom.net.br,InovaNet,ISP
 inpe.br,INPE Brazilian National Institute for Space Research,Science
@@ -3261,6 +3666,7 @@ inria.fr,INRIA,Science
 inspire.net.nz,Inspire Net Limited,ISP
 inspirebroadband.net,Inspire Broadband,ISP
 inspiren.my,Inspiren,Marketing
+instanetvasai.com,Instanet Vasai,ISP
 instantprint.com,Instant Print Corp,Print
 instinet.com,Instinet,Finance
 institutomix.com.br,Instituto Mix,Education
@@ -3274,6 +3680,7 @@ inteliquent.com,Inteliquent,ISP
 intellicentre.net.au,Macquarie Technology,IaaS
 intellisurvey.com,InteliSurvey,SaaS
 intelsat.com,SES (Formerly Intelsat),ISP
+intelvision.sc,Intelvision Seychelles,ISP
 inter.com.ve,Inter Telecom,ISP
 inter.edu,Interamerican University of Puerto Rico,Education
 inter.net.il,Internet Gold,ISP
@@ -3298,20 +3705,27 @@ internet-webhosting.com,iWHOST,Web Host
 internet.co.za,Axxess,ISP
 internet.fo,Føroya Tele,ISP
 internet.gmo,GMO Internet,ISP
+internet.lu,Luxembourg Online,ISP
+internet.one,Internet ONE,ISP
 internet10.net.br,Internet 10,ISP
 internetlocal.com.ar,Internet Local,ISP
 internetmailserver.net,Internet Mail Server Networks,Email Provider
 internetnamesforbusiness.com,Internet Names For Business,Web Host
 internetparatodos.com.ar,Internet Para Todos La Rioja,Government
+internetport.se,Internetport Sweden,ISP
 internetsuper.com.br,Internet Super,ISP
 internetvikings.com,Internet Vikings,Web Host
 internetway.com.br,Internet Way,ISP
+internetx.com,InterNetX,Web Host
+internex.at,InterneX,Web Host
 internexa.com,InterNexa,ISP
 internext.cz,Internext,ISP
 internexus.co.uk,Internexus,ISP
+interphone.com.au,Interphone Australia,ISP
 interra.ru,Interra,ISP
 interserver.net,InterServer,Web Host
 intervel.com.br,Intervel Telecom,ISP
+intervolve.com.au,New Era Technology (Intervolve),MSP
 interworks.co.za,Interworks,ISP
 interzet.ru,ER-Telecom,ISP
 inti.net.id,Inti Data Telematika,ISP
@@ -3326,6 +3740,7 @@ inxserver.de,Inxmail,Marketing
 ioflood.com,IOFLOOD,Web Host
 ioflood.net,I/O Flood,Web Host
 ioh.co.id,IM3,ISP
+ioko.com,Redcentric (ioko),Web Host
 iomart.com,iomart,Web Host
 ionblade.com,IonBLADE,Web Host
 ionnetwork.co.id,ION Network (PT Parsaoran Global Datatrans),ISP
@@ -3360,17 +3775,22 @@ ip-92-204-129.us,OVH,Web Host
 ip-92-204-134.us,OVH,Web Host
 ip-home.net,iP-Home,ISP
 ip-kyoto.ad.jp,Advanced Software Technology & Management Research Institute of Kyoto,Education
+ip-max.net,IP-Max,ISP
 ip-projects.de,IP-Projects,Web Host
+ipacct.com,IPACCT Cable,ISP
+ipex.cz,IPEX,ISP
 iphmx.com,Cisco Cloud Email Security (CES),Email Security
 iphost.gr,IpHost,Web Host
 iphost.net,IpHost,Web Host
 iphotel.net.br,IPHOTEL Hosped,Web Host
 iphouse.net,Sandwich,Web Host
+ipinternational.net,IP Access International,ISP
 ipko.com,IPKO,ISP
 iplan.com.ar,IPlan,ISP
 ipm.ac.ir,Institute for Research in Fundamental Sciences,Education
 ipm.com,Intelligent Protection Management,Web Host
 ipn.mx,Instituto Politecnico Nacional,Education
+ipnet.ua,IPnet Kyiv,ISP
 ipnettelecom.com.br,IPNET,ISP
 ipnext.com.ar,IPNEXT,ISP
 ipnxnigeria.net,ipNX Nigeria,ISP
@@ -3378,9 +3798,15 @@ ipost.com,iPost,Marketing
 ippathways.com,IP Pathways,MSP
 iprimus.com.au,iPrimus,ISP
 ipserverone.com,IP ServerOne,Web Host
+ipstar.com.au,IPSTAR Australia,ISP
+iptel.com.ar,Iptel Argentina,ISP
+iptelecom.it,IP Telecom Italy,ISP
 iptp.com,IPTP Networks,ISP
 ipv.net.pl,Promedia,ISP
+ipvisie.com,IP Visie Networking,ISP
 ipx.com.au,IP Exchange Australia,ISP
+ipxon.com,IPXON,Web Host
+iq.group,iQ Group Iraq,ISP
 iqcomputing.com,IQComputing,Web Host
 iqcomputing.net,IQComputing,Web Host
 iqfiber.com,IQ Fiber,ISP
@@ -3388,8 +3814,11 @@ iqhive.com,IQ Hive,MSP
 iqon-global.com,IQON Global,Web Host
 irbr.ru,ИРБР,Web Host
 irib.ir,IRIB Islamic Republic of Iran Broadcasting,Government Media
+irinn.in,IRINN India Registry,Nonprofit
+irm.srl,IP.RO (Internet Resources Management),Web Host
 ironmountain.com,Iron Mountain,Technology
 ironwoodcrc.com,Ironwood Cancer & Research Centers,Healthcare
+irtelcom.ru,Irtelcom,ISP
 is.co.za,Internet Solutions,ISP
 is74.ru,Intersvyaz,ISP
 isc.org,Internet Systems Consortium,Nonprofit
@@ -3400,6 +3829,7 @@ isid.co.jp,Information Services International-Dentsu,MSP
 isiline.it,Isiline,ISP
 isite.de,iWelt,MSP
 isnet.net.tr,Is Net,ISP
+isoceltelecom.com,Isocel,ISP
 isomediainc.com,Isomedia,ISP
 isp.net,ISP.net Las Vegas,ISP
 ispalliance.cz,ISP Alliance,ISP
@@ -3424,22 +3854,27 @@ it7.net,IT7,Web Host
 itafiber.com.br,ITAFIBER,ISP
 itainternet.com.br,Ita Internet,ISP
 italiaonline.it,Italiaonline,Web Host
+itam.mx,ITAM Instituto Tecnologico Autonomo de Mexico,Education
 itanet.psi.br,ITANET,ISP
 itaon.net.br,ITAON,ISP
 itb.ac.id,Institut Teknologi Bandung,Education
+itc-web.com,Interstate Telecommunications Cooperative,ISP
 itcen.com,ITCenenTec,ISP
 itcsa.net,Informática y Telecomunicaciones,ISP
 itdz-berlin.de,IT-Dienstleistungszentrum Berlin,Government
 ite.net,IT&E Guam,ISP
 itel.com,iTel Networks,ISP
+itenos.de,ITENOS,MSP
 iteso.mx,ITESO,Education
 itgate.it,IT.Gate,ISP
 itglobal.com,ITGLOBAL,IaaS
+ithaca.edu,Ithaca College,Education
 ithostline.com,IT HOSTLINE,MSP
 iti-e.co.jp,ITI,Healthcare
 itility.co.uk,Itility,Web Host
 itm8.com,itm8,MSP
 itmedia.co.jp,ITmedia,News
+itnet33.ru,ITNET Kovrov,ISP
 itnorrbotten.se,IT Norrbotten,MSP
 itools.mn,iTools,MSP
 itop.net.br,iTop,ISP
@@ -3477,6 +3912,7 @@ jaaikosei.or.jp,Aichiken Kosei Agricultural Cooperative Association,Agriculture
 jabatus.fr,o2switch,Web Host
 jabbroadband.com,Rise Internet,ISP
 jablonka.cz,Jablonka.cz,Nonprofit
+jackhenry.com,Jack Henry,SaaS
 jacobs.com,Jacobs Engineering,Construction
 jadecom.or.jp,Japan Association for Development of Community Medicine,Healthcare
 jadeworld.com,Jade Software,SaaS
@@ -3506,16 +3942,19 @@ jcntv.co.kr,JCN,ISP
 jcom.co.jp,JCOM,ISP
 jcpenney.com,JCPenney,Retail
 jcu.edu.au,James Cook University,Education
+jcv.co.jp,Joetsu Cable Vision,ISP
 jcwifi.com,JC WiFi,ISP
 jd.com,JD.com,Retail
 jeebr.net,Jeebr Mumbai,ISP
 jefferson.edu,Thomas Jefferson University,Education
+jejunu.ac.kr,Jeju National University,Education
 jellyfish.systems,Namecheap,Email Security
 jenny.africa,Jenny Internet,ISP
 jeroenboschziekenhuis.nl,Jeroen Bosch Ziekenhuis,Healthcare
 jetappcloud.com,Jetapp,Web Host
 jetcan.com.my,jetCan,Industrial
 jetflash.net.id,Jet-Flash,ISP
+jetnet.es,Jetnet Wimax,ISP
 jetz.com.br,Jetz Internet,ISP
 jewishnews.net.au,The Australian Jewish News,News
 jhu.edu,Johns Hopkins University,Education
@@ -3529,12 +3968,15 @@ jisc.ac.uk,Jisc,Education
 jjexpress.com.my,JJ Express Services,Logistics
 jknet.com.br,JK Telecom,ISP
 jlab.org,Thomas Jefferson National Accelerator Facility,Education
+jlm.net.id,Jala Lintas Media,ISP
 jm-data.at,JM-DATA,MSP
 jma-c.jp,Japan Medical Alliance Corporation,Healthcare
+jmdi.pl,JMDI,ISP
 jmu.edu,James Madison University,Education
 jnt.fi,JNT Jakobstadsnejdens Telefon,ISP
 jnu.ac.kr,Chonnam National University,Education
 joanneum.at,Joanneum Research,Science
+jocarroll.com,Jo-Carroll Energy,Utilities
 johnshopkins.edu,Johns Hopkins University,Education
 joink.com,Joink,ISP
 joker-forward.com,Joker.com,Email Provider
@@ -3544,11 +3986,13 @@ joomlawired.com,Joomla Wired,Web Host
 jotazo.com,Jotazo,ISP
 jotazo.net,Jotazo Telecom,ISP
 jote.cloud,Jotelulu,Web Host
+jotel.co.rs,Jotel Serbia,ISP
 jotelulu.cloud,Jotelulu,Web Host
 jotelulu.com,Jotelulu,Web Host
 jouwweb.site,JouwWeb,Web Host
 joyent.com,Joyent,IaaS
 jpmchase.com,JPMorgan Chase,Finance
+jpmorgan.com,JPMorgan Chase,Finance
 jpmorganchase.com,JPMorgan Chase,Finance
 jprdigital.in,JPR Digital,ISP
 jreast.co.jp,JR East,Logistics
@@ -3563,14 +4007,18 @@ juce.ca,JUCE Communications,ISP
 juicemagazine.com,Juice Magazine,Publishing
 juliusbaer.com,Julius Baer,Finance
 junct.com,The Junction Internet,ISP
+junet.se,Junet,ISP
 jupiter.com.br,Jupiter Telecomunicacoes,ISP
 jupiterprovedor.com.br,Jupiter Provedor,ISP
 just-size.net,Just-Size Networks,Web Host
 justwebtelecom.com.br,JustWeb,ISP
 jvsnet.com.br,JVS Net,ISP
 jwa.or.jp,Japan Weather Association,Government
+jway.jp,JWAY Cable TV,ISP
 jweiland12.net,domainfactory GmbH,Web Host
+jwemc.coop,Joe Wheeler EMC,Utilities
 jwtech.co.th,JW TECH,Industrial
+k-sistemos.lt,KIS Kauno interneto sistemos,ISP
 k-state.edu,Kansas State University,Education
 k-telecom.org,K-Telecom,ISP
 k12.hi.us,Hawaii Department of Education,Education
@@ -3581,6 +4029,7 @@ kaashosting.nl,KaasHosting,Web Host
 kabel-deutschland.de,Vodafone,ISP
 kabelplus.at,kabelplus,ISP
 kabelszat2002.hu,KabelszatNet,ISP
+kacific.com,Kacific Broadband Satellites,ISP
 kaeri.re.kr,Korea Atomic Energy Research Institute,Government
 kagawa-u.ac.jp,Kagawa University,Education
 kages.at,KAGes (Steiermarkische Krankenanstaltengesellschaft),Healthcare
@@ -3590,12 +4039,15 @@ kagoya.net,KAGOYA,Web Host
 kai.jp,KAI Group,Manufacturing
 kainosprint.com.au,Kainos Print,Print
 kaisanet.fi,Kaisanet,ISP
+kaiserpermanente.org,Kaiser Permanente,Healthcare
 kaist.ac.kr,KAIST,Education
 kakaocorp.com,Kakao,SaaS
+kalaam-telecom.com,Kalaam Telecom Bahrain,ISP
 kalittacharters.com,Kalitta Charters,Logistics
 kaluga.ru,CentrTelecom Kaluga,ISP
 kamatera.com,Kamatera,IaaS
 kamensktel.ru,KamenskTelecom,ISP
+kamopower.com,KAMO Electric Cooperative,Utilities
 kamtv.ru,SKTV,ISP
 kanazawa-u.ac.jp,Kanazawa University,Education
 kaneka.co.jp,Kaneka,Industrial
@@ -3606,10 +4058,12 @@ kansas.gov,State of Kansas,Government
 kansas.net,KansasNwt,MSP
 kaopucloud.com,Kaopu Cloud,IaaS
 kari.re.kr,KARI Korea Aerospace Research Institute,Science
+karistelefon.fi,Karis Telefon,ISP
 kartelkomi.ru,Kartel,ISP
 kaspr-privacy.io,Kaspr,Marketing
 kasserver.com,all-inkl.com,Web Host
 katch.co.jp,KATCH Network,ISP
+kate-wing.si,KATE Nova Gorica,ISP
 katelecom.com.br,KA Telecom,ISP
 kater.com.br,Kater Telecom,ISP
 kattare.com,Kattare,Web Host
@@ -3620,6 +4074,8 @@ kaust.edu.sa,KAUST King Abdullah University,Education
 kazintercom.kz,Kaz InterCom,ISP
 kazrena.kz,KazRENA,Education
 kaztranscom.kz,Jusan Mobile,ISP
+kband.no,Hardanger Breiband,ISP
+kbc.com,KBC Group,Finance
 kbro.com.tw,kbro,ISP
 kbtelecom.net,Koos Broadband Telecom,ISP
 kcc.com,Kimberly-Clark,Manufacturing
@@ -3637,6 +4093,7 @@ kcweb.net,KC Web,ISP
 kddi-webcommunications.co.jp,KDDI Web Communications,Web Host
 kddi.com,KDDI,ISP
 kddi.ne.jp,KIDDI,ISP
+kdtidc.com,KDT Korea Data Telecommunication,Web Host
 keio.ac.jp,Keio University,Education
 keio.jp,Keio University,Education
 kek.jp,KEK,Education
@@ -3661,6 +4118,7 @@ kforce.com,Kforce,Staffing
 kg-graphics.net,KG Graphics,Print
 kggroup.eu,Kauno Grūdai,Food
 khalijfarsonline.net,Khalij Fars Online,ISP
+khalijonline.net,Khalij Online,ISP
 khplay.nl,KaasHosting,Web Host
 khu.ac.kr,Kyung Hee University,Education
 kicks-ass.net,DynDNS,Web Host
@@ -3678,12 +4136,15 @@ kinx.net,KINX,ISP
 kio.tech,KIO Networks,Web Host
 kirchmann-hurry.co.za,Kirchmann-Hurry Construction,Construction
 kirkbrothers.com,Kirk Brothers Supercenter,Automotive
+kirz.com,KIRZ,ISP
 kist.re.kr,KIST Korea Institute of Science and Technology,Science
 kit.ac.jp,Kyoto Institute of Technology,Education
 kit.edu,Karlsruhe Institute of Technology,Education
 kitano-hp.or.jp,Kitano Hospital,Healthcare
+kitcarson.com,Kit Carson Electric Cooperative,Utilities
 kjm6.de,kajomi MAIL,Email Provider
 kk-takano.co.jp,Takano,Industrial
+kktcell.com,Kuzey Kibris Turkcell,ISP
 klimovsk.net,Klimovsk Network,ISP
 klinik-arlesheim.ch,Klinik Aresheim,Healthcare
 kliniken-es.net,Klinikum Esslingen,Healthcare
@@ -3695,13 +4156,16 @@ kmtn.ru,Kostrom City Telephone Network,ISP
 kmu.ac.jp,Kansai Medical University,Education
 kmu.ac.kr,Keimyung University,Education
 kmv.ru,Post LTD,ISP
+knet.ca,K-Net (Keewaytinook Okimakanak),ISP
 knet.kg,Kyrgyztelecom,ISP
 knipp.de,Knipp Medien und Kommunikation,Web Host
 knockdesign.com,Knock Design,Marketing
 knowit.fi,Knowit,MSP
 knu.ac.kr,Kyungpook National University,Education
+koba.pl,Koba,ISP
 kobe-u.ac.jp,Kobe University,Education
 kochi-u.ac.jp,Kochi University,Education
+kochind.com,Koch Industries,Conglomerate
 kodak.com,Kodak,Technology
 kodiaksys.com,ARIOS,SaaS
 koerber.de,Korber,Conglomerate
@@ -3709,17 +4173,24 @@ koesio.com,Koesio,MSP
 kogakuin.ac.jp,Kogakuin University,Education
 kogite.fr,KoGite,Web Host
 kolsitegroup.com,Kolsite Group,Industrial
+komfort21vek.ru,Comfort XXI Century,ISP
+komro.net,komro,ISP
 kongkow.com,Kongkow,SaaS
 konicaminolta.us,Konica Minolta,Technology
+konkuk.ac.kr,Konkuk University,Education
+konverto.eu,Konverto,MSP
 korbank.pl,Korbank,ISP
 kordia.co.nz,Kordia,ISP
 korea.ac.kr,Korea University,Education
 korea.kr,Government of South Korea,Government
+koscom.co.kr,KOSCOM,Finance
+koshinomiyako.jp,Koshinomiyako Network,ISP
 kosovotelecom.com,Telekomi i Kosoves (Vala),ISP
 kostroma.net,Kostrom City Telephone Network,ISP
 koumbit.net,Koumbit.org,MSP
 kovacmed.com,KOVAC-MED,Healthcare
 kpchealth.com,KPC Healthcare,Healthcare
+kpi.ua,Kyiv Polytechnic Institute,Education
 kpmg.com,KPMG,Consulting
 kpn.com,KPN,ISP
 kpn.net,KPN,ISP
@@ -3727,13 +4198,16 @@ kpu-m.ac.jp,Kyoto Prefectural University of Medicine,Education
 kreativemachinez.tech,Kreative Machinez,Marketing
 kreonet.net,KREONET,Education
 kroger.com,The Kroger Co,Retail
+kronoz.co.jp,kronos,MSP
 kryptronic.com,Kryptronic,SaaS
 ksc.net,KSC,Web Host
 ksmship.com,Korea Eco Management,Logistics
 ksu.tj,Khujand State University,Education
+kt-net.at,KT-NET Austria,ISP
 kt.com,Korea Telecom,ISP
 kt.kg,Kyrgyztelecom,ISP
 ktc.kz,KTC Kazakhstan LLP,Industrial
+kth.se,KTH Royal Institute of Technology,Education
 kthcn.co.kr,kt HCN,ISP
 ktis.net,Kingdom Networks,ISP
 ktk-sol.co.jp,KtK Solutions,Email Security
@@ -3752,6 +4226,7 @@ kusunoki-hp.com,Kusunoki Hospital,Healthcare
 kutztown.edu,Kutztown University,Education
 kvant-telecom.ru,Kvant-Telecom,ISP
 kvhasia.com,KVH Asia,ISP
+kw.ac.kr,Kwangwoon University,Education
 kwaoo.com,K-NET (Kwaoo),ISP
 kyberio.com,Kyberio,Web Host
 kyivstar.ua,Kyivstar,ISP
@@ -3764,6 +4239,7 @@ kyoto-su.ac.jp,Kyoto Sangyo University,Education
 kyoto-u.ac.jp,Kyoto University,Education
 l3harris.com,L3Harris,Defense
 la.net.ua,Lanet,ISP
+labcorp.com,Labcorp,Healthcare
 laboratoires-thea.fr,Laboratoires Théa,Healthcare
 laca.org,Licking Area Computer Association,Nonprofit
 lacoe.edu,Los Angeles County Office of Education,Education
@@ -3772,15 +4248,19 @@ lacounty.gov,Los Angeles County,Government
 ladwp.com,LADWP Los Angeles Department of Water and Power,Utilities
 lafayette.edu,Lafayette College,Education
 lagoon.nc,Lagoon New Caledonia,ISP
+lakeregionfiber.com,Lake Region Technology,ISP
 lakotanetwork.com,CRST Telephone Authority (Lakota Network),ISP
 lamar.edu,Lamar University,Education
 lamrc.com,Lam Research,Manufacturing
 lancastergeneralhealth.org,Penn Medicine Lancaster General Health,Healthcare
 lane.edu,Eugene School District 4J,Education
 lanet.ua,Lanet,ISP
+lankacom.net,Lanka Communication Services,ISP
 lanl.gov,Los Alamos National Laboratory,Government
 lanoptic.ru,LAN-Optic,ISP
+lanset.com,Lanset America,ISP
 lanta-net.ru,LanTa,ISP
+laotel.com,Lao Telecom,ISP
 laptech.com,LapTech Precision,Manufacturing
 larkinhealth.com,Larkin Health System,Healthcare
 larkinhospital.com,Larkin Health System,Healthcare
@@ -3794,6 +4274,7 @@ latisys.com,Latisys (Zayo),Web Host
 latisys.net,Latisys,Web Host
 latitude.sh,Latitude.sh,IaaS
 latrobe.edu.au,La Trobe University,Education
+latvenergo.lv,Latvenergo,Utilities
 laurentian.ca,Laurentian University,Education
 lauruslabs.com,Lasarus Labs,Healthcare
 lawtendo.com,Lawtendo,Legal
@@ -3801,10 +4282,13 @@ lazernet.com.br,Lazernet,ISP
 lb.go.gov.br,Government of Goias State Brasil,Government
 lbl.gov,Lawrence Berkeley National Laboratory,Government
 lblesd.k12.or.us,Linn Benton Lincoln Education Service District,Education
+lchost.co.uk,LCHost,Web Host
 lcmh.com,Lake Charles Memorial Health System,Healthcare
+lcrcom.es,Aire Networks (LCR),ISP
 lcube-server.de,LCube,Web Host
 lcv.jp,LCV,ISP
 lcv.ne.jp,LCV Corporation,ISP
+ldexconnect.co.uk,Iomart LDeX (LDexConnect),Web Host
 lds.online,Luganskie Domashnie Seti,ISP
 ldw.com,Last Day of Work,Entertainment
 leaderdrug.com,Cardinal Health,Healthcare
@@ -3812,7 +4296,9 @@ leadergpu.com,LeaderGPU,IaaS
 leadpages.co,Leadpages,Marketing
 leadsystemsmarketing.com,Lead Systems Marketing,Marketing
 leaguelineup.com,LeagueLineup,Sports
+leaptel.com.au,Leaptel,ISP
 learn.ac.lk,Lanka Education and Research Network,Education
+learn.k12.ct.us,LEARN Connecticut,Education
 learningstream.com,Learning Stream,SaaS
 leaseweb.ca,Leaseweb,Web Host
 leaseweb.com,Leaseweb,Web Host
@@ -3822,11 +4308,14 @@ legenditsolutions.com,Legend IT Solutions,Web Host
 legroupeforget.com,Le Groupe Forget,Healthcare
 lehigh.edu,Lehigh University,Education
 leidos.com,Leidos,Defense
+leon.k12.fl.us,Leon County Schools Florida,Education
 leon.pl,Leon Polish ISP,ISP
 leonardocompany.com,Leonardo,Defense
 leonet.de,LEONET,ISP
+leonet.it,Var Group (Leonet),MSP
 lepida.net,Lepida,ISP
 lestetelecom.com.br,Leste,ISP
+letaba.net,Letaba Networks,ISP
 letsrev.com,REV,ISP
 level-7.co.za,Level 7 Internet,ISP
 level3.com,Lumen,ISP
@@ -3835,6 +4324,7 @@ lewtelnet.de,LEW TelNet,ISP
 lexi.net,Lexicom,MSP
 lexicom.ca,Lexicom,MSP
 lf.net,LF.net Stuttgart,ISP
+lgatelecom.net,LGA Telecom,MSP
 lgcns.com,LG CNS,Technology
 lgfl.net,London Grid for Learning,Education
 lghealth.org,Penn Medicine Lancaster General Health,Healthcare
@@ -3860,6 +4350,7 @@ libraesva.com,Libraesva,Email Security
 library.on.ca,Ontario Libraries,Nonprofit
 lidernetfibra.com.br,Lidernet,ISP
 lidero.net,Lidero Network,ISP
+lietpark.com,Lietpark Communications,ISP
 life.by,Life Belarus (BeST),ISP
 lifecell.ua,lifecell,ISP
 lifenetworks.com.br,Lifenetworks,ISP
@@ -3867,10 +4358,12 @@ ligataxi.com,LiguaTaxi,SaaS
 liggatelecom.com.br,Ligga Telecom,ISP
 lightbound.com,LightBound,ISP
 lightedge.com,LightEdge,MSP
+lightningbroadband.com.au,Lightning Broadband,ISP
 lightningfibre.co.uk,Lightning Fibre,ISP
 lightnode.com,LightNode,Web Host
 lightower.net,Lightower Fiber Networks,ISP
 lightpathfiber.com,Lightpath,ISP
+lightwire.co.nz,Lightwire NZ,ISP
 lightwyse.com,Lumos,ISP
 ligmais.com.br,Lig+Telecom,ISP
 liguriadigitale.it,Liguria Digitale,MSP
@@ -3884,9 +4377,12 @@ lindsaymunicipalhospital.com,Lindsay Municipal Hospital,Healthcare
 line-net.ru,LineNet,ISP
 linejet.net.br,LineJet,ISP
 linfortel.com.br,Linfortel,ISP
+linivo.net,Linivo,SaaS
 link-assistant.com,SEO PowerSuite,SaaS
 link.net.id,Link Net,ISP
 link.net.pk,Jazz,ISP
+link.net.ua,Link Telecom Ukraine,ISP
+link11.com,Link11,Email Security
 link3.net,Link3 Technologies,ISP
 linkbrasil.net.br,Link Brasil,ISP
 linkedin.com,LinkedIn,Social Media
@@ -3902,12 +4398,16 @@ linqtelecom.com.br,LinQ Telecom,ISP
 lintasarta.net,Lintasarta,ISP
 linxtelecom.com,CITIC Telecom CPC,ISP
 linzag-telekom.at,LINZ AG TELEKOM,ISP
+linznet.at,LinzNet,ISP
 liquid.tech,Liquid Intelligent Technologies,ISP
 liquidnetlimited.com,LiquidNet,Web Host
 liquidtelecom.com,Liquid Intelligent Technologies,ISP
 liquidtelecom.net,Liquid Intelligent Technologies,ISP
 liquidweb.com,Liquid Web,Web Host
+lisco.com,LISCO,ISP
 listrak.com,Listrak,Marketing
+litecom.ch,Litecom,ISP
+liteserver.nl,LiteServer,Web Host
 liteserverdns.in,The PowerHost,Web Host
 litiumdrift.se,Litium,SaaS
 litnet.lt,LITNET Lithuanian Research and Education Network,Education
@@ -3921,15 +4421,19 @@ livedns.co.il,LiveDNS,Web Host
 livedo.jp,Livedo Corporation,Healthcare
 livemail.co.uk,Fasthosts Internet Ltd,Web Host
 livenation.com,Live Nation,Entertainment
+liveoakfiber.com,LiveOak Fiber,ISP
 liveperson.net,LivePerson,SaaS
 liwest.at,LIWEST,ISP
 llnl.gov,Lawrence Livermore National Laboratory,Government
+lloydsbanking.com,Lloyds Banking Group,Finance
 lloydsbankinggroup.com,Lloyds Banking Group,Finance
 lluh.org,Loma Linda University Health,Healthcare
 llumc.edu,Loma Linda University Medical Center,Healthcare
 lmco.com,Lockheed Martin,Defense
 lmi.net,LMi.net,ISP
+lmt.lv,LMT Latvia,ISP
 lmu.edu,Loyola Marymount University,Education
+ln.edu.hk,Lingnan University,Education
 lncc.br,LNCC Brazilian National Laboratory for Scientific Computing,Science
 loading.es,Loading,Web Host
 loblaw.ca,Loblaw,Retail
@@ -3953,6 +4457,7 @@ logosoft.ba,Logosoft,ISP
 lokalonline.com.br,Lokal Online Telecom,ISP
 lolipop.jp,Lolipop,Web Host
 lomalindahealth.org,Loma Linda University Health,Healthcare
+lonconnect.co.uk,LonConnect,ISP
 london.on.ca,St. Joseph's Health Care London,Healthcare
 longlines.com,Long Lines Broadband,ISP
 loni.org,LONI,Education
@@ -3965,6 +4470,7 @@ louisiana.edu,University of Louisiana at Lafayette,Education
 louisiana.gov,Louisiana Government,Government
 louisville.edu,University of Louisville,Education
 lounea.fi,Lounea,ISP
+lovelandpulse.com,Pulse Loveland,Utilities
 lowesthosting.com,Lowest Hosting,Web Host
 loyalty.com,LoyaltyOne,SaaS
 lpages.co,Leadpages,Marketing
@@ -3986,7 +4492,11 @@ ltt.ly,Libya Telecom & Technology,ISP
 ltu.se,Luleå University of Technology,Education
 lu.se,Lund University,Education
 lubonet.net.pl,LUBONET,ISP
+luc.edu,Loyola University Chicago,Education
+lucky.net,Lucky Net Ukraine,ISP
+luganet.ru,Luganet,ISP
 lugtel.com,Lugansk Telephone Company,ISP
+lukoil-inform.ru,Lukoil-Inform,Industrial
 lumen.com,Lumen,ISP
 luminabroadband.com,Lumina Broadband,ISP
 lumison.net,Pulsant,Web Host
@@ -4011,8 +4521,10 @@ m1net.com.sg,M1,ISP
 m247.ro,M247,IaaS
 m247global.com,M247,Web Host
 m2dtelecom.com.br,M2D Telecom,ISP
+m3comva.com,M3COM,ISP
 m4w.at,M4W Kreativ,Marketing
 m9network.com,Volico Data Centers,Web Host
+mable.jp,San-in Cable Vision,ISP
 macalester.edu,Macalester College,Education
 machanet.com.br,Grupo Nordeste Telecom,ISP
 macomnet.ru,Macomnet,ISP
@@ -4026,6 +4538,7 @@ maddock.net,Maddock Films,Entertainment
 maersk.com,Maersk,Logistics
 maestroit.com,Maestro IT Services,MSP
 maffin.ad.jp,"MAFF (Japan Ministry of Agriculture, Forestry and Fisheries)",Government
+magazineluiza.com.br,Magazine Luiza,Retail
 mageal.ru,Mageal,ISP
 magenta.at,Magenta,ISP
 magentosite.cloud,Adobe Magento,SaaS
@@ -4047,6 +4560,7 @@ mailchimp.com,Intuit Mailchimp,Marketing
 mailcloud.com.tw,MailCloud,Email Provider
 mailcontrol.com,Forcepoint,Email Security
 maildealer.jp,Mail Dealer,SaaS
+mailgun.com,Mailgun,SaaS
 mailgun.info,Mailgun,SaaS
 mailgun.net,Mailgun,SaaS
 mailgun.us,Mailgun,SaaS
@@ -4078,11 +4592,13 @@ malmo.se,City of Malmo,Government
 mamacheaps.com,Mama Cheaps,Retail
 man-da.de,MANDA Darmstadt,Education
 managedns.org,IBM Cloud,IaaS
+managedway.com,ManagedWay,Web Host
 manchetelecom.fr,Manche Telecom,ISP
 mandrillapp.com,Mailchimp Transactional,SaaS
 mango.com.bd,Mango Teleservices Bangladesh,ISP
 manh.com,Manhattan,SaaS
 manhattan.edu,Manhattan University,Education
+manitu.de,manitu,Web Host
 manxtelecom.com,Manx Telecom,ISP
 mapheadstart.org,Mississippi Action for Progress,Nonprofit
 mappsoluciones.com,MappS Soluciones,Web Host
@@ -4100,6 +4616,7 @@ marriott-service.com,Marriott,Travel
 marriott.com,Marriott,Travel
 mars-inc.com,Mars,Food
 marsh.com,Marsh,Finance
+marshall.edu,Marshall University,Education
 martinsnet.com.br,Martins.Net,ISP
 marubeni.com,Marubeni,Conglomerate
 maruyamakai.jp,Maruyamakai,Healthcare
@@ -4136,16 +4653,20 @@ matrixnetglobal.com,Matrixnet,ISP
 mauriziano.it,Ordine Mauriziano,Healthcare
 maxaninteirorsystems.com,Maxan Interior Systems,Industrial
 maximtech.com,Maximtech,Web Host
+maximuma.net,MaximumNet,ISP
 maximweb.com,Maxim Management Services,Healthcare
 maxindo.net.id,Maxindo Mitra Solusi,ISP
 maxis.com.my,Maxis,ISP
+maxnet.ru,Maxnet Kaluga,ISP
 maxnet.ua,Maxnet,ISP
 maxxsouth.com,MaxxSouth Broadband,ISP
 mayernetworks.com,Mayer Networks,MSP
 mayoclinic.com,Mayo Clinic,Healthcare
 mbari.org,Monterey Bay Aquarium Research Institute,Education
+mbcokinawa.net,MBC Okinawa,ISP
 mbonetworks.com,MBO Networks,ISP
 mc.net.co,Media Commerce Partners,ISP
+mcat.co.jp,MCAT,ISP
 mccooknet.com,McCookNet,Web Host
 mccormickplace.com,McCormick Place,Event Planning
 mcdir.me,McHost,Web Host
@@ -4157,6 +4678,7 @@ mcgill.ca,McGill University,Education
 mchsi.com,MediacomCable,ISP
 mci.ir,MCI Iran,ISP
 mckesson.com,McKesson,Healthcare
+mckinsey.com,McKinsey and Company,Consulting
 mclaut.com,McLaut,ISP
 mcmahonmed.com,McMahon Publishing,Publishing
 mcmaster.ca,McMaster University,Education
@@ -4164,6 +4686,7 @@ mcmaster.com,McMaster-Crr,Manufacturing
 mcmtelecom.com,MCM Business (Megacable Mexico),ISP
 mcnbd.com,Millennium Computer's & Networking,MSP
 mcnc.org,MCNC,Education
+mcntelecom.com,MCN Telecom (Kompaas),ISP
 mcpre.ru,McHost,Web Host
 mcpsmd.org,Montgomery County Public Schools (Maryland),Education
 mcsnet.ca,MCSnet,ISP
@@ -4178,8 +4701,10 @@ mdcc.gob.pe,Municipalidad Distrital de Cerro Colorado,Government
 mdcourts.gov,Maryland Courts,Government
 mdlink.de,MDlink,MSP
 mdlsx.ca,"Middlesex County, Canada",Government
+mdstelecom.com.ve,MDS Telecom,ISP
 mdu.com,MDU Resources,Utilities
 me.com,Apple iCloud,Email Provider
+mec.pt,Portuguese Ministry of Education,Government
 mecon.gov.ar,Argentina Ministry of Economy,Government
 medallia.com,Medllia,SaaS
 medcity.net,HCA Healthcare,Healthcare
@@ -4193,6 +4718,7 @@ mediafuze.com,Mediafuze,Marketing
 mediaprint.at,Mediaprint,Publishing
 mediasolutionsco.com,Media Solutions,Marketing
 mediasolutionscorp.com,Media Solutions,Marketing
+mediateknik.net,Mediateknik,Web Host
 mediaticanet.it,Mediatica,Web Host
 medical-surveys.com,Medical Surveys,Healthcare
 medicalcomputersystems.com,Medical Computer Systems,Healthcare
@@ -4205,6 +4731,8 @@ medline.com,Medline,Healthcare
 medtronic.com,Medtronic,Healthcare
 meduniwien.ac.at,Medical University of Vienna,Education
 medweb.net,Medweb,Healthcare
+meerfarbig.net,meerfarbig,Web Host
+mega-m.net,Mega M MegaTel,ISP
 mega.kg,Maga-Line,ISP
 mega.mx,Megacable,ISP
 megacable.com.ar,MERCO Comunicaciones,ISP
@@ -4216,6 +4744,7 @@ megadata.net.id,Megadata ISP,ISP
 megafon.ru,MegaFon,ISP
 megafon.tj,MegaFon,ISP
 megaline.kg,Maga-Line,ISP
+megalink.com,MegaLink Bolivia,ISP
 megalink.net.ru,Мегалинк,ISP
 megalinkinternet.com.br,MegaLink,ISP
 megamailservers.com,MegaMailServers,MSP
@@ -4223,6 +4752,8 @@ megamailservers.eu,MegaMailServers,MSP
 meganetrj.com.br,Meganet,ISP
 megared.net.mx,Megared,ISP
 megavision.net.id,Megavision,ISP
+meghbelabroadband.com,Meghbela Broadband,ISP
+meijer.com,Meijer,Retail
 meiji.ac.jp,Meiji University,Education
 meinserver.io,Timme Hosting,Web Host
 mekongnet.com.kh,MekongNet,ISP
@@ -4243,6 +4774,7 @@ mercury.co.nz,Mercury NZ,Utilities
 mercurygate.net,MercuryGate,SaaS
 merezha.in.ua,Merezha,ISP
 meric.net.tr,Meriç Hosting,Web Host
+meriplex.com,Meriplex Communications,MSP
 merit.edu,Merit Network,Education
 merl.com,Mitsubishi Electric Research Labs,Education
 merlien.com,Merlien,Event Planning
@@ -4257,15 +4789,20 @@ messagingengine.com,Fastmail,Email Provider
 mesvr.com,ReadNotify,Email Provider
 metalink.net,MetaLINK Technologies,ISP
 metanet.co.kr,Metanet DT,MSP
+metasolutions.net,META Solutions,Education
 metcal.com.my,Metcal Technologies,Industrial
 meteversecloud.com,Meteverse,IaaS
 metfone.com.kh,Metfone,ISP
 metpro.co,MetPro,SaaS
 metricsthatmatter.com,Metrics That Matter,SaaS
+metro-set.ru,Metroset Tyumen,ISP
 metro.digital,METRO Digital,Technology
 metrocomm.com,Metro Communications,ISP
 metrofibre.co.za,Metrofibre,ISP
+metroflex.com.br,Metroflex,ISP
 metrohealth.org,MetroHealth,Healthcare
+metrolink.it,Metrolink Italy,ISP
+metromax.ru,Metromax,ISP
 metronet.com,MetroNet,ISP
 metronetinc.net,Metronet,ISP
 metrored.com.mx,Metrored,ISP
@@ -4276,6 +4813,8 @@ metrotel.net.co,Metrotel,ISP
 metsagroup.com,Metsa Group,Manufacturing
 mettel.net,MetTel,ISP
 metu.edu.tr,Middle East Technical University,Education
+mevspace.com,Mevspace,Web Host
+mewecom.it,Mewecom,ISP
 mexxus.com,Mexxus Media,Marketing
 mexxusmedia.com,Mexxus Media,Marketing
 mezmotech.com,Mezmo,SaaS
@@ -4283,6 +4822,7 @@ mf.gov.pl,Polish Ministry of Finance,Government
 mfa-inc.com,MFA,Industrial
 mfeed.ad.jp,Internet Multifeed (JPNAP),ISP
 mgb.org,Mass General Brigham,Healthcare
+mgconecta.com.br,Conecta,ISP
 mgnettelecom.com.br,MG NET Telecom,ISP
 mgp.net.br,MGP Telecom,ISP
 mgsm.ru,Aviasales,Travel
@@ -4298,6 +4838,7 @@ michigan.gov,State of Michigan,Government
 microchip.com,Microchip Technology,Manufacturing
 microchip.net.pl,Microchip s.c.,ISP
 microfocus-japan.com,Micro Focus,MSP
+microfocus.com,Micro Focus (OpenText),SaaS
 micron.com,Micron Technology,Manufacturing
 micron21.com,Micron21 Datacentre,Web Host
 micronet.in,MicroNet Gigafiber,ISP
@@ -4306,11 +4847,14 @@ microscaninternet.com,Microscan,ISP
 microservizi.com,Microservizi,ISP
 microsoft.com,Microsoft,Technology
 mid-hudson.com,Mid-Hudson Cablevision,ISP
+midcentury.com,Mid Century Communications,ISP
 midcityvet.com,MidCity Veterinary Hospital,Healthcare
 midco.com,Midco,ISP
 middlebury.edu,Middlebury College,Education
 middlesex.ca,"Middlesex County, Canada",Government
 midi-loisirs.com,Midi Loisirs,Entertainment
+midrivers.com,Mid-Rivers Communications,ISP
+midsouthfiber.com,MidSouth Fiber,ISP
 mie-u.ac.jp,Mie University,Education
 migadu.com,Migadu,Email Provider
 migracion.go.cr,Costa Rica Migration,Government
@@ -4339,6 +4883,7 @@ mirai.ne.jp,Mirai NET,ISP
 miralogic.ru,MiraLogic,ISP
 miranda-media.ru,Miranda Media,ISP
 mirohost.net,MiroHost,Web Host
+misaka.io,Misaka Network,IaaS
 misd.net,Macomb Intermediate School District,Education
 misshosting.se,Miss Hosting,Web Host
 mississauga.ca,City of Mississauga,Government
@@ -4356,6 +4901,7 @@ mittwald.info,Mittwald,Web Host
 mittwaldserver.info,Mittwald,Web Host
 miva.com,Mirva,SaaS
 mivamerchant.net,Mirva,SaaS
+mixvoip.com,Mixvoip,ISP
 miyazaki-catv.ne.jp,Miyazaki Cable Television,ISP
 mizban.com,Mizban,Web Host
 mk.de,MK Netzdienste,MSP
@@ -4376,14 +4922,18 @@ mmprovedor.com.br,MM Telecom,ISP
 mmrs.jp,Mirai Communication Network Inc.,Web Host
 mnet.bg,MSAT Cable,ISP
 mni.net,MNI,Marketing
+mnogobyte.ru,MnogoByte,Web Host
 mnsi.net,MNSi Telecom,ISP
 mnzoo.org,Minnesota Zoo,Entertainment
 moack.co.kr,MOACK,Web Host
+mobi.net.lb,Mobi Lebanon (Broadband Plus),ISP
 mobifone.vn,MobiFone,ISP
+mobil.com,ExxonMobil,Industrial
 mobilecountypublicworks.net,Mobile County Public Works,Government
 mobilosoft.be,Mobilosoft,Marketing
 mobilosoft.com,Mobilosoft,Marketing
 mobily.com.sa,Mobily,ISP
+mobinet.mn,Mobinet Mongolia,ISP
 mobinil.com,Orange Egypt,ISP
 mobinnet.net,Mobinnet,ISP
 mobtelecom.com.br,Mob Telecom,ISP
@@ -4429,10 +4979,13 @@ morganstanley.com,Morgan Stanley,Finance
 morganstanleysmithbarney.com,Morgan Stanley Smith Barney,Finance
 morrisville.edu,SUNY Morrisville,Education
 morroonline.com.br,Morro Telecom,ISP
+mosaictelecom.com,Mosaic Technologies,ISP
 moselletelecom.fr,Moselle Télécom,ISP
 mostobene.com,Mostobene,Healthcare
+motivtelecom.ru,Motiv,ISP
 motorola.com,Motorola,Technology
 mounet.com,MouNet,ISP
+mountaintelephone.com,Mountain Telephone,ISP
 mountsinai.org,Mount Sinai,Healthcare
 moverworx.net,MoverworX,SaaS
 movicel.co.ao,Movicel,ISP
@@ -4458,6 +5011,7 @@ mserwis.pl,MSERWIS,Web Host
 msfiber.net,Mainstream Fiber Networks,ISP
 msfibra.com.br,MS Fibra,ISP
 msgexch.com,Constant Contact,Marketing
+msk-ix.ru,MSK-IX,ISP
 mskcc.org,Memorial Sloan Kettering Cancer Center,Healthcare
 msoe.edu,Milwaukee School of Engineering,Education
 mssm.edu,Icahn School of Medicine at Mount Sinai,Education
@@ -4465,18 +5019,23 @@ msstate.edu,Mississippi State University,Education
 mst.edu,Missouri University of Science and Technology,Education
 msu.edu,Michigan State University,Education
 msu.ru,Moscow State University,Education
+mt.net,Montana Internet,ISP
+mta.info,MTA New York,Government
 mtaroutes.com,N-able,Email Security
 mtasolutions.com,Matanuska Telecom Association,ISP
 mtasv.net,Postmark,SaaS
 mtc.com.na,MTC,ISP
 mtccomm.net,MTC Communications,ISP
+mtco.com,MTCO Conxxus,ISP
 mtdtraining.co.uk,MTD Training Group,SaaS
 mtel.ba,Mtel,ISP
 mtel.me,Mtel,ISP
+mtel.mo,MTel Macau,ISP
 mtholyoke.edu,Mount Holyoke College,Education
 mtn.ci,MTN,ISP
 mtn.cm,MTNL,ISP
 mtn.co.rw,MTN Rwanda,ISP
+mtn.co.ug,MTN Uganda,ISP
 mtn.com,MTN,ISP
 mtn.com.gh,MTN,ISP
 mtn.ng,MTN,ISP
@@ -4506,6 +5065,7 @@ mufg.jp,MUFG,Finance
 multacom.com,MULTACOM,Web Host
 multi.net.pk,Multinet Pakistan,ISP
 multimedia.pl,Multimedia Polska,ISP
+multiplay.pl,Multiplay Poland,ISP
 multipolar.co.id,Multipolar Technology,MSP
 multivelox.com.br,Multivelox,ISP
 mun.ca,Memorial University of Newfoundland,Education
@@ -4517,9 +5077,11 @@ muni.cz,Masaryk University,Education
 munich-airport.de,Munich Airport,Travel
 musashi-eng.co.jp,Musashi Engineering,Manufacturing
 musc.edu,Medical University of South Carolina,Healthcare
+musfiber.com,Morristown Utilities (MUS Fiber),Utilities
 mutualofomaha.com,Mutual of Omaha,Finance
 muvnet.com.br,Muvnet Telecom,ISP
 mvd.ru,Ministry of Internal Affairs of Russia,Government
+mvps.net,MVPS,Web Host
 mwainternet.com.br,MWA Internet,ISP
 mweb.co.za,MWEB,ISP
 mwprem.net,NTT,ISP
@@ -4533,6 +5095,7 @@ my-tss.com,Performive,MSP
 myaccess.ca,Access Communications,ISP
 myactv.net,Antietam Broadband,ISP
 myaisfibre.com,AIS Fibre,ISP
+myanmaposts.net.mm,Myanma Posts and Telecommunications,ISP
 mybluehost.me,Bluehost,Web Host
 mybluepeak.com,Bluepeak,ISP
 myctgs.com,CTG Server,Web Host
@@ -4552,6 +5115,7 @@ mygrande.com,Grande Communications,ISP
 myhome-server.de,DDNSS,Web Host
 myhost.ie,MyHost.ie,Web Host
 myhosting.com,MyHosting,Web Host
+mykris.net,Enterprise Managed Services Mykris,ISP
 myleader.com,Cardinal Health,Healthcare
 mylinkline.com,MyLinkLine,SaaS
 mymailcheap.com,Mailcheap,Email Provider
@@ -4572,6 +5136,7 @@ myrepublic.net,MyRepublic,ISP
 mysecurecloudhost.com,World Host Group,Web Host
 mysecuritas.com,Securitas,Physical Security
 myshopify.com,Shopify,SaaS
+mysint.ru,SiNT Achinsk,ISP
 myspreadshop.at,Spreadshop,SaaS
 myspreadshop.be,Spreadshop,SaaS
 myspreadshop.ca,Spreadshop,SaaS
@@ -4591,6 +5156,7 @@ myspreadshop.nl,Spreadshop,SaaS
 myspreadshop.no,Spreadshop,SaaS
 myspreadshop.pl,Spreadshop,SaaS
 myspreadshop.se,Spreadshop,SaaS
+mytel.com.mm,Mytel Myanmar,ISP
 mytelstar.com,Tel-Star,ISP
 mythic-beasts.com,Mythic Beasts,Web Host
 mywhc.ca,Web Hosting Canada,Web Host
@@ -4602,6 +5168,7 @@ nab.com.au,National Australia Bank,Finance
 nabthat.com,Nabthat,SaaS
 nacao.net.br,Net Nação,ISP
 nadracardcentre.co.uk,Nadra Card Centre,SaaS
+naeci.com,NAEC Next,Utilities
 nagoya-cu.ac.jp,Nagoya City University,Education
 nagoya-u.ac.jp,Nagoya University,Education
 nahealth.com,Northern Arizona Healthcare,Healthcare
@@ -4617,14 +5184,19 @@ nano.lv,nano.lv,Web Host
 nano.uz,Nano Telecom,ISP
 nao.ac.jp,National Astronomical Observatory of Japan,Education
 nap.net.tw,Taiwan Network Access Point,ISP
+napinfo.co.id,NAP Info Indonesia,ISP
 nasa.gov,NASA,Government
 nasboces.org,Nassau BOCES,Education
 nascoeducation.com,Nasco EDucation,Education
+nasdaq.com,Nasdaq,Finance
 nashville.gov,Nashville Davidson County,Government
 nask.pl,NASK,Education
 nasonline.org,National Academy of Sciences,Education
 nasstar.com,Nasstar,MSP
 nastech.bg,Nastech Plus,ISP
+natcom.com.ht,Natcom Haiti,ISP
+natecorp.com,NATE Communications,ISP
+nationalgeneral.com,National General (Allstate),Finance
 nationalhha.com,National Home Health,Healthcare
 nationlanka.com,Nation Lanka Finance,Finance
 nationwide.co.uk,Nationwide Building Society,Finance
@@ -4642,10 +5214,12 @@ navercorp.com,Naver,Technology
 naviexp.jp,NaviExp,MSP
 navigata.ca,Navigata Communications,ISP
 navisite.com,Navisite,MSP
+navox.kr,Navox,ISP
 navy.mil,U.S. Navy,Defense
 nayatel.com,Nayatel,ISP
 nazwa.pl,NetArt Group,Web Host
 nbcb.cn,Bank of Ningbo,Finance
+nbcuni.com,NBCUniversal,Entertainment
 nbpower.com,New Brunswick Power,Utilities
 nbstelecom.psi.br,NBS Telecom,ISP
 nc.gov,State of North Carolina,Government
@@ -4661,15 +5235,18 @@ ncv.co.jp,Newmedia Corporation,ISP
 nd.edu,University of Notre Dame,Education
 nd.gov,North Dakota Government,Government
 ndensan.co.jp,Densan,MSP
+nds-g.co.jp,NDS Japan,MSP
 nearlyfreespeech.net,NearlyFreeSpeach.NET,Web Host
 nearoute.io,Nearoute (Ikuuu Network),Web Host
 neas.mr.no,Neas,ISP
+nebius.com,Nebius,IaaS
 nebraska.edu,University of Nebraska,Education
 nebraska.gov,State of Nebraska,Government
 nebulaglobal.com,Nebula Global,Web Host
 nec.com,NEC,Manufacturing
 nec.com.au,NEC,Technology
 necam.com,NEC,Technology
+nectec.or.th,NECTEC Thai R&E Network,Education
 need-link-eng.co.jp,Need Link Engineering,Technology
 needles.co.kr,Tae Chang Industrial,Healthcare
 neencloud.it,NEEN,MSP
@@ -4678,18 +5255,26 @@ neo-fiber.net,NeoFiber Communications,ISP
 neoclan.net,Neoclan Networks,ISP
 neoclan.net.mx,Neoclan Networks,ISP
 neocomisp.com,NeocomISP,ISP
+neocomisp.com.kh,NeocomISP Cambodia,ISP
 neosnetworks.com,Neos Networks,ISP
 neotechprovedor.com.br,NeoTech,ISP
 neotel.co.za,Neotel,ISP
 neotel.mk,Neotel North Macedonia,ISP
+neovia.com.br,Neovia Solutions,ISP
 neovision.de,NEOVISION,Marketing
 nephronpharm.com,Nephon,Healthcare
+nepustil.net,nepustil.net,ISP
 neric.org,Northeastern Regional Information Center,Education
 nersc.gov,National Energy Research Scientific Computing Center,Government
+nesparc.com,NE SPARC,ISP
 nessus.at,Nessus GmbH,ISP
+nestle.com,Nestle,Food
+net-gate.ro,Net Gate Romania,ISP
 net-rosas.com.br,Net Rosas,ISP
 net-uno.net,Net Uno,ISP
+net.de,net.DE,IaaS
 net.ru,NET.RU Mega ISP,ISP
+net11.com.br,Net Onze,ISP
 net4you.com.br,NET4YOU,ISP
 net92.ru,Sevastopol Telecom,ISP
 netactuate.com,NetActuate,Web Host
@@ -4706,19 +5291,24 @@ netceu.com.br,TURBO 10 Telecom,ISP
 netcol.com.br,Netcol,ISP
 netcologne.de,NetCologne,ISP
 netcom-bw.de,NetCom BW,ISP
+netcom-kassel.de,Netcom Kassel,ISP
 netcom-r.ru,NetCom-R,ISP
 netcomafrica.com,Netcom Africa,ISP
 netcomet.com.br,Netcomet,ISP
 netcore.co.in,Netcore,Marketing
+netcrawler.ca,Netcrawler,ISP
 netcup.com,netcup,Web Host
 netcup.de,netcup,Web Host
 netdesignhost.com,Netdesign Group,Web Host
+netdirekt.com.tr,Netdirekt,Web Host
 netease.com,NetEase,Email Provider
 neterra.net,Neterra,ISP
 netexpand.com.br,NetExpand,ISP
 netfinn.net,netFinn,Web Host
 netflix.com,Netflix,Entertainment
+netforest.ad.jp,Netforest,Web Host
 netglobalis.net,MCL Internet (Netglobalis),ISP
+netguard.bg,NETGUARD,ISP
 netherlandsservers.org,Netherlands Servers,Web Host
 nethinks.com,NETHINKS,MSP
 nethosting.com,NetHosting,Web Host
@@ -4737,27 +5327,36 @@ netnam.com,NetNam,ISP
 netnam.vn,NetNam,ISP
 netnar.com.py,Netnar,ISP
 netnerd.com,NetNerd,Web Host
+netone.ru,NetOne Russia,ISP
 netonline.net,Netonline,ISP
 netowl.jp,スターアカウント,ISP
 netpagedns.net,Netpage Internet Services,ISP
 netpeu.com.br,Netpeu,ISP
+netplanet.at,Netplanet,MSP
 netplus.ch,Net+,ISP
 netplus.co.in,Netplus Broadband,ISP
+netplusfr.net,netplusFR,ISP
 netpluz.asia,Netpluz Asia,ISP
 netrax.pl,Netrax,ISP
+netregistry.com.au,NetRegistry HELP,Web Host
 netregistry.net,Netregistry,Web Host
 netrevolution.com,NetRevolution,ISP
+netrics.ch,Netrics,MSP
 netrixllc.com,Netrix,MSP
 netroad.ru,Mobile TeleSystems,ISP
+netrouting.com,Netrouting,Web Host
 netsat.in,Netsat Communications,ISP
 netservice-jeziorany.pl,Netservice Jeziorany,ISP
+netservices.de,net services,ISP
 netskope.com,Netskope,SaaS
 netsolus.com,IP Pathways,MSP
 netstore.inf.br,Netstore Telecom,ISP
+netstream.ch,Netstream Switzerland,IaaS
 netsuitesuiteprojectspro.com,Oracle NetSuite OpenAir,SaaS
 netsulonline.com.br,Netsul Telecom,ISP
 netsurf.bg,Net-Surf Bulgaria,ISP
 netsville.com,Netsville,Marketing
+netsync.net,DFT Communications,ISP
 netsystemcampos.com.br,NETSYSTEM,ISP
 netsystemtelecom.net.br,NetSystem FibraTelecom,ISP
 nettlinx.com,Nelinx,ISP
@@ -4777,21 +5376,27 @@ network-tech.com,Network Technologies International (NTI),SaaS
 network.kz,network.kz,ISP
 network.lviv.ua,Network-Lviv,ISP
 network80.com,Network80,Web Host
+networkip.net,NetworkIP,ISP
 networknebraska.net,Network Nebraska,Government
 networksolutions.com,Network Solutions,Web Host
 networktransit.net,Network Transit,ISP
+networthtelecom.fr,Networth Telecom,ISP
+netzquadrat.de,netzquadrat,Web Host
 neu.edu,Northeastern University,Education
 neubox.com,Neubox,Web Host
 neubox.net,Neubox,Web Host
 neuca.pl,NECUA Group,Healthcare
 neunet.com.ar,Neunet,ISP
 neustarsecurityservices.com,Vercara (Neustar Security Services),Email Security
+neutraldata.com,Neutral Data Centers,Web Host
 nevada.edu,Nevada System of Higher Education,Education
+nevalink.net,Nevalink,ISP
 new-life.com,New Life,Retail
 newfold.com,Newfold Digital,Web Host
 newinvestingexplained.com,New Investing Explained,News
 newlifechurchoffaith.org,New Life Church of Faith,Nonprofit
 newmarket.com,Newmarket,Travel
+newmediaexpress.com,NewMedia Express,Web Host
 newnet.com.br,Newnet,MSP
 newoeste.com.br,New Oeste Telecom,ISP
 newpages.com.my,NEWPAGES,Retail
@@ -4806,6 +5411,7 @@ newsunseo.com,NewSunSEO,Marketing
 newtekone.com,NewtekOne,Finance
 newtekwebhosting.com,Intelligent Protection Management,Web Host
 newworldpresenter.com,New World Presenter,News
+nex-techwireless.com,Nex-Tech Wireless,ISP
 nexcess.net,Nexcess,Web Host
 nexeon.com,Nexeon,IaaS
 nexg.net,KX NexG,ISP
@@ -4825,21 +5431,28 @@ nextnet.pe,Nextnet Peru,ISP
 nextnetworks.net,NextNetworks,MSP
 nextpertise.nl,Nextpertise,ISP
 nexttelecom.net.br,Next Internet,ISP
+nexusguard.com,Nexusguard,Email Security
 nforce.com,NForce Entertainment,Web Host
 nfshost.com,NearlyFreeSpeech.NET,Web Host
+nftctelecom.com,NFTC North Frontenac Telephone,ISP
 ngblunetworks.nl,NGBLU Networks,ISP
+ngenix.net,NGENIX,SaaS
 ngloba.com,Ngloba Devices,MSP
 ngpweb.com,Bonterra,Marketing
 ngren.edu.ng,NgREN Nigerian Research and Education Network,Education
 nh-serv.co.uk,Nimbus Hosting,Web Host
 nhisac.org,H-ISAC,Healthcare
 nhn-techorus.com,NHN Techorus,MSP
+nhn.no,Norsk Helsenett,Healthcare
 nhncloud.com,NHN Cloud,IaaS
 nhs.net,NHSmail,MSP
 ni.ac.rs,University of Nis,Education
+nia.or.kr,NIA Korea,Government
 nibtv.co.kr,Namincheon Broadcasting,ISP
 nic.ad.jp,JPNIC,Nonprofit
+nic.uk,Nominet,Nonprofit
 nice.com,NICE CX,SaaS
+nichost.ru,RU-Center (NicHost),Web Host
 nicknetwork.com.br,NickNetwork,ISP
 nicmail.ru,RU-CENTER,Email Provider
 nicnet.com.br,Nicnet,ISP
@@ -4847,16 +5460,19 @@ nict.go.jp,NICT,Government
 niels-stensen-kliniken.de,Marienhospital Osnabrück,Healthcare
 nifs.ac.jp,National Institute for Fusion Science,Education
 nifty.com,@nifty,Web Host
+nigcomsat.gov.ng,NIGCOMSAT,Government
 nih.gov,National Institutes of Health,Government
 nihon-u.ac.jp,Nihon University,Education
 niigata-u.ac.jp,Niigata University,Education
 nikhef.nl,Nikhef,Science
 nikkei.co.jp,Nikkei,News
 nimsite.uk,Nimbus Hosting,Web Host
+nine.ch,Nine Internet Solutions,IaaS
 nineweb.net,Nine Web,Web Host
 niosh.com.my,Malaysian National Institute of Occupational Safety and Health,Government
 nip.io,nip.io,SaaS
 nipbr.com,NipBr Telecom,ISP
+nipbr.com.br,NipBr (NipCable),ISP
 nir-telecom.ru,NIR-Telecom,ISP
 nissan.co.jp,Nissan,Automotive
 nist.gov,National Institute of Standards and Technology,Government
@@ -4866,6 +5482,8 @@ nititancommercial.com,Niti Tan Commercial,Industrial
 nitrado.net,Nitrado (marbis),Web Host
 niu.edu,Northern Illinois University,Education
 nixihost.com,NixiHost,Web Host
+nj-ix.net,NJ IX,ISP
+nj.gov,State of New Jersey,Government
 njedge.net,Edge,Nonprofit
 njit.edu,New Jersey Institute of Technology,Education
 nkh.com.tw,New Kaohsiung Broadband,ISP
@@ -4873,6 +5491,7 @@ nkn.gov.in,National Knowledge Network,Education
 nktelco.com,NKTELCO,ISP
 nktelco.net,NKTELCO,ISP
 nktele.com,NkTelecom,Web Host
+nlighten.com,nLighten,Web Host
 nls.kz,NLS Kazakhstan,ISP
 nmsu.edu,New Mexico State University,Education
 nmt.edu,New Mexico Tech,Education
@@ -4906,21 +5525,27 @@ nonstoponline.com,Starnet,ISP
 noor.net,Noor Group,ISP
 nordic.tel,Nordic Telecom,ISP
 nordictelecom.cz,Nordic Telecom,ISP
+nordlo.com,Nordlo,MSP
 nordnet.com,Nordnet,ISP
 nordnet.fr,Nordnet,ISP
+nordsec.com,Nord Security,SaaS
 nordstrom.com,Nordstrom,Retail
 noris.de,noris network,Web Host
 norlys.dk,Norlys,ISP
 noroestenet.com,NoroesteNet,ISP
 norrnod.se,UMDAC (Umeå University),Education
 nortetelecom.net.br,Norte Telecom,ISP
+nortex.com,Nortex Communications,ISP
 northcdatacenters.ch,NorthC Datacenters,Web Host
 northcdatacenters.com,NorthC Datacenters,Web Host
+northcentralelectric.com,Northcentral Electric Cooperative,Utilities
 northeastern.edu,Northeastern University,Education
+northland.net,Northland Communications,ISP
 northlandcable.com,Vyve Broadband (Northland Cable),ISP
 northropgrumman.com,Northrop Grumman,Defense
 northshore.org,NorthShore University HealthSystem,Healthcare
 northwestern.edu,Northwestern University,Education
+norvado.com,Norvado,ISP
 nos.pt,NOS,ISP
 noticiasnrt.com,Corporativo Núcleo Radio Televisión,News
 notion.com,Notion,SaaS
@@ -4929,6 +5554,7 @@ nour.net.sa,NourNet,ISP
 nova.edu,Nova Southeastern University,Education
 nova.gr,Nova Greece,ISP
 nova.is,Nova Iceland,ISP
+nova.net.cn,Shenzhen Nova Technologies,ISP
 novafibratelecom.com.br,NovaFibra (Ligga),ISP
 novaredenet.com.br,NovaRedeNet,ISP
 novascotia.ca,Government of Nova Scotia,Government
@@ -4966,6 +5592,7 @@ nstplnet.com,Navkar Supertech,ISP
 nsupdate.info,nsupdate.info,Web Host
 nsw.gov.au,State of New South Wales,Government
 nt.gov.au,Northern Territory Government,Government
+nt.net,NorthernTel,ISP
 nt.tas.gov.au,Networking Tasmania,Government
 ntc.net.np,Nepal Telecom,ISP
 ntdatacenter.net,NT Data Center,Web Host
@@ -4975,11 +5602,15 @@ ntelos.net,Lumos,ISP
 nthu.edu.tw,National Tsing Hua University,Education
 ntirety.com,Ntirety,MSP
 ntplc.co.th,National Telecom (Thailand),ISP
+ntplx.net,NETPLEX,ISP
 nts.ch,NTS Workspace,MSP
 ntt-east.co.jp,NTT East,ISP
+ntt-f.co.jp,NTT Comware,MSP
 ntt-me.co.jp,NTT-ME,ISP
 ntt.co.jp,NTT,ISP
 ntt.com,NTT Communications,ISP
+ntt.lt,NTT Lithuania,ISP
+nttbizsol.jp,NTT Business Solutions,MSP
 nttdata.com,NTT DATA,Consulting
 nttdocomo.co.jp,NTT DOCMO,ISP
 nttdocomo.com,NTT DOCOMO,ISP
@@ -5000,12 +5631,14 @@ nuvancehealth.org,Nuvance Health,Healthcare
 nuvera.net,Nuvera Communications,ISP
 nuveramail.net,Nuvera,Email Provider
 nvc.net,Northern Valley Communications,ISP
+nvidia.com,Nvidia,Manufacturing
 nvtel.com.br,NovaNet,ISP
 nw027.com,Poppulo (Formerly Newsweaver),SaaS
 nwinetworks.com,NWINetworks,MSP
 nwtel.ca,Northwestel,ISP
 nwu.ac.za,North-West University,Education
 nxcli.net,Liquid Web,Web Host
+nxp.com,NXP Semiconductors,Manufacturing
 ny.gov,State of New York,Government
 nyc.gov,City of New York,Government
 nychealthandhospitals.org,NYC Health + Hospitals,Healthcare
@@ -5023,6 +5656,7 @@ o-mx.com,Omedia,Marketing
 o2.co.uk,O2 (Telefónica UK),ISP
 o2.cz,O2,ISP
 o2bs.sk,O2 Business Services Slovakia,ISP
+o2dc.com,Perviy TSOD (O2DC),Web Host
 oakland.k12.mi.us,Oakland Schools,Education
 oakwood.org,Oakwood Healthcare,Healthcare
 oauife.edu.ng,Obafemi Awolowo University,Education
@@ -5049,6 +5683,7 @@ ocnk.net,Ochanoko,SaaS
 oct-net.ne.jp,Oita Cable Telecom,ISP
 octacom.ca,Octacom,MSP
 octantis.ca,Octantis,Marketing
+octv.jp,Obihiro City Cable,ISP
 oderland.com,Oderland,Web Host
 odessa.tv,Sana Plus (Renome-Service),ISP
 odido.nl,Odido,ISP
@@ -5066,6 +5701,7 @@ ohio.gov,State of Ohio,Government
 ohsu.edu,Oregon Health & Science University,Education
 oja.at,oja.at,ISP
 ojt.kz,ntustik Zharyk Transit,Industrial
+ok.gov,State of Oklahoma,Government
 okanagan.net,Okanagan.net,Web Host
 okayama-u.ac.jp,Okayama University,Education
 okstate.edu,Oklahoma State University,Education
@@ -5076,6 +5712,7 @@ oleanwebhosting.com,Olean Web Hosting,Web Host
 olemiss.edu,University of Mississippi,Education
 omantel.om,Omantel,ISP
 omeda.com,Omedia,Marketing
+omeganetworks.com,Omega Networks Texas,ISP
 omegatech.cz,Nordic Telecom,ISP
 ometria.com,Ometria,Marketing
 ometria.email,Ometria,Marketing
@@ -5091,6 +5728,7 @@ omnistep.com,OmniStep Incorporated,ISP
 on-web.fr,Planet-Work,Web Host
 onamae.ne.jp,GMO Internet,Web Host
 onastra.fr,SES Astra,ISP
+onatel.bf,ONATEL Burkina Faso,ISP
 onati.pf,Onati,ISP
 ondal.com,Ondal Medical Systems,Healthcare
 ondigitalocean.app,DigitalOcean,PaaS
@@ -5112,6 +5750,7 @@ onenationuk.org,One Nation,Nonprofit
 onenet.net,OneNet,ISP
 oneoffice.jp,OneOffice,SaaS
 oneonta.edu,SUNY Oneonta,Education
+oneprovider.com,OneProvider,Web Host
 oneringnetworks.com,One Ring Networks,ISP
 onetechtelecom.net.br,Onetech Telecom,ISP
 oni.pt,ONI,ISP
@@ -5129,15 +5768,18 @@ onlineagency.com,Online Agency,SaaS
 onlinehome-server.info,IONOS,Web Host
 onlinenetgo.com.br,Online Net Go,ISP
 onlinetelecomip.net.br,Online Telecom,ISP
+onlycable.es,Onlycable,ISP
 onnet21.com,LG Uplus,ISP
 onnettelecom.com.br,OnNet Telecomunicações,ISP
 ono.com,Vodafone Ono,ISP
 onrender.com,Render,PaaS
 ontario.ca,Government of Ontario,Government
+ontariohealth.ca,Ontario Health,Healthcare
 ontarioshores.ca,Ontario Shores Centre for Mental Health,Healthcare
 ontash.com,Ontash & Ermac,Industrial
 onthenet.com.au,On The Net,ISP
 onvif.org,Onvif,Technology
+onx.com,OnX,MSP
 ooma.com,Ooma,ISP
 oops.net.br,Oops Telecom,ISP
 ooredoo.com.kw,Ooredoo,ISP
@@ -5159,12 +5801,14 @@ opt.nc,OPT-NC New Caledonia,ISP
 optage.co.jp,Optage,ISP
 opticaltel.com,Fibernow (Opticaltel),ISP
 opticomm.com.au,Opticomm,ISP
+optimaitalia.com,Optima Italia,ISP
 optimantra.com,OptiMantra,SaaS
 optimum.com,Optimum,ISP
 optimum.net,Optimum,ISP
 optimus.si,Optimus IT d.o.o.,MSP
 optimusmedia.com,Optimus Media,Marketing
 optipub.com,OptiPub,Publishing
+optix.pk,Optix Pakistan,ISP
 optonline.net,Optimum,ISP
 optus.com.au,Optus,ISP
 optus.net.au,Optus,ISP
@@ -5195,6 +5839,7 @@ orangemali.com,Orange Mali,ISP
 oratelecom.com.br,ORA Telecom,ISP
 orbetelecom.com.br,Orbe Telecom,ISP
 orbital.net,Orbital Net,ISP
+orbitel.com,Orbitel Communications,ISP
 oregon.gov,Oregon Government,Government
 oregonstate.edu,Oregon State University,Education
 ori.net,ORI,ISP
@@ -5203,6 +5848,8 @@ orionnet.ru,Orion Telecom,ISP
 oriontelekom.rs,Orion Telekom,ISP
 oristelekom.com,ORIS Telekom,ISP
 orlandodiocese.org,Diocese of Orlando,Nonprofit
+orn.ru,Resurs-Svyaz,ISP
+ornethd.net,Orne THD,ISP
 ornl.gov,Oak Ridge National Laboratory,Government
 orthodoxws.com,Orthodox Web Solutions,Web Host
 osaka-sandai.ac.jp,Osaka Sangyo University,Education
@@ -5213,7 +5860,9 @@ ose.gov.pl,OSE Polish National Education Network,Government
 oser.com,Oser Comunications Group,Marketing
 oshean.org,OSHEAN,Education
 osir.net.br,Osirnet,ISP
+oskolnet.ru,Osknolnet,ISP
 oslo.kommune.no,City of Oslo,Government
+osn.de,OSN Online Service,Web Host
 osnetpr.net,Osnet Wireless Puerto Rico,ISP
 osnova.tv,Osnova,ISP
 osogrande.net,Oso Grande Technologies,ISP
@@ -5259,6 +5908,7 @@ oxfordnetworks.net,FirstLight Fiber,ISP
 oxio.ca,oxio,ISP
 oxsus-vadesecure.net,Scaleway,Web Host
 oxy.edu,Occidental College,Education
+oxylion.pl,Oxylion,ISP
 ozarksgo.net,OzarksGo,ISP
 p4net.com.br,P4NET,ISP
 p4net.net.br,P4NET Telecom,ISP
@@ -5298,6 +5948,7 @@ pantherex.com,Pantherex,Consulting
 papaki.com,Papaki,Web Host
 papaki.gr,Papaki,Web Host
 paperworks.com,Paperworks,Retail
+paradisenetworks.net,Paradise Networks,ISP
 paragould.com,Paragould Municipal Utilities,ISP
 paragould.net,Paragould Municipal Utilities,ISP
 paratus.africa,Paratus Telecom,ISP
@@ -5320,6 +5971,7 @@ paulbunyan.net,Paul Bunyan Communications,ISP
 pausd.org,Palo Alto Unified School District,Education
 pavlovmedia.com,Pavlov Media,ISP
 paxio.com,Paxio,ISP
+paychex.com,Paychex,SaaS
 paycom.com,Paycom,SaaS
 paycomonline.com,Paycom,SaaS
 paylodegrowth.com,Paylode,SaaS
@@ -5354,6 +6006,7 @@ penguinwebhosting.com,Penguin Webhosting,Web Host
 penki.lt,Penki,ISP
 pennwest.edu,Pennsylvania Western University,Education
 penteledata.net,PenTeleData,ISP
+people.net.ua,PEOPLEnet Ukraine,ISP
 peopleanswers.com,Infor,SaaS
 peoplescom.net,Peoples Telephone Cooperative,ISP
 peopleshost.com,PeoplesHost,Web Host
@@ -5361,8 +6014,10 @@ peopleshostshared.com,PeoplesHost,Web Host
 pepitrans01.com,Netcore (Formerly Pepipost),SaaS
 pepitrans02.com,Netcore (Formerly Pepipost),SaaS
 pepperdine.edu,Pepperdine University,Education
+pepsico.com,PepsiCo,Food
 perception-point.io,Perception Point,Email Security
 perenso.com,Perenso,Marketing
+perfectip.net,Perfect International,Web Host
 perfora.net,IONOS,Web Host
 performive.com,CloudFirst,Web Host
 perimeterwatch.com,PerimeterWatch,MSSP
@@ -5371,6 +6026,7 @@ peteralan.co.uk,Peter Alan,Real Estate
 petrobras.com.br,Petrobras,Industrial
 petroed.com,PetroEd,Education
 petronas.com,Petronas,Industrial
+petrus.pl,Petrus,ISP
 pfalzkom.de,PFALZKOM,ISP
 pfcloud.io,pfcloud,Web Host
 pfizer.com,Pfizer,Healthcare
@@ -5381,12 +6037,16 @@ pgcps.org,Prince George's County Public Schools,Education
 pge.com,PG&E,Utilities
 ph.net,PHNet Philippine Network Foundation,Education
 phaselayer.com,Private Layer,Web Host
+phibee-telecom.net,Phibee Telecom,ISP
 phila.gov,City of Philadelphia,Government
 philasd.org,School District of Philadelphia,Education
 phmgmt.com,PhMgmt VyprVPN,Web Host
+phoenix-c.or.jp,Phoenix Communications Japan,ISP
 phoenixnap.com,phoenixNAP,Web Host
+phonoscope.com,Phonoscope Fiber,ISP
 phpoy.fi,Elmonet (PHP Oy),ISP
 phpwebhosting.com,PHPWebHosting,Web Host
+pickup.hu,PickUp Kft,ISP
 piedmonteye.com,Piedmont Eye Center,Healthcare
 piercecountywa.gov,"Pierce County, Washington",Government
 pif.co.uk,Pinnacle Freight,Logistics
@@ -5395,13 +6055,16 @@ pilotfiber.com,Pilot Fiber,ISP
 pima.edu,Pima Community College,Education
 pima.gov,Pima County Arizona,Government
 pindc.ru,Pindc Petersburg Internet Network,ISP
+pine-net.com,Pine Telephone,ISP
 pinellascounty.org,Pinellas County,Government
 pink.co.rs,Mink Media Group,Marketing
 pinnaclecart.com,PinnacleCart,SaaS
 pinpro.by,PinPro,ISP
 pinspb.ru,Petersburg Internet Network (Pinspb),ISP
+pioncomm.net,Pioneer Communications Kansas,ISP
 pioneer.co.in,Pioneer Online,ISP
 pioneer.co.th,Pioneer Transportation,Logistics
+pioneer.net,Pioneer Connect,ISP
 pip.com.au,PIP Total IT Solutions,Web Host
 pipefy.com,Pipefy Inc,SaaS
 pirxnet.pl,PirxNet,ISP
@@ -5410,6 +6073,7 @@ pitchile.cl,PIT Chile,ISP
 pitt.edu,University of Pittsburgh,Education
 pius-hospital.de,Pius-Hospital Oldenburg,Healthcare
 pixeledges.com,Pixel Edges Technologies,Marketing
+pknu.ac.kr,Pukyong National University,Education
 plala.or.jp,Plala,ISP
 planet.net,Planet Networks,ISP
 planetel.it,Planetel,ISP
@@ -5417,11 +6081,13 @@ planetfiber.com.br,Planet Fiber,ISP
 planethoster.fr,PlanetHoster,Web Host
 planethoster.net,PlanetHoster,Web Host
 planety.com.br,Planety Internet,ISP
+planters.net,Planters Communications,ISP
 plateautel.com,Plateau Telecommunications,ISP
 platform.sh,Upsun,PaaS
 plattsburgh.edu,SUNY Plattsburgh,Education
 play-internet.pl,Play,ISP
 play.pl,Play,ISP
+play2go.cloud,Play2Go,Web Host
 playbackmail.com,PlayBackMail,Email Provider
 playstation.com,Sony PlayStation,Entertainment
 playtech.ee,Playtech,Entertainment
@@ -5446,6 +6112,7 @@ plusserver.com,PlusServer,Web Host
 plusvps.com,Plus Hosting,Web Host
 pmc.gov.au,Australian Department of PM and Cabinet,Government
 pmcon.net,Premium Connectivity,ISP
+pmt.org,Project Mutual Telephone Cooperative,ISP
 pmweb.com.br,pmweb,Marketing
 pnc.com,PNC Bank,Finance
 pobox.com,Pobox,Email Provider
@@ -5453,6 +6120,8 @@ pocketinet.com,PocketiNet,ISP
 poda.cz,PODA,ISP
 podzone.net,DynDNS,Web Host
 podzone.org,DynDNS,Web Host
+pogozone.com,PogoZone,ISP
+poig.ru,POIG (Schelkovo-net),ISP
 point-broadband.com,Point Broadband,ISP
 pol-online.com,Bangladesh Online,ISP
 pol.ir,ParsOnline,ISP
@@ -5468,6 +6137,7 @@ polyesterday.mk,Polyesterday,Marketing
 polyu.edu.hk,Hong Kong Polytechnic University,Education
 poneytelecom.eu,Pony Telecom,Web Host
 pontenova.com.br,Ponte Nova Online,News
+popp.com,POPP Communications,ISP
 popsnet.com.br,POP's Net,ISP
 popularelectriccentre.com,Popular Electric Centre,Industrial
 populoos.es,Populoos,ISP
@@ -5478,6 +6148,8 @@ portalcom.inf.br,Portal.com,ISP
 portative.com,Portative Technologies,ISP
 portative.net,Portative Technologies,ISP
 portlandk12.org,Portland Public Schools,Education
+portunity.de,Portunity,Web Host
+portusdatacenters.com,Portus Data Centers,Web Host
 poscoict.com,POSCO DX,MSP
 positive.sk,Positive,SaaS
 post.ch,Swiss Post,Logistics
@@ -5499,7 +6171,10 @@ ppg.com,PPG Industries,Manufacturing
 pphosted.com,Proofpoint,Email Security
 pratt.lib.md.us,Enoch Pratt Free Library,Government
 prchost.com,PRC Hosting,Web Host
+preciousnetcom.in,Precious Netcom,ISP
 precisehotels.com,Precise Hotels and Resorts,Travel
+predialnet.com.br,Predialnet,ISP
+premierdc.com.tr,PremierDC,Web Host
 prempub.com,Premier Publishing,Marketing
 previder.com,Previder,Web Host
 prgmr.com,Tornado VPS,Web Host
@@ -5525,7 +6200,10 @@ pro-m.hu,Pro-M,ISP
 pro01.net,Pro01 (Toyu),Marketing
 proagentwebsites.com,ProAgent Websites,Real Estate
 probe-networks.de,Probe Networks,Web Host
+procergs.rs.gov.br,PROCERGS Rio Grande do Sul,Government
 procopa.dk,Procopa IT,MSP
+proderj.rj.gov.br,PRODERJ Rio de Janeiro,Government
+prodesp.sp.gov.br,Prodesp,Government
 prodocom.com.au,Prodocom,SaaS
 produccion.gob.ec,Ecuador Ministry of Production,Government
 proen.co.th,PROEN,Web Host
@@ -5536,12 +6214,14 @@ prontomarketing.com,Pronto Marketing,Marketing
 proofhubmail.com,ProofHub,SaaS
 proofpoint.com,Proofpoint,Email Security
 propersupportmedia.com,Proper Support Media,Web Host
+prophase.es,Prophase Telecom,ISP
 prosites.com,ProSites,Web Host
 prosodie.com,Odigo,SaaS
 prospect.pl,Prospect,ISP
 proton.ch,Proton,Email Provider
 proton.me,Proton,Email Provider
 protonmail.ch,Proton,Email Provider
+provector.pl,Provector,ISP
 provedorfutel.net.br,Futel,ISP
 provedornet.com.br,Provedornet,ISP
 provedornetcenter.com.br,Netcenter,ISP
@@ -5560,15 +6240,19 @@ prtcom.ru,Pokrovsky Radiotelefon,ISP
 prtelecom.hu,PR-TELECOM,ISP
 prudential.com.sg,Prudential Singapore,Finance
 prudentpublishing.com,Prudent Publishing,Retail
+prvepa.com,PearlComm,ISP
 prw.net,Puerto Rico Webmasters,Web Host
+ps.kz,PS Cloud Services,Web Host
 psc.edu,Pittsburgh Supercomputing Center,Education
 psdschools.org,Poudre School District,Education
 pserver.space,Profitserver,Web Host
 pskovline.ru,Pskovline,ISP
+pslightwave.com,PS Lightwave,ISP
 psn.co.id,Pasifik Satelit Nusantara,ISP
 pspinc.com,Pacific Software Publishing,Web Host
 psu.edu,Penn State,Education
 psychz.net,Psychz Networks,Web Host
+ptci.net,PTCI Panhandle Telephone,ISP
 ptcl.com.pk,PTCL,ISP
 ptd.net,PTD,ISP
 ptisp.com,PTisp,Web Host
@@ -5576,6 +6260,8 @@ ptp.net.id,Perdana Teknologi Persada,ISP
 ptrcloud.net,GMO GlobalSign,IaaS
 ptspb.ru,Severen-Telecom,ISP
 ptvtelecom.com,PTV Telecom,ISP
+publicdomainregistry.com,PDR (PublicDomainRegistry),Web Host
+publicsvc.com,Public Service Data,ISP
 pubnetplus.ne.kr,LG Uplus,ISP
 pubnix.net,PubNIX,Web Host
 puc-rio.br,PUC Rio,Education
@@ -5593,6 +6279,7 @@ purplecowinternet.com,Purple Cow Internet,ISP
 purtel.com,PURtel,ISP
 pusan.ac.kr,Pusan National University,Education
 pvamu.edu,Prairie View A&M University,Education
+pvt.com,Penasco Valley Telecommunications,ISP
 pwc.com,PwC,Consulting
 pwtinternet.com.br,PWT Internet,ISP
 pwuhui.com.tw,Perfect Medical,Healthcare
@@ -5604,6 +6291,7 @@ qantas.com.au,Qantas,Travel
 qbeyond.de,q.beyond,MSP
 qcell.gm,Qcell Gambia,ISP
 qcell.sl,QCell Sierra Leone,ISP
+qcpl.in,Quest Consultancy,ISP
 qemailserver.com,Qualtrics,SaaS
 qf.org.qa,Qatar Foundation,Education
 qhoster.net,QHoster,Web Host
@@ -5623,6 +6311,8 @@ qtsc.com.vn,Quang Trung Software City,IaaS
 qtsdatacenters.com,QTS,IaaS
 quadax.com,Quadax,Healthcare
 quadranet.com,Quadranet,Web Host
+qualcomm.com,Qualcomm,Manufacturing
+quality-network.eu,QualityNetwork,ISP
 qualtrics.com,Qualtrics,SaaS
 quantcom.cz,Quantcom,ISP
 quantum.net.id,Quantum Tera Network,ISP
@@ -5679,11 +6369,14 @@ rambler.ru,Rambler,Email Provider
 rampermail.com.br,Ramper,Marketing
 ramsaysante.fr,Ramsay Santé,Healthcare
 randdcomp.com,R&D Computers,MSP
+randomhouse.com,Penguin Random House,Publishing
+range.net,Range Internet,ISP
 ranksitt.net,Ranks ITT,MSP
 rapeedo.net.br,Rapeedo,ISP
 rapidscale.net,RapidScale,Web Host
 raschig.de,Raschig,Manufacturing
 ratiokontakt.de,Ratiokontakt,ISP
+rawbandwidth.com,Raw Bandwidth Communications,ISP
 raycdjr.com,Ray Chrysler Dodge Jeep RAM,Automotive
 raytheon.com,Raytheon,Defense
 razaoinfo.com.br,RazaoInfo,ISP
@@ -5708,12 +6401,15 @@ readthedocs-hosted.com,Read the Docs,SaaS
 readthedocs.com,Read the Docs,SaaS
 readthedocs.io,Read the Docs,SaaS
 real-net.pro,Real-net,ISP
+realconnect.com,RealConnect,Web Host
 realnet.kg,Realnet,ISP
 rebelnetworks.com,Rebel Networks,Web Host
+recast-it.com,recast IT,Web Host
 reconn.ru,Reconn,ISP
 red-7.net,Red 7 Telecomunicaciones,ISP
 redbird.net,NexGenAccess (Formerly Redbird),ISP
 redcentricplc.com,Redcentric,MSP
+redcom.ru,Redcom Khabarovsk,ISP
 redcondor.net,Red Condor,Email Security
 redcotel.bo,Cotel Ltda.,ISP
 redcross.org,American Red Cross,Nonprofit
@@ -5736,9 +6432,11 @@ redirectme.net,No-IP,Web Host
 rediris.es,RedIRIS,Education
 rednesp.br,rednesp,Education
 redtailtechnology.com,Redtail Technology,SaaS
+redtone.com,REDtone,ISP
 reed.edu,Reed College,Education
 reef-guardian.com,Reef Guardian,Education
 reevo.it,ReeVo,MSP
+refinitiv.com,LSEG (Refinitiv),SaaS
 reflected.net,Reflected Networks,Web Host
 reg.ru,Reg.ru,Web Host
 reg365.net,register365,Web Host
@@ -5748,12 +6446,14 @@ regiomed-kliniken.de,Sana Kliniken Oberfranken,Healthcare
 regionaltelecom.net.br,Regional Telecom,ISP
 regiondemurcia.es,Region de Murcia,Government
 regione.toscana.it,Regione Toscana,Government
+regions.com,Regions Bank,Finance
 regionstockholm.se,Region Stockholm,Government
 register.it,Register.it,Web Host
 register365.com,register365,Web Host
 register4less.com,Register4Less,Web Host
 registeredsite.com,Web.com,Web Host
 registrar-servers.com,Namecheap,Web Host
+registro.br,NIC.br,Nonprofit
 regusnet.com,Regus,Real Estate
 regxa.com,Regxa Cloud,Web Host
 relaix.net,RelAix Networks,ISP
@@ -5770,6 +6470,7 @@ render.com,Render,PaaS
 renet.ru,Renet Com,ISP
 renu.ac.ug,RENU,Education
 reportjourneyus.com,Report Journey US,News
+resa.net,Wayne County RESA,Education
 respina.net,Respina Networks,ISP
 responselogix.com,Digital Air Strike,Marketing
 restena.lu,RESTENA,Education
@@ -5779,6 +6480,9 @@ retn.net,RETN,ISP
 retn.ru,RETN Russia,ISP
 reuna.cl,REUNA,Education
 reverse-mundo-r.com,R Cable y Telecomunicaciones,ISP
+reyrey.com,Reynolds and Reynolds,SaaS
+reytel.hn,Reytel Honduras,ISP
+rftkabel.de,RFT Kabel,ISP
 rge.com,Rochester Gas and Electric,Utilities
 rh-tec.de,rh-tec,Web Host
 rhcloud.com,Red Hat OpenShift,PaaS
@@ -5790,7 +6494,9 @@ ri.gov,State of Rhode Island,Government
 riberasaludmail.com,Ribera Salud,Healthcare
 rice.edu,Rice University,Education
 richmond.edu,University of Richmond,Education
+richmondfed.org,Federal Reserve Bank of Richmond,Government
 ridsa.com.ar,Red Intercable Digital,ISP
+rig.net,RigNet,ISP
 rightel.ir,Rightel,ISP
 rightnowtech.com,Oracle Service Cloud,SaaS
 rightside.ru,Telecoma,ISP
@@ -5803,6 +6509,7 @@ rima-tde.net,"TELEFONICA, S.A.",ISP
 rimon.net.il,Internet Rimon,ISP
 ringsquared.com,RingSquared,ISP
 ringstad.no,Ringstad Consulting,MSP
+riotgames.com,Riot Games,Entertainment
 risd.org,Richardson Independent School District,Education
 riseinternet.com,Rise Internet,ISP
 risetelecoms.co.za,Rise Telecoms,ISP
@@ -5823,6 +6530,7 @@ robi.com.mk,Telekabel,ISP
 roblox.com,Roblox,Entertainment
 roche.com,Roche,Healthcare
 rochester.edu,University of Rochester,Education
+rockcom.co,Rockman Communications,ISP
 rockefeller.edu,The Rockefeller University,Education
 rockenstein.de,Rockenstein,Web Host
 rocketsoftware.com,Attachmate (Rocket Software),Technology
@@ -5830,10 +6538,12 @@ rockwellcollins.com,Collins Aerospace,Defense
 rodenyc.com,RODE Advertising,Marketing
 roedu.net,RoEduNet,Education
 rogers.com,Rogers,ISP
+rogerscapital.mu,Rogers Capital Mauritius,MSP
 roguevalleyurology.com,Rogue Valley Urology,Healthcare
 rootlayer.net,RootLayer LTD.,Web Host
 ropa.de,ropa,Web Host
 rose-hulman.edu,Rose-Hulman Institute of Technology,Education
+rosintel.com,Rosintel,ISP
 rosnet.ru,OJSC Rosnet,ISP
 rossoxweb.it,RossoXweb,MSP
 rostelecom.com.br,ROS Telecom,ISP
@@ -5853,6 +6563,7 @@ rrtelecomrs.net.br,RR Telecom,ISP
 rsa.com,RSA,Technology
 rsaweb.co.za,RSAWEB,ISP
 rsgsv.net,Intuit Mailchimp,Marketing
+rsonet.com.ar,RSONet,ISP
 rssulnet.com.br,RS Sul Net,ISP
 rstp.org.sz,Royal Science and Technology Park,Government
 rt.ru,Rostelecom,ISP
@@ -5860,6 +6571,7 @@ rtcomm.ru,RTComm,ISP
 rtctel.com,Ringgold Telephone Company,ISP
 rti.org,Research Triangle Institute,Education
 rtinetwork.com.br,RTI Network,ISP
+rtmc.coop,Randolph Telephone,ISP
 rtx.com,RTX,Defense
 ru.ac.za,Rhodes University,Education
 ruelala.com,Rue La La,Retail
@@ -5868,6 +6580,7 @@ runbox.com,Runbox,Email Provider
 runhosting.com,RunHosting,Web Host
 ruralroadshealthservices.ca,Alexandra Hospital,Healthcare
 ruraltelephone.com,Nex-Tech (Rural Telephone Service),ISP
+rusety.ru,Russet,ISP
 rush.edu,Rush University,Education
 rusonyx.ru,Rysonyx Cloud,Web Host
 rutgers.edu,Rutgers University,Education
@@ -5903,8 +6616,10 @@ saimanet.kg,Saima Telecom,ISP
 saimatelecom.kg,Saima Telecom,ISP
 saimiya.com,Saiseikai Utsunomiya Hospital,Healthcare
 saint-gobain.com,Saint-Gobain,Manufacturing
+saintmarys.edu,Saint Mary's College,Education
 sait.ca,Southern Alberta Institute of Technology,Education
 sakura.ad.jp,Sakura Internet,Web Host
+sakura.as,SAKURA LINK,ISP
 sakura.ne.jp,SAKURA Internet,ISP
 salam.sa,Salam,ISP
 salary.com,Salary.com,SaaS
@@ -5930,6 +6645,7 @@ sanantonio.gov,City of San Antonio,Government
 sandi.net,San Diego Unified School District,Education
 sandia.gov,Sandia National Laboratories,Government
 sandrix.com,Sandrix Technologies,MSP
+sandvikenenergi.se,Sandviken Energi,Utilities
 sanet.sk,SANET,Education
 sangchaimeter.com,Sangchai Meter,Industrial
 sangoma.com,Sangoma,SaaS
@@ -5945,6 +6661,7 @@ sap.com,SAP,Technology
 saplbd.com,Summit Alliance Port,Logistics
 sapmed.ac.jp,Sapporo Medical University,Healthcare
 sapo.pt,SAPO,Email Provider
+sappa.se,Sappa,ISP
 saremail.com,SAREnet,ISP
 sarenet.es,Sarenet,ISP
 sargentlundy.com,Sargent and Lundy,Consulting
@@ -5958,6 +6675,7 @@ satfilm.pl,Sat Film,ISP
 satis-tl.ru,Satis,ISP
 satnet.net,Xtrim,ISP
 satorilabs.com,NextGen Healthcare,Healthcare
+satro.sk,SATRO Slovakia,ISP
 sattrakt.com,Sat-Trakt,ISP
 saudi.net.sa,Saudi Telecom Company,ISP
 saunalahti.fi,Elisa,ISP
@@ -5979,6 +6697,7 @@ sc.gov,South Carolina Government,Government
 scaladatacenters.com,Scala Data Centers,Web Host
 scalaxy.com,Scalaxy,IaaS
 scaledsystems.com,SimpleNet,Web Host
+scaleuptech.com,ScaleUp Technologies,Web Host
 scaleway.com,Scaleway,Web Host
 scania.com,Scania,Manufacturing
 scatair.com,Scatair,Manufacturing
@@ -5998,6 +6717,7 @@ scinternet.net,South Central Communications,ISP
 scip.es,SCIP Soluciones Corporativas IP,ISP
 scis.gov.az,Special Communication Service of Azerbaijan,Government
 scjohnson.com,S.C. Johnson,Manufacturing
+scloud.sg,SCloud Singapore,IaaS
 scn-net.ne.jp,Shonan Cable Network,ISP
 scnet.com.br,SCNet,ISP
 scorm.com,SCORM,SaaS
@@ -6011,6 +6731,7 @@ scsk.jp,SCSK,MSP
 sctv.com.vn,SCTV,ISP
 scu.edu,Santa Clara University,Education
 scw.cloud,Scaleway,IaaS
+sddatacenter.com,SD Data Center,Web Host
 sdldelivery.com,Specialty Delivery & Logistics,Logistics
 sdncommunications.com,SDN Communications,ISP
 sdsc.edu,San Diego Supercomputer Center,Education
@@ -6026,6 +6747,7 @@ seaspraymta2.com,Cox Communications,ISP
 seattlechildrens.org,Seattle Children's Hospital,Healthcare
 seciu.edu.uy,SeCIU Uruguay,Education
 secomtrust.net,SECOM Trust Systems,MSP
+secrel.com.br,SecrelNet,ISP
 sectormail.net,Sectorlink,Web Host
 secure-mailgate.com,Secure Mailgate,Email Provider
 secure-mails.com,Tata Communications,SaaS
@@ -6043,13 +6765,17 @@ securian.com,Securian Financial,Finance
 security-mail.net,Secuserve,Email Security
 securitymetrics.com,SecurityMetrics,MSSP
 securitynet.cz,SecurityNet.cz,ISP
+secyt.gov.ar,Secretaria de Ciencia y Tecnologia Argentina,Government
 sedmultitel.it,SED Multitel,ISP
 seed.net.tw,Seednet,ISP
 seedshosting.jp,Seeds Hosting,Web Host
 seeweb.it,Seeweb,IaaS
 segasammy.co.jp,Sega Sammy,Entertainment
 segra.com,Segra,ISP
+seicommunications.com,SEI Communications,ISP
 seinan-gu.ac.jp,Seinan Gakuin University,Education
+sejamaxx.com.br,MAXX Telecomunicacoes,ISP
+sejong.ac.kr,Sejong University,Education
 sejongtelecom.net,Sejong Telecom,ISP
 selectel.com,Selectel,Web Host
 selectel.ru,Selectel,Web Host
@@ -6080,9 +6806,12 @@ sendmetric.com,Sendmetric,Email Security
 sendnode.com,MAILINGWORK,Marketing
 sendoso.com,Sendoso,Marketing
 sensaphone.com,Sensaphone,SaaS
+senselan.ch,senseLAN,ISP
 sentara.com,Sentara,Healthcare
 sentex.ca,Sentexx,ISP
+sentex.net,Sentex Communications,ISP
 sentia.com,Sentia,MSP
+seoul.go.kr,Seoul Metropolitan Government,Government
 seqtek.net,SEQTEK,MSP
 sercomtel.com.br,Sercomtel,ISP
 serenitydayspaofmemphis.com,Serenity Day Spa,Beauty
@@ -6096,6 +6825,7 @@ serveblog.net,No-IP,Web Host
 servebolt.cloud,Servebolt,Web Host
 servebolt.com,Servebolt,Web Host
 servebyte.com,Servebyte,Web Host
+servecentric.com,ServeCentric,Web Host
 servehttp.com,No-IP,Web Host
 serveminecraft.net,No-IP,Web Host
 server24.eu,Server24,Web Host
@@ -6115,6 +6845,7 @@ serverpanel.com,Shock Hosting,Web Host
 serverpoint.com,ServerPoint,Web Host
 servers.com,Servers.com,Web Host
 serversaustralia.com.au,Servers Australia,Web Host
+servetheworld.net,ServeTheWorld,Web Host
 service-now.com,ServiceNow,SaaS
 service.one,One.com,Web Host
 servicehoster.ch,Green,Web Host
@@ -6131,29 +6862,35 @@ ses-stiftung.de,Schwester Euthymia Stiftung,Healthcare
 ses.com,SES (Formerly Intelsat),ISP
 setardsl.aw,SETAR,ISP
 seven-sky.net,Seven Sky,ISP
+sevennet.net,Goran Net (Sevennet),ISP
 severen.ru,Severen Telecom,ISP
 sevstar.net,Lancom,ISP
 sevtelecom.ru,Sevastopol Telecom,ISP
 sewan.fr,Sewan,ISP
+sewikom.de,sewikom,ISP
 sezampro.rs,Orion Telekom,ISP
 sf.gov,City and County of San Francisco,Government
 sfasu.edu,Stephen F. Austin State University,Education
+sfcn.org,Spanish Fork Community Network,Utilities
 sfr.fr,SFR,ISP
 sfr.net,SFR,ISP
 sfr.re,SFR,ISP
 sfu.ca,Simon Fraser University,Education
 sfusd.edu,San Francisco Unified School District,Education
 sfwmd.gov,South Florida Water Management District,Government
+sg.gs,SG.GS,ISP
 sh.cz,SH.cz,Web Host
 sh27.com.br,SunHost,Web Host
 shabakah.com.sa,Shabakah Net,ISP
 shahrad.net,Sefroyek Pardaz,ISP
 shalomnet.com.br,Shalomnet,ISP
 shamrog.com,Shamrog,Web Host
+shanxitele.com,China Telecom Shanxi,ISP
 share-international.us,Share International USA,Nonprofit
 shared-server.net,GMO Cloud,Web Host
 sharehostserver.com,Sharehostserver,Web Host
 shareman.tv,Shareman,SaaS
+sharif.ir,Sharif University of Technology,Education
 sharktech.net,Sharktech,Web Host
 shatel.ir,Shatel,ISP
 shaw.ca,Shaw,ISP
@@ -6166,7 +6903,9 @@ sherwin.com,Sherwin-Williams,Retail
 shield.security,Mailprotector,Email Security
 shift4shop.com,Shift4Shop,SaaS
 shinbiro.com,Shinbiro,ISP
+shinjiru.com.my,Shinjiru,Web Host
 shinpoly.co.jp,Shin-Etsu Polymer,Industrial
+shinsegae.com,Shinsegae,Retail
 ship.edu,Shippensburg University,Education
 shizuoka.ac.jp,Shizuoka University,Education
 shizuokaseiki.com,Shizuoka Seiki,Industrial
@@ -6188,6 +6927,7 @@ shtorm.com,Shtorm,ISP
 shtorm.net,Shtorm,ISP
 shudo-u.ac.jp,Hiroshima Shudo University,Education
 shugiin.go.jp,House of Representatives of Japan,Government
+shuxun.net,Shanghai Data Solution,Web Host
 shyamgroup.org,Shyam Group,Conglomerate
 si.edu,Smithsonian Institution,Education
 siac.com,SIAC,Finance
@@ -6203,6 +6943,7 @@ sifytechnologies.com,Sify,ISP
 sig.com,Susquehanna International Group,Finance
 signal.no,Signal,ISP
 signalhire.com,SignalHire,SaaS
+signaltv.net,Signal TV,ISP
 signet.nl,Signet,ISP
 signetbreedband.nl,Signet,ISP
 signium.co.jp,Signium,Consulting
@@ -6234,7 +6975,9 @@ sinectis.com.ar,Sinectis,ISP
 sinergit.com.do,Sinergit,MSP
 sineris.net,Sineris,Web Host
 sinet.ad.jp,SINET,Education
+sinet.com.kh,SINET Cambodia,ISP
 sinfony6.com,Sinfony6,Web Host
+singingriver.com,Singing River Connect,Utilities
 singnet.com.sg,SingNet,ISP
 singtel.com,Singtel,ISP
 sinica.edu.tw,Academia Sinica,Education
@@ -6242,6 +6985,7 @@ sinnet.com.cn,Sinnet,Web Host
 siol.net,Telekom Slovenije,ISP
 sion.com,Sion Argentina,ISP
 sipartech.com,Sipartech,ISP
+siriuscom.com,Sirius (CDW),MSP
 siriustelecom.uz,Sirius Telecom,ISP
 sita.aero,SITA,SaaS
 sita.co.za,SITA,Government
@@ -6249,6 +6993,7 @@ site.rb-hosting.io,Raidboxes,Web Host
 siteground.com,SiteGround,Web Host
 sitehost.co.nz,SiteHost,Web Host
 sitehost.nz,SiteHost,Web Host
+sitel.net.pl,Sitel (Livenet),ISP
 sitelbra.com.br,Sitelbra,ISP
 siteprotect.com,SiteMail,Email Provider
 sitios.win,Sitios Win,Web Host
@@ -6256,6 +7001,7 @@ sitsa.com.ar,SITSA Telecomunicaciones,ISP
 sitsanetworks.net,SiTSA,ISP
 siu.edu,Southern Illinois University Carbondale,Education
 siue.edu,Southern Illinois University Edwardsville,Education
+six-group.com,SIX Group,Finance
 sixinternet.com.br,Six Internet,ISP
 sjcoe.org,San Joaquin County Office of Education,Education
 sjfc.edu,St. John Fisher University,Education
@@ -6278,9 +7024,11 @@ sknt.ru,Skynet,ISP
 sktelecom.com,SK Telecom,ISP
 sky.com,Sky,ISP
 sky.it,Sky,ISP
+skybest.com,SkyLine SkyBest,ISP
 skybroadband.com,Sky,ISP
 skydsl.eu,skyDSL,ISP
 skydsl.it,skyDSL,ISP
+skyhighsecurity.com,Skyhigh Security,Email Security
 skymail.com.br,Skymail,Email Provider
 skymesh.net.au,SkyMesh,ISP
 skynet.kg,Skynet Telecom,ISP
@@ -6323,12 +7071,16 @@ smileserv.com,Smileserv,Web Host
 smith.edu,Smith College,Education
 smithbucklin.com,Smithbucklin,Consulting
 smithville.com,Smithville Fiber,ISP
+smoltelecom.ru,Smoltelecom,ISP
+sms-teleport.com,SMS Teleport,ISP
 smsmasivos.com.ar,SMS Masivos,SaaS
+smsnet.pl,SMSnet,ISP
 smtp.com,SMTP.com,SaaS
 smtp.cz,Active24,Web Host
 smtp25.com,Zix,Email Security
 smtp2go.com,SMTP2GO,SaaS
 smu.edu,Southern Methodist University,Education
+snafu.de,snafu,Web Host
 snapengage.com,SnapEngage,SaaS
 snapfiles.com,SnapFiles,Technology
 snc.edu,St. Norbert College,Education
@@ -6339,12 +7091,15 @@ snthostings.com,SnTHostings,Web Host
 snu.ac.kr,Seoul National University,Education
 so-net.ne.jp,So-net,ISP
 so-net.net.tw,So-net,ISP
+sobralnet.com.br,Sobralnet,ISP
 socgen.com,Societe Generale,Finance
 socialfive.com,Social5,Marketing
 socialservices-ssmd.ca,Social Services Sault Ste. Marie,Government
 socket.net,Socket,ISP
+soco.net,SOCO,ISP
 socoolsolution.com,So Cool Solution,MSP
 sodetel.net.lb,sodetel,ISP
+soe.com,Daybreak Game Company,Entertainment
 sofreafurnishings.com,Sofrea Furnishings,Retail
 softbank.jp,SoftBank,ISP
 softbank.ne.jp,SoftBank,ISP
@@ -6366,10 +7121,12 @@ solarwinds.com,SolarWinds Service Desk,SaaS
 solcon.nl,Solcon,ISP
 solentnewsletters.uk,Solent Newsletters,Marketing
 solfibraotica.com.br,Sol Internet Fibra Óptica,ISP
+solidtools.com,SolidTools,ISP
 soliton.co.jp,Soliton Systems,SaaS
 solnet.ch,SolNet,ISP
 soltia.es,Soltia,Web Host
 solutions.com.sa,STC,ISP
+solvinity.com,Solvinity,MSP
 somelec.mr,SOMELEC,Industrial
 somyatrans.com,Somya Translators,Consulting
 sonatel.com,Sonatel,ISP
@@ -6379,6 +7136,7 @@ sonic.com,Sonic,ISP
 sonic.net,Sonic,ISP
 sonichealthcareusa.com,Sonic Healthcare USA,Healthcare
 sonicwall.com,SonicWall,Email Security
+sony.com,Sony,Entertainment
 sonygs.co.jp,Sony Global Solutions,MSP
 sonynetwork.co.jp,So-net,ISP
 soon.com.ar,Red Intercable Digital,ISP
@@ -6392,14 +7150,18 @@ soumaster.com.br,Master Internet,ISP
 southern-comms.co.uk,SCG (Southern Communications),ISP
 southernco.com,Southern Company,Utilities
 southerncompany.com,Southern Company,Utilities
+southernphone.com.au,Southern Phone,ISP
 southlandind.com,Southland Industries,Construction
 southslope.com,South Slope Communications,ISP
+southwestern.edu,Southwestern University,Education
 souuni.com,Uni Telecom,ISP
 soverin.com,Soverin,Email Provider
 soverin.net,Soverin,Email Provider
 sp.edu.sg,Singapore Polytechnic,Education
 sp2-brevo.net,Brevo (Sendinblue),Marketing
 space.net,SpaceNet,MSP
+spacenet.ru,Internet-Cosmos (Spacenet),ISP
+spacenorway.com,Space Norway,ISP
 spaceship.com,Spaceship,Web Host
 spaceship.net,Spaceship,Web Host
 spaceweb.ru,SpaceWeb,Web Host
@@ -6408,17 +7170,21 @@ spambusters.email,Spambusters,Email Security
 spamfiltering.com,Hosting UK,Web Host
 spamtitan.com,SpamTitan,Email Security
 spark.co.nz,Spark,ISP
+sparkassen-it.de,Sparkassen-IT,MSP
 sparklight.com,Sparklight,ISP
 sparklight.net,Sparklight,ISP
 sparkmail.jp,U-netSURF,ISP
 sparkpostmail.com,Bird (Formerly SparkPost),Marketing
+sparktechltd.com,SparkTech,ISP
 sparq.com.au,Sparq (Energex),Utilities
 sparqnet.net,Sparqnet,ISP
 spartanhost.org,Spartan Host,Web Host
 spb.ru,Smart Telecom,ISP
+spbu.ru,Saint Petersburg State University,Education
 spcmail.jp,SPC Mail S.T.,Email Provider
 spd-mgts.ru,MGTS,ISP
 spd.co.il,SPD Hosting,Web Host
+spd.net.tr,SPDNet,Web Host
 spectra.co,Shyam Spectra,ISP
 spectranet.com.ng,Spectranet,ISP
 spectranet.in,Spectra,ISP
@@ -6444,17 +7210,21 @@ spherion-southbend.com,Spherion,Staffing
 sphostserver.com,Server Plan,Web Host
 spiecom.com,SPIE ICS,MSP
 spinnakernet.info,Spinnaker,ISP
+spinservers.com,SpinServers,Web Host
 spintel.net.au,SpinTel,ISP
 spintheweb.com,Spin The Web,Web Host
+spirit.com.au,Spirit Technology,MSP
 spitfire.co.uk,Spitfire,ISP
 spitzer.org,Spitzer Autoworld,Automotive
 splashtop.com,Splashtop,Technology
+splius.lt,Splius,ISP
 spnetinternet.com.br,SP NET,ISP
 spoje.net,SPOJE.NET,ISP
 spok.com,Spok,Healthcare
 spotler.com,Spotler,Marketing
 springernature.com,Springer Nature,Education
 springfield.ma.us,Springfield Public Schools,Education
+springnet.net,SpringNet,ISP
 sprint-bg.net,Sprint Bulgaria,ISP
 sprint-inet.ru,SPRINTInet (Спринт-инет),ISP
 sprintinet.ru,SPRINTInet,ISP
@@ -6462,6 +7232,7 @@ sprious.com,Sprious,Web Host
 sps.net.sa,Gulf Computer Services,ISP
 spt.vn,Saigon Postel,ISP
 sptel.com,SPTel,ISP
+square-enix.com,Square Enix,Entertainment
 square7.ch,bplaced,Web Host
 square7.de,bplaced,Web Host
 square7.net,bplaced,Web Host
@@ -6470,9 +7241,11 @@ srgtelecom.com.br,SRG Telecom,ISP
 sri.com,SRI International,Education
 srpnet.com,Salt River Project,Utilities
 srt.com,SRT Communications,ISP
+srtc.coop,Santa Rosa Telephone Cooperative,ISP
 srvape.com,Smart Ape LLC,Web Host
 ssc-spc.gc.ca,Shared Services Canada,Government
 ssdcloudindia.net,E2E Networks,Web Host
+ssimicro.com,SSi Canada,ISP
 sslmda.com,Maxar Space (Space Systems Loral),Defense
 ssmhealth.com,SSM Health,Healthcare
 ssnettelecom.net.br,SSNET Telecom,ISP
@@ -6480,17 +7253,26 @@ sst2u.com,SST2U,Education
 ssuv.uz,"Samarkand Institute of Veterinary Medicine, Animal Husbandry and Biotechnology",Education
 st.nl,Schiphol Telematics,MSP
 stabletransit.com,Rackspace,Web Host
+stack.net,Stackster,ISP
 stackit.de,STACKIT (Schwarz),IaaS
 stackmail.com,20i,Web Host
+stacksdiscovery.com,Stacks,Web Host
+stadtnetz-bamberg.de,Stadtnetz Bamberg,ISP
+stadtwerke-kufstein.at,Stadtwerke Kufstein,Utilities
 stadtwerke-neumuenster.de,SWN Stadtwerke Neumünster,Utilities
+stadtwerke-neustrelitz.de,Stadtwerke Neustrelitz,Utilities
+stadtwerke-schwedt.de,Stadtwerke Schwedt,Utilities
+stadtwerke.it,Azienda Pubbliservizi Brunico,Utilities
 stalliongroup.com,Stallion Group,Conglomerate
 stalliongroup.com.ng,Stallion Group,Conglomerate
 stampduty.gov.ng,Stamp Duty Nigeria,Government
+standardbank.co.za,Standard Bank,Finance
 standex.co.jp,Standex,Industrial
 stanford.edu,Stanford University,Education
 star.ne.jp,Xserver,Web Host
 starcat.ne.jp,StarCat Cable Network,ISP
 starchapter.com,StarChapter,SaaS
+stargate.ca,Stargate Connections,ISP
 stargatecommunications.com,X-Link Limited,ISP
 starhealthagency.com,Star Home Health,Healthcare
 starhub.com,StarHub,ISP
@@ -6501,6 +7283,7 @@ starnet.cz,Starnet,ISP
 starnet.md,StarNet,ISP
 starnet.net.id,StarNet,ISP
 starnetcomunicacao.com.br,Starnet Comunicação,ISP
+starnettelecom.pl,StarNet Telecom Poland,ISP
 starnetweb.com.br,Starnet,ISP
 starnova.com,Starnova,Web Host
 starry.com,Starry,ISP
@@ -6522,6 +7305,8 @@ state.nv.us,State of Nevada,Government
 state.or.us,The State of Oregon,Government
 state.sd.us,South Dakota Government,Government
 state.tn.us,Tennessee Government,Government
+statens-it.dk,Statens IT Denmark,Government
+statestreet.com,State Street,Finance
 station030.com,123eHost,Web Host
 staywellhealth.org,StayWell Health Center,Healthcare
 stbonifacehospital.ca,St. Boniface Hospital,Healthcare
@@ -6529,6 +7314,7 @@ stc.com.bh,STC,ISP
 stc.com.kw,STC,ISP
 stc.com.sa,STC,ISP
 stcable.net,ST Cable,ISP
+stealth.net,Stealth Communications,ISP
 stellantis.com,Stellantis,Automotive
 stellarllc.net,Gardonville Cooperative Telephone Association,ISP
 stelogy.com,Stelogy (VoIP Telecom),ISP
@@ -6540,6 +7326,8 @@ stewarthowe.com,Newfold Digital,Web Host
 stfx.ca,St. Francis Xavier University,Education
 sti.net,Sierra Tel,ISP
 stibo.com,Stibo,SaaS
+stiegeler.com,Stiegeler Internet,ISP
+stil.dk,STIL Denmark,Government
 stjansdal.nl,Hospital St Jansdal,Healthcare
 stjohns.edu,St. John's University,Education
 stjude.org,St. Jude Children's Research Hospital,Healthcare
@@ -6559,18 +7347,28 @@ stratanetworks.com,Strata Networks,ISP
 strategictreasurer.com,Strategic Treasurer,Finance
 strato.de,STRATO,Web Host
 stratoserver.net,STRATO,Web Host
+stratosglobal.com,Inmarsat (Stratos Global),ISP
 stratus.com,Stratus Technologies,Technology
+stratusiq.com,StratusIQ,ISP
 streamlit.app,Snowflake,SaaS
 streamlit.io,Snowflake,SaaS
 streamlitapp.com,Snowflake,SaaS
 streamnet.co.uk,Streamline Solutions,MSP
 streamsend.com,Campaigner,Marketing
+strencom.net,DigitalWell (Strencom),ISP
+strongtechnology.net,StrongVPN,Web Host
 stsci.edu,Space Telescope Science Institute,Science
 stsnet.ro,Romanian Special Telecommunications Service,Government
+sttelcom.com,S and T Communications,ISP
 stu.edu.gh,Sunyani Technical University,Education
 studio4web.com,Studio4Web,Web Host
+stv.ee,STV Estonia,ISP
 suanettelecom.com.br,Suanet Telecom,ISP
+subisu.net.np,Subisu Cablenet,ISP
+subnet05.ru,Subnet,ISP
+subrigo.net,Subrigo,MSP
 succeed.net,Succeed.net,ISP
+success-hr.com,Success HR,SaaS
 sudatel.sd,Sudatel,ISP
 suddenlink.net,Suddenlink,ISP
 sulcatel.com.br,Sulcatel,ISP
@@ -6586,6 +7384,7 @@ sunet.se,SUNET,Education
 sunfield.ne.jp,Sun Field Internet,ISP
 sungardas.com,11:11 Systems,MSP
 sunnybrook.ca,Sunnybrook Health Sciences Centre,Healthcare
+sunnyvision.com,SunnyVision,Web Host
 sunrise.ch,Sunrise,ISP
 sunucun.com.tr,Sunucun,Web Host
 sunway.com.br,Sunway,ISP
@@ -6598,6 +7397,7 @@ supabase.com,Supabase,PaaS
 supabase.in,Supabase,PaaS
 supabase.net,Supabase,PaaS
 supatx.com,SUP ATX,Retail
+super.net.pk,Supernet Pakistan,ISP
 superb.net,CherryRoad (Formerly Superb Internet),Web Host
 supercabotv.com.br,Super Cabo,ISP
 superconectados.ar,ARLINK,ISP
@@ -6623,9 +7423,12 @@ surf.nl,SURF,Education
 surfairwireless.com,Surf Internet,ISP
 surfer.at,T-Mobile,ISP
 surfinternet.com,Surf Internet,ISP
+surfplanet.de,Surfplanet Cologne,Web Host
 surry.net,Surry Communications,ISP
+sv-en.ru,Svyaz-Energo,ISP
 sverigesradio.se,Sveriges Radio,News
 svn-repos.de,LCube,Web Host
+svorka.no,Svorka,ISP
 swan.sk,SWAN,ISP
 swarthmore.edu,Swarthmore College,Education
 swat.coop,Southwest Arkansas Telephone,ISP
@@ -6634,6 +7437,7 @@ sweb.ru,SpaceWeb,Web Host
 swedbank.se,Swedbank,Finance
 sweet.tv,OTT Ukraine,Entertainment
 swgfl.org.uk,SWGfL South West Grid for Learning,Education
+swhl.de,Stadtwerke Lubeck,Utilities
 swiatlowodem.pl,Blisko (Biznes Swiatlowodem),ISP
 swiftng.com,Swift Networks,ISP
 swiftslots.com,SwiftSlots,Web Host
@@ -6653,14 +7457,18 @@ syd.com.co,SyD Colombia,Healthcare
 sydney.edu.au,University of Sydney,Education
 symbio.global,Symbio,ISP
 symphony.net.th,Symphony Communication,ISP
+symphox.net,Symphox,MSP
 syn-alias.com,Synacor,SaaS
 syn.is,Sýn,ISP
+syn.one,SYN,ISP
 synapse.jp,Synapse,ISP
 synapse.ne.jp,Synapse,ISP
 synapse.net.ua,Synapse Network,ISP
+synapsis-it.co,Synapsis Colombia,MSP
 synccentric.com,Synccentric,SaaS
 synchronoss.net,Synchronoss,SaaS
 syncontel.net.br,Syncontel Telecomunicações,ISP
+syndeonetwork.com,Syndeo Networks,ISP
 synergywholesale.com,Synergy Wholesale,Web Host
 synlinq.de,Synlinq,Web Host
 synoptek.com,Synoptek,MSP
@@ -6668,14 +7476,17 @@ syntax.com,Syntax,MSP
 synthesys.live,Synthesys,SaaS
 synthite.co.uk,Synthite,Industrial
 syntura.io,Syntura,MSP
+syptec.com,Syptec,MSP
 syr.edu,Syracuse University,Education
 syriantelecom.sy,Syrian Telecom,ISP
 syriatel.sy,Syriatel,ISP
 syringanetworks.net,Syringa Networks,ISP
+syrion.pl,Syrion (Miconet),ISP
 sysaid.com,SysAid,SaaS
 sysaidit.com,SysAid,SaaS
 sysconinfoway.com,Syscon Infoway,Web Host
 syseleven.de,SysEleven,IaaS
+sysgroup.com,SysGroup,MSP
 sysnet.ie,VikingCloud,MSP
 systalent.com,Systalent,SaaS
 systex.com.tw,Systex,MSP
@@ -6684,12 +7495,15 @@ t-2.net,T-2,ISP
 t-com.hr,T-Com,ISP
 t-com.sk,Slovak Telekom,ISP
 t-ipconnect.de,Deutsche Telekom,ISP
+t-m-net.de,T-M-Net,ISP
 t-mobile.at,T-Mobile,ISP
 t-mobile.com,T-Mobile USA,ISP
 t-mobile.cz,T-Mobile,ISP
 t-mobile.de,T-Mobile,ISP
 t-mobile.pl,T-Mobile,ISP
+t-net.ne.jp,Tama Cable Network,ISP
 t-online.hu,Magyar Telekom,ISP
+t-pbs.net,Pacnet Business Solutions,ISP
 t-systems.at,T-Systems,MSP
 t-systems.com,T-Systems,MSP
 t-systems.de,T-Systems,MSP
@@ -6719,6 +7533,7 @@ tanzaniaservers.com,Tanzania Servers,Web Host
 target.com,Target,Retail
 tarhely.eu,Tárhely.Eu,Web Host
 tarr.hu,Tarr,ISP
+tasfrance.com,ATSAT (Nubevia),ISP
 tatacommunications.com,Tata Communications,ISP
 tataidc.co.in,Tata Tele Business Services (TTBS),ISP
 tataindicom.com,Tata Teleservices,ISP
@@ -6736,6 +7551,10 @@ tcftelecom.com.br,TCF Telecom,ISP
 tchile.com,Tchile,Web Host
 tci.ir,TCI,ISP
 tcmcorp.com,Southland Industries,Construction
+tcmhd.com.br,Sistema Oeste de Servicos,ISP
+tcn-catv.co.jp,Tokyo Cable Network,ISP
+tcoe.org,Tulare County Office of Education,Education
+tcpi.com,TCP Lighting,Manufacturing
 tcpnet.com.br,TCPNet,ISP
 tcrholdings.com,TCR Holdings,ISP
 tcs.com,TATA Consultancy Services,SaaS
@@ -6752,10 +7571,13 @@ teamglac.com,TeamGLAC,Healthcare
 teammidwest.com,MEC Midwest Energy and Communications,ISP
 tec.com,TEC of Jackson,ISP
 tec.mx,Tecnológico de Monterrey,Education
+tech.gov.sg,Government Technology Agency Singapore,Government
 tech.ru,TECH.RU,Web Host
 tech4hosting.com,Tech 4 Hosting,Web Host
 techdata.com,Tech Data,Logistics
 teche.net,Uniti,MSP
+techmahindra.com,Tech Mahindra,MSP
+technological.ro,Technological Romania,ISP
 technolutions.com,Technolutions,SaaS
 technolutions.net,Technolutions,SaaS
 technozone.com.ph,Technozone Corporation,Construction
@@ -6763,6 +7585,7 @@ tecwave.com.br,Tecwave Telecom,ISP
 tedata.net,Telecom Egypt,ISP
 tedforbes.com,Ted Forbes,Photography
 tees.ne.jp,Toyohashi Cable Network,ISP
+tegna.com,TEGNA (Nexstar),Government Media
 teksavvy.com,TekSavvy,ISP
 tel.net.ba,HT Eronet,ISP
 tel.ru,TEL Suntel,ISP
@@ -6790,16 +7613,20 @@ telecolumbus.com,Tele Columbus,ISP
 telecom-sudparis.eu,Telecom SudParis,Education
 telecom.by,Beltelecom,ISP
 telecom.com.ar,Telecom Argentin,ISP
+telecom.com.fj,Telecom Fiji,ISP
 telecom.kz,Kazakhtelecom,ISP
 telecom.li,FL1 (Telecom Liechtenstein),ISP
 telecom.mu,Mauritius Telecom,ISP
 telecom.na,Telecom Namibia,ISP
 telecom.net.ar,Telecom Argentina,ISP
+telecom.tm,Turkmentelecom,ISP
 telecomarmenia.am,Telecom Armenia (Team),ISP
 telecomitalia.com,TIM,ISP
 telecomitalia.it,TIM,ISP
+telecomitalia.sm,TIM San Marino,ISP
 telecomprovider.com.br,Telecom Provider,ISP
 teledata.de,TeleData,ISP
+teledataict.com,Teledata Ghana,ISP
 teledyne.com,Teledyne Technologies,Manufacturing
 telefonica.com,Telefónica,ISP
 telefonica.com.ar,Telefónica Argentina,ISP
@@ -6808,8 +7635,11 @@ telefonica.com.ec,Telefonica Ecuador (Otecel),ISP
 telefonica.com.pe,Telefónica Perú,ISP
 telefonica.de,Telefónica Germany,ISP
 telefonicachile.cl,Telefónica Chile,ISP
+telehouse.bg,Telehouse Bulgaria,Web Host
+telehouse.net,Telehouse,Web Host
 telekabel.com.mk,Telekabel,ISP
 telekom.at,A1,ISP
+telekom.com,Deutsche Telekom,ISP
 telekom.de,Deutsche Telekom,ISP
 telekom.hu,Magyar Telekom,ISP
 telekom.me,Crnogorski Telekom,ISP
@@ -6824,6 +7654,7 @@ telemaxx.de,TelemaxX,Web Host
 telenet-ops.be,Telenet BV,ISP
 telenet.be,Telenet,ISP
 telenet.lv,Telenet Latvia,ISP
+telenor.com.pk,Telenor Pakistan,ISP
 telenor.dk,Telenor,ISP
 telenor.no,Telenor,ISP
 telenor.se,Telenor,ISP
@@ -6834,11 +7665,15 @@ telepermit.co.nz,Spark NZ,ISP
 telered.com.ar,Telered,ISP
 telering.at,Magenta,ISP
 telesat.com,Telesat,ISP
+telesat.hr,Telesat Croatia,ISP
 teleservice.net,Teleservice Skane,ISP
+teleseti.com,Teleseti Plus,ISP
 teleson.net.br,Teleson Telecom,ISP
 telesp.net.br,Telefônica Brasil,ISP
 telesur.sr,Telesur,ISP
 teletu.it,Vodafone,ISP
+televiaducto.com.do,Televiaducto,ISP
+telfy.com,Telfy,ISP
 telia.dk,Norlys,ISP
 telia.ee,Telia,ISP
 telia.fi,Telia,ISP
@@ -6846,10 +7681,12 @@ telia.lt,Telia,ISP
 telia.lv,Tet,ISP
 telia.no,Telia Norge,ISP
 teliacompany.com,Telia,ISP
+teliacygate.se,Telia Cygate,MSP
 teligraph.com.sg,Teligraph,MSP
 telin.net,Telkom Indonesia,ISP
 telium.com.br,Telium Networks,ISP
 telium.net.br,Telium,ISP
+telkea.com,Telkea,ISP
 telkom.co.ke,Telkom Kenya,ISP
 telkom.co.za,Telkom South Africa,ISP
 telkomadsl.co.za,Telkom,ISP
@@ -6857,6 +7694,7 @@ telkomsa.net,Telkom,ISP
 telkomsel.com,Telkomsel,ISP
 tellas.gr,Nova Telecommunications,ISP
 telma.mg,Yas,ISP
+telmax.com,telMAX,ISP
 telmex.com,Telmex,ISP
 telmex.net.ar,Telmex Argentina,ISP
 telnetworldwide.com,Telnet Worldwide,ISP
@@ -6866,9 +7704,11 @@ telstra.com.au,Telstra,ISP
 telstra.net,Telstra,ISP
 telstrainternational.com,Telstra Global,ISP
 telsur.cl,Telefónica del Sur,ISP
+telta.de,TELTA Citynetz,ISP
 teluq.ca,Tele-Universite,Education
 telus.com,TELUS,ISP
 telus.net,TELUS,ISP
+telvgg.coop,Cooperativa Telefonica V.G.G.,ISP
 telviso.com.ar,TelViso,ISP
 telxius.com,Telxius,ISP
 tempe.gov,City of Tempe,Government
@@ -6881,6 +7721,7 @@ tenet.ua,TENET,ISP
 tennessee.edu,University of Tennessee,Education
 teol.net,mtel,ISP
 tera-byte.com,Tera-Byte,Web Host
+teracom.dk,Cibicom,ISP
 terago.ca,TeraGo,ISP
 teraline-telecom.net,Teraline Telecom,ISP
 teraline.kz,Teraline Telecom,ISP
@@ -6890,7 +7731,10 @@ ternet.or.tz,TERNET Tanzania Education and Research Network,Education
 terra.com,Terra Networks,Web Host
 terra.com.br,Terra Mail,Email Provider
 terra.net.lb,TerraNet,ISP
+terrakom.hr,Terrakom,ISP
+terranets-bw.de,terranets bw,Utilities
 terratransit.de,TerraTransit,ISP
+terrecablate.it,Terrecablate,ISP
 tesatelecom.com,Tesa Telecom,ISP
 tesla.com,Tesla,Automotive
 tet.lv,Tet,ISP
@@ -6899,10 +7743,13 @@ tevisat.net,Tevisat,ISP
 texas.gov,The Government of Texas,Government
 textowngroup.com,Textown Group,Manufacturing
 tfn.net.tw,Taiwan Fixed Network,ISP
+tgtel.com,Thacker-Grigsby Communications,ISP
 thaitoko.com,Thai Toko Engineering,Construction
+thalesgroup.com,Thales,Defense
 thcservers.com,THCServers,Web Host
 the.hosting,THE.Hosting,Web Host
 theaccessgroup.com,The Access Group,SaaS
+thebunker.net,The Bunker (Cyberfort),Web Host
 thecamels.org,Thecamels,Web Host
 thechristhospital.com,The Christ Hospital,Healthcare
 thecloud.net,Sky WiFi (The Cloud),ISP
@@ -6913,6 +7760,8 @@ theglobalresearchnetwork.com,Global Healthcare Research,Healthcare
 thehostgroup.com,The Host Group,Web Host
 themercury.com,The Mercury,News
 thibodaux.com,Thibodaux Hospitals,Healthcare
+thinkbignets.com,IQ Fiber (ThinkBig Networks),ISP
+thinkhuge.net,Think Huge,Web Host
 thomsonreuters.com,Thomson Reuters,SaaS
 three.co.uk,Three,ISP
 three.com.hk,3 Hong Kong (Hutchison),ISP
@@ -6938,6 +7787,7 @@ tietoevry.com,Tietoevry,Consulting
 tifr.res.in,Tata Institute of Fundamental Research,Science
 tigerconnect.com,TigerConnect,SaaS
 tigertech.net,Tiger Technologies,Web Host
+tiggee.com,Tiggee (DigiCert),Email Security
 tigo.co.tz,Tigo,ISP
 tigo.com,Tigo,ISP
 tigo.com.bo,Tigo,ISP
@@ -6953,6 +7803,7 @@ tim.it,TIM,ISP
 time.com.my,TIME,ISP
 timeetc.com,Time Etc,SaaS
 timenet.it,Timenet,ISP
+timernet.ru,Timer,ISP
 timeweb.com,Timeweb,Web Host
 timeweb.ru,Timeweb,Web Host
 timewebcloud.kz,Timeweb Cloud,Web Host
@@ -6967,6 +7818,7 @@ tis-dialog.ru,TIS Dialog,ISP
 tiscali.it,Tiscali,ISP
 tisco.mx,TISCO Networks,MSP
 tisnet.net.tw,TISNET,ISP
+tisp.com,Datawing (TISP),ISP
 titan.email,Titan,Email Provider
 titanhq.com,TitanHQ,Email Security
 titech.ac.jp,Institute of Science Tokyo,Education
@@ -6974,6 +7826,7 @@ tivit.com,Tivit,MSP
 tix.it,Tuscany Internet eXchange,ISP
 tjbtn.net,Tianjin Broadcasting TV Network,ISP
 tkchopin.pl,Chopin Telewizja Kablowa,ISP
+tkk.net.pl,Telewizja Kablowa Koszalin,ISP
 tkreal.ru,The Real Group,Logistics
 tktelekom.pl,TK Telecom,ISP
 tlapnet.cz,Tlapnet,ISP
@@ -6981,6 +7834,7 @@ tm.com.my,TM,ISP
 tm.net,Mercury Telecom,ISP
 tmc.edu,Truett McConnell University,Education
 tmccorp.com,TMC,Industrial
+tmcel.mz,Mocambique Telecom (TMcel),ISP
 tmcz.cz,T-Mobile,ISP
 tmd.ac.jp,Science Tokyo,Education
 tmdcloud.com,TMDHosting,Web Host
@@ -6990,12 +7844,14 @@ tmkultra.net.br,Tmk Net,ISP
 tmodns.net,T-Mobile USA,ISP
 tmone.com.my,TM Technology Services,ISP
 tmp.pe,Telcom Mikrotik Peru,ISP
+tmt.de,TMT GmbH,ISP
 tn.gov,Tennessee Government,Government
 tnc-neuro.com,Tallahassee Neurological Clinic,Healthcare
 tng.de,TNG Stadtnetz,ISP
 tngnet.com,TNGNET,ISP
 tnm.co.mw,TNM,ISP
 tnnet.fi,TNNet,MSP
+tnsi.com,TNS Transaction Network Services,SaaS
 tnsplus.kz,TNS-Plus,ISP
 tntsupport.net,TNT Support,MSP
 toast.net,TOAST.net,ISP
@@ -7009,7 +7865,9 @@ tohoyk.co.jp,Toho Pharmaceutical,Healthcare
 tojikiston.com,Babilon-T,ISP
 tokai-com.co.jp,TOKAI Communications,ISP
 tokala-mobile.com,Tokala Communications,ISP
+tombigbee.org,Tombigbee Communications,ISP
 tombigbeefiber.com,Tombigbee Fiber,ISP
+tomsknet.ru,Rostelecom Tomsk,ISP
 top-tokyo.co.jp,TOP CORPORATION,Healthcare
 top86.com,Qingdao Cable TV Network Center,ISP
 topauctions24-7.com,TopAuctions24-7,Retail
@@ -7033,14 +7891,19 @@ toto.co.jp,TOTO,Manufacturing
 totvs.com,Totvs,SaaS
 towerstream.com,Towerstream,ISP
 towngastelecom.com,Towngas Telecom,ISP
+townisp.com,Shrewsbury Electric SELCO,Utilities
+towson.edu,Towson University,Education
 toya.com.pl,Toya,ISP
 toyo.ac.jp,Toyo University,Education
 toyotasystems.com,Toyota Systems,Automotive
+tp.edu.sg,Temasek Polytechnic,Education
 tpgi.com.au,TPG,ISP
 tpgtelecom.com.au,TPG,ISP
 tpnet.pl,Orange,ISP
+tpodlasie.pl,Telekomunikacja Podlasie,ISP
 tps.uz,TPS Telecom,ISP
 tptel.ru,Teleport Telecom,ISP
+tpu.ru,Tomsk Polytechnic University,Education
 tpx.com,TPx Communications,ISP
 tradeeasyhk.net,TradeEasyHK,Retail
 tradeindia.com,TradeIndia,SaaS
@@ -7057,6 +7920,8 @@ transsped.com,Trans Sped,SaaS
 transsped.ro,Trans Sped,SaaS
 transtelco.net,Flō Networks,ISP
 transtelecom.net,Trans Telecom,ISP
+transvision.net,Transvision Reseau,ISP
+transworld-home.com,Transworld Home Pakistan,ISP
 travelers.com,Travelers,Finance
 tre.se,Tre,ISP
 treasury.gov,U.S. Department of the Treasury,Government
@@ -7067,6 +7932,7 @@ trentu.ca,Trent University,Education
 trgovinadijelova.hr,Trgovina dijelova,Automotive
 tri-c.edu,Cuyahoga Community College,Education
 tri.go.ke,Tourism Research Institute,Science
+tri.ph,Sky Cable Philippines (TRI),ISP
 triadefibra.com,Tríade Fibra,ISP
 triadefibra.com.br,Tríade Fibra,ISP
 triara.com,Triara,Web Host
@@ -7077,6 +7943,7 @@ trinity.cz,AB-NET,ISP
 trinity.edu,Trinity University,Education
 triolan.com,Triolan,ISP
 triolan.net,Triolan,ISP
+tripleplay.in,Triple Play Broadband,ISP
 tripster.com,Tripster,Travel
 triton.net,Triton Technologies,Technology
 triumf.ca,TRIUMF Canada Particle Accelerator Centre,Science
@@ -7094,9 +7961,13 @@ truemail.co.th,True Internet,ISP
 truespeed.com,TrueSpeed Communications,ISP
 truestreamfiber.com,Truestream Fiber,ISP
 truman.edu,Trueman State University,Education
+truphone.com,Truphone,ISP
+trusted-network.de,Trusted Network,Web Host
 trustifi.com,Trustifi,Email Security
 truvista.net,Truvista,ISP
+trytek.ru,Trytek,ISP
 tsimages.net,TSImages,SaaS
+tsl.ru,Teledyne Systems Limited,ISP
 tstc.edu,Texas State Technical College,Education
 tstt.co.tt,TSTT,ISP
 tstt.net.tt,TSTT,ISP
@@ -7120,6 +7991,7 @@ tulane.edu,Tulane University,Education
 tularosa.net,Tularosa Communications,ISP
 tulsaconnect.com,TULSACONNECT,MSP
 tum.de,Technical University of Munich,Education
+tums.ac.ir,Tehran University of Medical Sciences,Education
 tunasgroup.com,Tunas Group,Automotive
 tuni.fi,Tampere University,Education
 tunisietelecom.tn,Tunisie Telecom,ISP
@@ -7133,6 +8005,7 @@ turksat.com.tr,Türksat,ISP
 turktelekom.com.tr,Türk Telekom,ISP
 turktelekomint.com,Turk Telekom International,ISP
 turkticaret.net,Turkticaret.Net,Web Host
+turner.com,Warner Bros Discovery,Entertainment
 turnkeyinternet.net,Hivelocity (TurnKey Internet),Web Host
 tus.ac.jp,Tokyo University of Science,Education
 tusass.gl,Tusass Greenland,ISP
@@ -7149,7 +8022,9 @@ tvcabo.mz,TVCabo Mozambique,ISP
 tvk.pl,TVK Telka,ISP
 tvk.wroc.pl,TVK Telka,ISP
 tvpublica.com.ar,TVP,ISP
+tvsatrm.ro,TVSat Romania,ISP
 tvymas.co,TV&MÁS,ISP
+tw1.com,Transworld Associates Pakistan,ISP
 twilio.com,Twilio,SaaS
 twinlakes.net,Twin Lakes Communications,ISP
 twitter.com,X (Twitter),Social Media
@@ -7162,11 +8037,13 @@ twnic.tw,Taiwan Mobile,ISP
 twt.com.tw,Taiwan Mobile (TNET NET),ISP
 twu.edu,Texas Woman's University,Education
 txstate.edu,Texas State University,Education
+txtv-tz.com,TXTV Tuzla,ISP
 tygrys.net,TYGRYS.NET,ISP
 tylertech.com,Tyler Technologies,SaaS
 tyollisyysrahasto.fi,Työllisyysrahasto,Government
 typeform.com,Typeform,SaaS
 typo3server.info,Mittwald,Web Host
+tz.ru,Telecom TZ,ISP
 tzulo.com,Tzulo,Web Host
 u-fukui.ac.jp,University of Fukui,Education
 u-ryukyu.ac.jp,University of the Ryukyus,Education
@@ -7176,6 +8053,7 @@ u-tokai.ac.jp,Toki University,Education
 u-tokyo.ac.jp,University of Tokyo,Education
 u-toyama.ac.jp,University of Toyama,Education
 u.com.my,U Mobile Malaysia,ISP
+u1host.com,U1 Digital Services,Web Host
 ua.edu,University of Alabama,Education
 uab.edu,The University of Alabama at Birmingham,Education
 uabc.edu.mx,Universidad Autonoma de Baja California,Education
@@ -7197,13 +8075,16 @@ uat.edu.mx,Universidad Autonoma de Tamaulipas,Education
 uba.ar,Universidad de Buenos Aires,Education
 ubannet.com.br,Ubannet,ISP
 ubc.ca,The University of British Columbia,Education
+uber.com,Uber,SaaS
 uber.space,Uberspace,Web Host
 ubs.com,UBS,Finance
 ubxcloud.com,UBX Cloud,Web Host
 uc.cl,Pontificia Universidad Catolica de Chile,Education
 uc.edu,University of Cincinnati,Education
+uc.edu.ve,Universidad de Carabobo,Education
 ucalgary.ca,University of Calgary,Education
 ucar.edu,University Corporation for Atmospheric Research,Education
+ucatv.co.jp,Utsunomiya Cable TV,ISP
 uccs.edu,University of Colorado Colorado Springs,Education
 ucd.ie,University College Dublin,Education
 ucdavis.edu,UC Davis,Education
@@ -7212,6 +8093,7 @@ ucell.uz,Ucell,ISP
 ucf.edu,University of Central Florida,Education
 uchealth.com,UC Health,Healthcare
 uchicago.edu,University of Chicago,Education
+uchile.cl,Universidad de Chile,Education
 uchospitals.edu,University of Chicago Hospitals,Healthcare
 uci.edu,"University of California, Irvine",Education
 ucla.edu,UCLA,Education
@@ -7239,7 +8121,9 @@ udel.edu,University of Delaware,Education
 udg.mx,Universidad de Guadalajara,Education
 udlap.mx,Universidad de las Americas Puebla,Education
 udomain.hk,UDomain,Web Host
+uel.br,Universidade Estadual de Londrina,Education
 uen.org,Utah Education Network,Education
+uepg.br,Universidade Estadual de Ponta Grossa,Education
 ufanet.ru,Ufanet,ISP
 ufba.br,Universidade Federal da Bahia,Education
 ufinet.com,Ufinet,ISP
@@ -7248,6 +8132,8 @@ ufmg.br,UFMG,Education
 ufone.com,Ufone,ISP
 ufrgs.br,UFRGS,Education
 ufsc.br,UFSC,Education
+ufscar.br,Universidade Federal de Sao Carlos,Education
+ufuwa.com,Union Fu Wah Digital,Web Host
 ufv.br,Universidade Federal de Vicosa,Education
 ug.edu.gh,University of Ghana,Education
 uga.edu,University of Georgia,Education
@@ -7266,6 +8152,7 @@ ujat.mx,Universidad Juarez Autonoma de Tabasco,Education
 uk0.bigv.io,Bytemark,Web Host
 uk2.net,UK2.net,Web Host
 uk2net.com,UK2.net,Web Host
+ukbroadband.co.uk,UK Broadband,ISP
 ukg.com,UKG,SaaS
 ukraine.com.ua,Hosting Ukraine,Web Host
 ukrtel.net,Ukrtelecom,ISP
@@ -7278,6 +8165,7 @@ ulakbim.gov.tr,ULAKBIM,Education
 ulalaunch.com,United Launch Alliance,Defense
 ulaval.ca,Universite Laval,Education
 uleth.ca,University of Lethbridge,Education
+ultahost.com,UltaHost,Web Host
 ultimate-guitar.com,Ultimate Guitar,Entertainment
 ultimatedomain.hosting,Ultimate Domain Hosting,Web Host
 ultralinkce.com.br,Ultralink,ISP
@@ -7320,10 +8208,13 @@ unc.edu,UNC Chapel Hill,Education
 uncc.edu,UNC Charlotte,Education
 uncg.edu,UNC Greensboro,Education
 unco.edu,University of Northern Colorado,Education
+under.com.br,Under Servicos de Internet,Web Host
+under.net.ua,Undernet Ukraine,ISP
 une.com.co,UNE,ISP
 une.edu.au,University of New England,Education
 une.net.co,UNE,ISP
 unesp.br,UNESP,Education
+unetelecom.com.br,Une Telecom,ISP
 unf.edu,University of North Florida,Education
 uni-frankfurt.de,Goethe University Frankfurt,Education
 uni-graz.at,University of Graz,Education
@@ -7368,6 +8259,7 @@ united-domains.de,United Domains,Web Host
 united.com,United Airlines,Travel
 united.net,United Communications,ISP
 unitedfiber.com,United Fiber,ISP
+unitedlayer.com,UnitedLayer,IaaS
 unitedyacht.com,United Yacht Sales,Retail
 unitel.ao,Unitel Angola,ISP
 unitel.com.la,Unitel,ISP
@@ -7405,6 +8297,7 @@ up.com,Union Pacific Railroad,Logistics
 up99plus.com,Up99Plus,Web Host
 upc.ie,Virgin Media Ireland,ISP
 upcloud.com,UpCloud,IaaS
+upcspl.in,UP Communication Services,ISP
 updowntelecom.com.br,UpDown Telecom,ISP
 upei.ca,University of Prince Edward Island,Education
 upenn.edu,University of Pennsylvania,Education
@@ -7416,6 +8309,7 @@ uppsala.se,Uppsala Kommun,Government
 upr.edu,University of Puerto Rico,Education
 ups.com,UPS,Logistics
 upstate.edu,SUNY Upstate Medical University,Education
+upstream-network.co.uk,Upstream Network,ISP
 upsun.com,Upsun,PaaS
 uq.edu.au,University of Queensland,Education
 uqac.ca,Universite du Quebec a Chicoutimi,Education
@@ -7434,6 +8328,7 @@ usbank.com,U.S. Bank,Finance
 usc.edu,University of Southern California,Education
 uscomputers.com,U.S. Computer Corporation,MSP
 usda.gov,U.S. Department of Agriculture,Government
+usen.com,USEN,Entertainment
 user.fm,Fastmail,Email Provider
 usercontent.jp,Gehirn,Web Host
 usf.edu,University of South Florida,Education
@@ -7454,14 +8349,18 @@ ussignalcom.net,US Signal,MSP
 usssa.com,USSSA,Sports
 ust.hk,Hong Kong University of Science and Technology,Education
 usu.edu,Utah State University,Education
+ut.ac.ir,University of Tehran,Education
 uta.edu,University of Texas at Arlington,Education
 uta.fi,Tampere University,Education
 utah.edu,University of Utah,Education
 utah.gov,State of Utah,Government
+utahbroadband.com,Utah Broadband,ISP
+utande.co.zw,Dandemutande (Utande),ISP
 utas.edu.au,University of Tasmania,Education
 utc.edu,University of Tennessee at Chattanooga,Education
 utclonline.co.ug,Uganda Telecom,ISP
 utdallas.edu,University of Texas at Dallas,Education
+uteam.ua,UTeam Ivano-Frankivsk,ISP
 utelecom.com.ua,Ukrainian Telecommunication Group (UTG),ISP
 utelesup.edu.pe,Universidad privada Telesup,Education
 utep.edu,University of Texas at El Paso,Education
@@ -7496,6 +8395,7 @@ uvi.edu,University of the Virgin Islands,Education
 uvic.ca,University of Victoria,Education
 uvm.edu,University of Vermont,Education
 uw.edu,University of Washington,Education
+uw.edu.pl,University of Warsaw,Education
 uwa.edu.au,University of Western Australia,Education
 uwaterloo.ca,University of Waterloo,Education
 uwec.edu,University of Wisconsin-Eau Claire,Education
@@ -7525,6 +8425,7 @@ vantagepnt.com,Vantage Point Solutions,ISP
 vanwerthospital.org,Van Wert Health,Healthcare
 varzeanet.com.br,Varzea Net,ISP
 vassar.edu,Vassar College,Education
+vautron.de,Vautron Rechenzentrum,Web Host
 vccs.edu,Virginia Community College System,Education
 vck-gmbh.de,Vestische Caritas-Klinike,Healthcare
 vcn.com,Visionary Broadband,ISP
@@ -7535,6 +8436,7 @@ vd.ch,Canton de Vaud,Government
 vdonsk.ru,Microel,ISP
 vdsina.com,VDSina,Web Host
 vdsina.ru,VDSina,Web Host
+vdska.online,VDSka,Web Host
 vectorfibre.co.nz,Vector Fibre,ISP
 vectra.pl,Vectra,ISP
 vectranet.pl,Vectra,ISP
@@ -7547,8 +8449,11 @@ vegans.it,vegan/s,MSP
 vege.net,vege.net,Web Host
 vegvesen.no,Statens Vegvesen,Government
 veiganet.com.br,VEIGANET,ISP
+vel.net,Velocity Networks,ISP
 velfibra.com.br,Vel Fibra,ISP
 velia.net,velia.net,Web Host
+velo.co.id,VELO Networks Indonesia,ISP
+velocitymsc.com,Velocity Managed Solutions,MSP
 velocitynetwork.net,Velocity Network,ISP
 veloxfiber.com.br,Velox,ISP
 velozfibra.com.br,Veloz Fibra,ISP
@@ -7569,11 +8474,13 @@ verizon.com,Verizon,ISP
 verizon.net,Verizon,ISP
 verizonbusiness.com,Verizon Business,ISP
 vermont.gov,Vermont Government,Government
+vermontel.com,VTel Vermont,ISP
 verobroadband.com,Vero Fiber,ISP
 verointernet.com.br,Internet de Verdade,ISP
 versanet.de,1&1 Versatel,ISP
 vertikal6.com,Vertikal6,MSP
 veseli.cz,The city of Veseli nad Luznici,Government
+vetorial.net,Vetorial Internet,ISP
 vexusfiber.com,Vexus Fiber,ISP
 vgohosting.com,HostPapa,Web Host
 vgonline.com,Video Graphics,Web Host
@@ -7601,10 +8508,12 @@ videotron.ca,Videotron,ISP
 videotron.com,Videotron,ISP
 viecuri.nl,VieCuri,Healthcare
 viethwebhosting.com,MemberLeap,Web Host
+vietserver.vn,VietServer,Web Host
 viettel.com.vn,Viettel,ISP
 viettel.vn,Viettel,ISP
 viettelidc.com.vn,Viettel IDC,Web Host
 viewqwest.com,ViewQwest,ISP
+viewqwest.com.my,ViewQwest Malaysia,ISP
 vigban.com.br,Vigban,Physical Security
 vikingcloud.com,VikingCloud,MSP
 villanova.edu,Villanova University,Education
@@ -7647,6 +8556,7 @@ vistabroadband.com,Vista Broadband,ISP
 vitalnetprovedor.com.br,Vital Net,ISP
 vitelcom.net,ONE Communications,ISP
 vitroconnect.de,vitroconnect,ISP
+vitrodc.com,Vitro,Web Host
 viutelecom.com.br,Viu Internet,ISP
 viva.am,Viva Armenia,ISP
 viva.com.bo,Viva,ISP
@@ -7656,6 +8566,7 @@ vivatecnologia.com.br,Viva Tecnologia,ISP
 vivatele.com,Viva Telecom,ISP
 vivatele.com.br,Viva Telecom,ISP
 vivicta.com,Vivicta,Consulting
+vivid-hosting.net,Vivid-Hosting,Web Host
 vivozap.com.br,Vivo Mobile,ISP
 vk.com,VK,Social Media
 vk.company,VK,Social Media
@@ -7663,6 +8574,7 @@ vladinfo.ru,Vladinfo,ISP
 vladlink.ru,Vladlink,ISP
 vm.bytemark.co.uk,Bytemark,Web Host
 vm.co.mz,Vodacom Mozambique,ISP
+vmedia.ca,VMedia,ISP
 vmi.edu,Virginia Military Institute,Education
 vnet.sk,VNET Slovakia,ISP
 vng.com.vn,VNG Online,SaaS
@@ -7672,8 +8584,10 @@ vnpt.vn,VNPT,ISP
 vnr.de,VNR Group,SaaS
 vnrgroup.com,VNR Group,SaaS
 vntelecom.com.br,VN Telecom,ISP
+vo.lu,Visual Online Luxembourg,ISP
 voartelecom.com.br,Voar Telecom,ISP
 vocalocity.com,Vonage Business (Vocalocity),SaaS
+vocom.com,Vocom International,ISP
 vocus.co.nz,2degrees,ISP
 vocus.com.au,Vocus,ISP
 vodacom.co.ls,Vodacom Lesotho,ISP
@@ -7681,10 +8595,12 @@ vodacom.co.tz,Vodacom Tanzania,ISP
 vodacom.co.za,Vodacom,ISP
 vodacom.com,Vodacom,ISP
 vodafone-ip.de,Vodafone,ISP
+vodafone.al,Vodafone Albania,ISP
 vodafone.co.uk,Vodafone,ISP
 vodafone.com,Vodafone,ISP
 vodafone.com.au,Vodafone,ISP
 vodafone.com.eg,Vodafone,ISP
+vodafone.com.fj,Vodafone Fiji,ISP
 vodafone.com.tr,Vodafone,ISP
 vodafone.cz,Vodafone,ISP
 vodafone.de,Vodafone,ISP
@@ -7696,6 +8612,7 @@ vodafone.is,Sýn,ISP
 vodafone.it,Vodafone,ISP
 vodafone.nl,Vodafone,ISP
 vodafone.pt,Vodafone,ISP
+vodafone.qa,Vodafone Qatar,ISP
 vodafone.ro,Vodafone,ISP
 vodafone.ua,Vodafone,ISP
 vodafonedsl.it,Vodafone Itily,ISP
@@ -7715,6 +8632,7 @@ vom.com,Valley of the Moon,ISP
 voo.be,VOO,ISP
 vootelecom.com.br,Voo Telecom,ISP
 vorboss.com,Vorboss,ISP
+vosnet.ru,Home.Net Voskresensk,ISP
 vote4mentalhealth.org,NAMI,Healthcare
 votervoice.net,VoterVoice,SaaS
 voxdsl.co.za,Vox Telecom,ISP
@@ -7729,6 +8647,7 @@ vrmgr.com,Virtual Resort Manager,Real Estate
 vsc.edu,Vermont State Colleges,Education
 vsenet.de,VSE NET,ISP
 vshosting.cz,vshosting,Web Host
+vsp.fi,VSP Vakka-Suomen Puhelin,ISP
 vsu.by,Vitebsk State University,Education
 vt.edu,Virginia Tech,Education
 vtal.com,V.tal,ISP
@@ -7739,6 +8658,7 @@ vtr.com,VTR,ISP
 vtr.net,VTR,ISP
 vtt.fi,VTT Technical Research Centre of Finland,Education
 vtx.ch,VTX,ISP
+vtx1.net,VTX1 Communications,ISP
 vtxnet.net,VTX Services,ISP
 vu.edu.au,Victoria University,Education
 vulcnmold.com,VulcanMold,Industrial
@@ -7761,6 +8681,8 @@ walmartstores.com,Walmart,Retail
 wanadoo.fr,Orange,ISP
 wananchi.com,Wananchi Group,ISP
 wanao.com,Wanao,SaaS
+wancom.net.pk,Wancom Pakistan,ISP
+wansec.com,WANSecurity,Email Security
 warian.net,Warian,SaaS
 warwick.ac.uk,University of Warwick,Education
 waseda.jp,Waseda University,Education
@@ -7782,6 +8704,7 @@ wbhcp.com,Williams Bros Pharmacy,Healthcare
 wbroadband.net.au,Wholesale Communications Group,ISP
 wcoil.com,Watch Communications,ISP
 wconect.com.br,WCONECT,ISP
+wctatel.com,WCTA Winnebago Cooperative Telecom,ISP
 wctc.net,Solarus,ISP
 wctel.com,West Carolina Communications,ISP
 wcupa.edu,West Chester University,Education
@@ -7810,10 +8733,12 @@ webex.com,Cisco Webex,SaaS
 webflow.io,Webflow,SaaS
 webformix.com,Webformix,ISP
 webglobe.com,Webglobe,Web Host
+webhero.com,Webhero,Web Host
 webhorizon.net,WebHorizon,Web Host
 webhostbd.com,Web Host BD,Web Host
 webhostbd.net,Web Host BD,Web Host
 webhosting.be,Combell,Web Host
+webhosting.net,Webhosting.Net,Web Host
 webhosting.systems,netcup,Web Host
 webhostingireland.ie,Hosting Ireland,Web Host
 webinarhealth.com,WebinarHealth,Education
@@ -7845,17 +8770,22 @@ webzi.mx,Webzi,Web Host
 webzilla.com,Webzilla,Web Host
 webzine1.com,Webzine Online,Web Host
 webzineonline.com,Webzine Online,Marketing
+wecenergygroup.com,WEC Energy,Utilities
 weclix.com.br,Weclix,ISP
 weendeavor.com,Endeavor Communications,ISP
 welcomeitalia.it,Vianova,ISP
 well.com,The WELL,Email Provider
 wellesley.edu,Wellesley College,Education
+wellington.com,Wellington Management,Finance
 wellmont.org,Wellmont Health System,Healthcare
 wellsfargo.com,Wells Fargo,Finance
 wellstar.org,Wellstar Health System,Healthcare
 wemacom-breitband.de,WEMACOM Breitband,ISP
+wemaconnect.de,Wemaconnect,ISP
 wescor.com,ELITechGroup,Healthcare
+weserve.nl,Weserve,ISP
 wesleyan.edu,Wesleyan University,Education
+wessexinternet.com,Wessex Internet,ISP
 westbrook.ms,Westbrook Construction,Construction
 westcall.ru,WestCall,ISP
 westchestergov.com,County of Westchester,Government
@@ -7863,6 +8793,7 @@ westcloudvalley.com,Ningxia West Cloud Data,IaaS
 westcoastinternet.com,West Coast Internet (WCI),ISP
 westdc.net,WestHost,Web Host
 westmancom.com,Westman Communications,ISP
+westpac.com.au,Westpac,Finance
 westriv.com,WRT,ISP
 weverfastfiber.com,Everfast Fiber Networks,ISP
 wewehost.com,WeWeHost,Web Host
@@ -7878,7 +8809,9 @@ whatdev.com,What Development,Healthcare
 whc.ca,Web Hosting Canada,Web Host
 wheaton.edu,Wheaton College,Education
 wheelhouseracingschool.com,The Ford Performance Racing School,Automotive
+whidbeytel.com,Whidbey Telecom,ISP
 whirlpoolcorp.com,Whirlpool,Manufacturing
+whitelabelcolo.com,WhiteLabelColo,Web Host
 whitelighthost.net,Acklo,MSP
 whiteoakemail.com,MailEnable,Email Provider
 whitesky.us,Whitesky Communications,ISP
@@ -7892,27 +8825,36 @@ wi-fiber.io,Wi-Fiber,ISP
 wi.gov,The State of Wisconsin,Government
 wia.cz,WIA Telecommunications,ISP
 wichita.edu,Wichita State University,Education
+wicity.it,WicitY,ISP
 wide.ad.jp,WIDE Project,Science
 widener.edu,Widener University,Education
 wien.gv.at,City of Vienna,Government
 wifeet.com.do,Wifeet,ISP
+wifine.ru,Intercity (Wifine),ISP
+wifinity.co.uk,Wifinity,ISP
 wifire.ru,MegaFon,ISP
 wifirst.com,Wifirst,ISP
+wightfibre.com,WightFibre,ISP
 wightman.ca,Wrightman Telecom,ISP
 wigner.hu,Wigner Research Centre for Physics,Science
 wiit.cloud,WIIT,IaaS
 wikitelecom.com.br,Wki Telecom,ISP
+wiktel.com,Wiktel Wikstrom,ISP
+wiland.ru,Wiland,ISP
 wildpark.net,WildPark,ISP
 wilhelm-tel.de,wilhelm.tel,ISP
 wiline.com,WiLine Networks,ISP
 wilkes.edu,Wilkes University,Education
 wilkes.net,RiverStreet (Wilkes Communications),ISP
 willamette.edu,Willamette University,Education
+williams.com,Williams Companies,Industrial
 williams.edu,Williams College,Education
 williamsbrospharmacy.com,Williams Bros Pharmacy,Healthcare
 willnet.org,WilliNet,ISP
 wilsoncomputer.com,Wilson Computer Support,MSP
 wilsonss.com,Wilson Computer Support,MSP
+wimore.it,WiMore,ISP
+win.be,Win Belgium,ISP
 win.pe,Win Telecom Peru,ISP
 wind.com.do,WIND Telecom,ISP
 wind.it,WINDTRE,ISP
@@ -7947,8 +8889,11 @@ wixsite.com,Wix,SaaS
 wixstudio.com,Wix,SaaS
 wixstudio.io,Wix,SaaS
 wizmoworks.com,Wizmo,MSP
+wjhtedu.com,Beijing WangJu,ISP
 wktelecom.net.br,WK Telecom,ISP
+wku.ac.kr,Wonkwang University,Education
 wku.edu,Western Kentucky University,Education
+wkve.com.br,WKVE Internet,ISP
 wlannetwork.com.br,WLAN Network,ISP
 wlink.com.np,WorldLink Communications,ISP
 wlu.edu,Washington & Lee University,Education
@@ -7963,8 +8908,10 @@ wntellecom.net.br,WN Tellecom,ISP
 wntpr.net,WorldNet Telecommunications,ISP
 wobcom.de,Wobcom Wolfsburg,ISP
 wockhardt.com,Wockhardt,Healthcare
+wolfpaw.com,Wolfpaw Data Centres,Web Host
 wolnet.it,Wolnet,ISP
 wolseleyinc.ca,Wolseley Canada,Industrial
+wolve.com,Wolverine Trading,Finance
 wom.cl,WOM,ISP
 wom.co,Partners Telecom Colombia (Formerly WOM Colombia),ISP
 woodside.com.au,Woodside Energy,Industrial
@@ -7973,6 +8920,7 @@ woodynet.net,WoodyNet (Packet Clearing House),Nonprofit
 woolworths.co.za,Woolworths,Retail
 wooster.edu,College of Wooster,Education
 wordpress.com,Wordpress.com,Web Host
+work.de,n@work,Web Host
 workbandalarga.com.br,Work Banda Larga,ISP
 workday.com,Workday,SaaS
 workhorseirons.com,Workhorse Irons,Industrial
@@ -7982,8 +8930,10 @@ worksmobile.com,Naver Works,SaaS
 worldbank.org,World Bank Group,Nonprofit
 worldbankgroup.org,World Bank Group,Nonprofit
 worldcall.net.pk,WorldCom Telecom,ISP
+worldgatein.net,WorldGate,ISP
 worldline.com,Worldline,SaaS
 worldlink.com.np,WorldLink Communications,ISP
+worldnetpr.com,WorldNet Telecommunications,ISP
 worldphone.in,World Phone India,ISP
 worldstream.com,Worldstream,Web Host
 worria.com,Cloudie,Web Host
@@ -8002,6 +8952,9 @@ wsigenesis.com,Action Hosting,Web Host
 wsnetfibra.com.br,WSNET,ISP
 wstelecom.us,WS Telecom,ISP
 wsu.edu,Washington State University,Education
+wtccommunications.ca,WTC Communications Canada,ISP
+wtccommunications.com,WTC Communications,ISP
+wtvk.pl,Winogradzka Telewizja Kablowa,ISP
 wu-wien.ac.at,Vienna University of Economics and Business,Education
 wustl.edu,Washington University in St. Louis,Education
 wvnet.edu,WVNET,Education
@@ -8017,10 +8970,13 @@ wyoming.com,Wyoming.com,ISP
 wyyerd.com,Wyyerd Fiber,ISP
 x-city.ua,X-City,ISP
 x-com.kz,X-COM,ISP
+x-ion.de,x-ion,Web Host
 x-mailer.de,Power-Netz,Web Host
+x-stream.biz,XSTREAM Italy,ISP
 xbiz.ne.jp,Xserver,Web Host
 xcelenergy.com,Xcel Energy,Utilities
 xceleratorsoftware.com,Key Software Systems Xcelerator,SaaS
+xchangetelecom.com,Skywire (Xchange Telecom),ISP
 xcitium.com,Xcitium,SaaS
 xecu.net,Xecunet,MSP
 xen.prgmr.com,prgmr.com,Web Host
@@ -8032,6 +8988,7 @@ xilinx.com,Xilinx,Manufacturing
 xinet.com.mx,Xinet,MSP
 xipline.com,Ritter Communications,ISP
 xl.co.id,XL Axiata,ISP
+xlshosting.nl,XLS Hosting (Signet),Web Host
 xlsmart.co.id,XL Smart (XL Axiata),ISP
 xmission.com,XMission,SaaS
 xmr3.com,OpenText,SaaS
@@ -8040,6 +8997,7 @@ xn.qh.cn,China Telecom,ISP
 xneelo.co.za,Xneelo,Web Host
 xnet.co.nz,One NZ (Formerly Vodafone New Zealand),ISP
 xnet.mx,Xnet,MSP
+xorek.cloud,XorekCloud,Web Host
 xphone.co.il,XPhone,ISP
 xplore.ca,Xplore,ISP
 xrea.com,XREA,Web Host
@@ -8073,15 +9031,21 @@ yandexcloud.net,Yandex Cloud,IaaS
 yardi.com,Yardi,SaaS
 yarnet.ru,Yarnet,ISP
 yas.mg,Yas,ISP
+yas.sn,Yas Senegal,ISP
 yas.tg,Yas Togo,ISP
+yecaoyun.com,Yecaoyun (LucidaCloud),Web Host
 yellow-inbox.com,Yellow Imbox,Marketing
 yellowinbox.com,Yellow Imbox,Marketing
 yelpcorp.com,Yelp,Social Media
 yemen.net.ye,YemenNet,ISP
 yesfibra.com.br,YES Fibra,ISP
+yeshost.cz,YesHost,Web Host
 yettel.hu,Yettel,ISP
+ygnition.com,Ygnition (Access Media),ISP
 yisu.com,Yisu Cloud,Web Host
 ykwc.com,Yellowknife Wireless,ISP
+ync.ac.kr,Yeungnam College of Science Technology,Education
+ynu.ac.kr,Yeungnam College of Science Technology,Education
 yonsei.ac.kr,Yonsei University,Education
 yorku.ca,York University,Education
 yotta.com,Yotta Network Services,IaaS
@@ -8102,6 +9066,7 @@ yu.ac.kr,Yeungnam University,Education
 yu.edu,Yeshiva University,Education
 yu.net,YUnet International,ISP
 yukanet.com.br,Ykaline,ISP
+yumenet.jp,Kasaoka Cable Vision,ISP
 yurekpharmacy.com,Yurek Pharmacy,Healthcare
 yuuai.or.jp,Social Medical Corporation Yuuaikai,Healthcare
 yuvox.net,Yuvox Telecom,ISP
@@ -8112,6 +9077,7 @@ zaansmedischcentrum.nl,Zaans Medical Center,Healthcare
 zaaztelecom.com.br,Zaaz Telecomunicacoes,ISP
 zain.com,Zain,ISP
 zajil.com,KEMS,ISP
+zamix.com.br,Zamix Multiplay,ISP
 zamren.zm,ZAMREN,Education
 zamtel.zm,Zamtel,ISP
 zap-hosting.com,ZAP-Hosting,Web Host
@@ -8147,6 +9113,8 @@ zid.com,ZiD Internet,ISP
 ziggo.nl,Ziggo,ISP
 ziggozakelijk.nl,Ziggo,ISP
 zillion.network,Zillion Network,ISP
+zimonline.co.za,Zimbabwe Online,ISP
+zinca.com,Zinca (Cesena Net),ISP
 ziplyfiber.com,Ziply Fiber,ISP
 zipweb.net,Zipweb,Web Host
 zirrus.com,Xirrus.com,ISP
@@ -8164,6 +9132,8 @@ zoho.in,Zoho,SaaS
 zohocloud.ca,Zoho,SaaS
 zohocorporation.com,Zoho,SaaS
 zohomail.com,Zoho,SaaS
+zon.pt,NOS Acores,ISP
+zona.ba,Zona DASTO,ISP
 zoneedit.com,Zoneedit,Web Host
 zong.com.pk,Zong (CMPak),ISP
 zoom.com,Zoom,SaaS
@@ -8174,6 +9144,7 @@ ztv.co.jp,ZTV,ISP
 zumpnet.com.br,Zumpnet,ISP
 zumtobelgroup.com,Zumtobel Group,Manufacturing
 zurich.com,Zurich Insurance,Finance
+zut.edu.pl,West Pomeranian University of Technology,Education
 zyner.net,Zyner,Email Provider
 zyner.one,Zyner,Email Provider
 zyner.org,Zyner,Email Provider

--- a/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
+++ b/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
@@ -146,6 +146,7 @@ alsiscad.com
 altecnets.com
 alternativaip.net.br
 alttelecom.net.br
+altushost.com
 aluminati.org
 aluminumpipetubing.com
 alzewayed.com
@@ -158,7 +159,6 @@ americaneagle.com
 americanstorageca.com
 amfm.live
 amik.net.ru
-amis.hr
 amointernet.net.br
 amplusserver.info
 ampr.be
@@ -464,6 +464,7 @@ cascable.net
 cashflowcourier.com
 cashflowmasterypro.com
 caspian.trade
+castleaccess.com
 catalystdiscoverysolutions.my
 cavabeen.com
 cbanewname-com.icu
@@ -565,6 +566,7 @@ cmsintelligence.com
 cnode.io
 cnode.jp
 cnppmpr-ufa.ru
+cnserver.com
 cnt-grms.ec
 cntcloud.com
 cntelecomweb.net.br
@@ -617,6 +619,7 @@ contactsglamour.info
 contactssafari.com
 contenucredit.com
 conterra-inc.com
+convex.ru
 conxxus.net
 cookingartsnetwork.com
 coolblaze.com
@@ -640,6 +643,7 @@ coxfiber.net
 cp2-myorderbox.com
 cpelafrimousse.ca
 cpenet.com.ar
+cpn.it
 cpointcc.com
 cps.com.ar
 creative-entropy.com
@@ -718,6 +722,7 @@ delhaize.be
 delicatesignature.com
 delicious-fukuoka.com
 deliquesce.shop
+deltahost.com.ua
 democompunera.com
 demos2clients.com
 denizhanmedikal.com
@@ -850,6 +855,7 @@ e-tiger.net
 e3webmail.com
 eagleredes.net.br
 eaglezip.com
+eancenter.com
 eappscdn.com
 earthcare.com
 easternkingspei.com
@@ -891,6 +897,7 @@ elista.ru
 elitedjsc.com
 eliton-websolutions.shop
 elixirzorka.xyz
+eljawal.mr
 elonline.com.br
 emailgids.net
 emailperegrine.com
@@ -1083,6 +1090,7 @@ futureinnovation.vn
 futurismtechnologies.com
 fvds.ru
 fwu.edu.pk
+g-service.ru
 g20telecom.net.br
 g3linktelecom.com.br
 gainsightapp.com
@@ -1212,6 +1220,7 @@ hairinninc.com
 haisoft.net
 halcyon-aboveboard.com
 haldenwick.space
+hamarasystem.net
 hanaokaseishu.com
 hanasta.net.id
 hand-delivered.net
@@ -1231,6 +1240,7 @@ hawkaccess.com
 hderit.com
 hdomestic.com
 hdprosupply.com
+headoff.com
 healthcareathome.ca
 healthfuljourneyjoy.com
 healthgoodmovement.com
@@ -1332,6 +1342,7 @@ hwccustomers.com
 hwclouds-dns.com
 hybridinternet.co
 hypericine.com
+hypernet.co.id
 hypointfarms.com
 i-com.fr
 i-mecca.net
@@ -1396,6 +1407,7 @@ indsalelimited.com
 indulgent-holistic.com
 industechint.org
 industry123.com
+inet.co.kr
 infiniteprofitflow.com
 infinitysrv.com
 influxreview.com
@@ -1483,6 +1495,7 @@ itelsa.com.ar
 ithinc.net
 itourismlimited.com
 itproximus.com
+itscom.ad.jp
 itsidc.com
 itsweb.com.br
 itv-3.com
@@ -1530,6 +1543,7 @@ journaladvisor.us
 journalpost.info
 joyomokei.com
 js-hpbs.jp
+jscndata.com
 jumanra.org
 jump.bg
 juniornetfibra.com.br
@@ -1650,6 +1664,7 @@ lindsaywalt.net
 lineadns.com
 linenew.ru
 linet.zp.ua
+link-region.ru
 linknetporto.com.br
 linnemere.xyz
 lintonvale.live
@@ -1741,6 +1756,7 @@ makasasun.com
 makeyourgrowth.com
 malardino.net
 malugainfor.net.br
+mammoth.com.au
 managed-vps.net
 manfred-raab.de
 mangabey.io
@@ -1829,6 +1845,7 @@ milleniumsrv.com
 mindworksunlimited.com
 mine4biz.com
 mirasoft.pl
+mirgiga.net
 mirth-gale.com
 misk.com
 misorpresa.com
@@ -1967,6 +1984,7 @@ netflexbr.com
 netglobal.it
 netglowstudios.pl
 neti.ee
+netjoin.it
 netkl.org
 netkom.de
 netlatin.net.ar
@@ -1974,6 +1992,7 @@ netlilfy.com
 netlinebahia.net.br
 netminasfibra.net.br
 netorn.ru
+netrack.ru
 netscan.hu
 netsky.net.br
 netstartech.sg
@@ -2043,6 +2062,7 @@ ns360.net
 nssonline.com
 nstelecablecr.com
 nt-isp.net
+ntc.net.pk
 ntesmail.com
 nty.uy
 nucleusemail.com
@@ -2294,6 +2314,7 @@ radianthealthrenaissance.com
 radicaltechreveal.com
 radioactive.name
 radiodays.jp
+radioservice.net.ua
 radius.ph
 raimax.com.br
 ranchesmontana.com
@@ -2362,6 +2383,7 @@ rifnet.jp
 rillcrestly.xyz
 rioaccess.com
 rippecloud.com
+rit.ac.th
 rittercommunications.com
 rivencroft.space
 riverwindy.xyz
@@ -2404,6 +2426,7 @@ safesecurewebmail.com
 safevictoryda.com
 sageevents.co.ke
 sahacker-2020.com
+sainet.or.jp
 saiseikai-hp.chuo.fukuoka.jp
 saiseikai-moriyama.jp
 saiwai-pharmacy.com
@@ -2472,6 +2495,7 @@ serverforhost.com
 serveri.org
 serverlicious.com
 servernap.net
+serverplan.com
 serversfarm.com
 servershost.biz
 serversignin.com
@@ -2483,6 +2507,7 @@ seymenkolej.k12.tr
 sfek.kz
 sfr-sh.net
 sgcloudhosting.com
+sgholding.org
 sgict.gov.sg
 sgnetway.net
 shanecircuit.net
@@ -2694,6 +2719,7 @@ techosphere.ng
 techpaperonline.com
 techscape3.com
 techxtrasoft.com
+tecnoadsl.it
 tecnoxia.net
 tecweb-us.com
 tedra.es
@@ -2744,6 +2770,7 @@ thewatchprofessionals.com
 thewedding.directory
 thewitchesparlour.shop
 thinline.cz
+thisiscyberia.com
 threembb.co.uk
 threembb.ie
 throughputclimb.com
@@ -2799,6 +2826,7 @@ tresguerras.com.mx
 tri-countyfence.com
 triciadunlap.me
 tricofood.com
+tricolinksc.com
 tristatemg.com
 triway.net.br
 truezenity.com
@@ -2873,6 +2901,7 @@ unipharm.com
 uniredes.net.br
 unite.services
 unitedrdc.com
+unrealservers.net
 untexklante.org
 unwiredbb.net
 urawasl.com
@@ -2890,6 +2919,7 @@ valleyapothecary.com
 valueserver.com.br
 vamo.net.br
 vamosinternet.com.br
+vanilla.co.za
 vapttelecom.com.br
 varvia.de
 vbcploo.com
@@ -2959,6 +2989,7 @@ vst.net.br
 vtal.net.br
 vulterdi.edu
 vvondertex.com
+w-link.com
 w1o.com
 wacminus.com
 waechter.eu


### PR DESCRIPTION
## Summary

Continued the MMDB ASN-domain coverage walk from #746 into the 30k–18k IPv4-weight band. Added **971 new map entries** and 32 new known-unknown entries from the top 1,000 unmapped candidates.

**Coverage delta:**
- ASN-domain coverage by IPv4 weight: **95.3% → 96.0%**
- ASN-domain coverage by domain count: 8.0% → 9.5%
- Map total entries: 8,180 → 9,151

**Composition of additions:**
- ~30 universities and government / state agencies (maryland.gov, ok.gov, nj.gov, NIA Korea, NECTEC Thailand, gov.si, gov.ru, etc.)
- ~80 globally-known brands (Nvidia, Tesla, Intel, Ford, GM, Volvo, Disney, EA, Roblox, Riot Games, Sony PlayStation, JPMorgan, Goldman Sachs, Morgan Stanley, Charles Schwab, AXA, Cigna, Cargill, Hallmark, Pepsi, Kroger, Random House, NBCUniversal, Qualcomm, Deutsche Bank, UBS, Citi, Lloyds Banking, Westpac, CommBank, Adobe, Broadcom, NXP, Schaeffler, Saint-Gobain, Hanwha, Doosan, Hyundai Autoever, Square Enix, Garena, etc.)
- Long tail of regional ISPs / hosters / MSPs / data center operators classified via MMDB `as_name` + homepage corroboration

**known-unknown changes:** 1 entry promoted out, 32 added where the two-corroborating-sources bar still wasn't met. The two files remain disjoint per the workflow guardrail.

## Test plan

- [x] `python sortlists.py` exits 0 (types valid, alphabetic sort, dedupe)
- [x] CRLF line endings preserved in `base_reverse_dns_map.csv`
- [x] No domain appears in both `base_reverse_dns_map.csv` and `known_unknown_base_reverse_dns.txt` (`comm -12` check passes)
- [x] No full-IP entries in either file (privacy rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)