### PR TITLE
Classify ~940 more reverse DNS map entries from MMDB ASN-domain coverage gap (round 3)

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -25,6 +25,7 @@ base_reverse_dns,name,type
 123website.ch,One.com,Web Host
 123website.lu,One.com,Web Host
 123website.nl,One.com,Web Host
+1240.hu,EuroCable Hungary,ISP
 126.com,NetEase,Email Provider
 15min.lt,15min,News
 163.com,163,Email Provider
@@ -47,8 +48,10 @@ base_reverse_dns,name,type
 2degrees.nz,2degrees,ISP
 2iij.net,IIJ,ISP
 2mtelecom.net.br,2M Telecom,ISP
+31173.se,31173 Services,Web Host
 34sp.com,34SP.com,Web Host
 360.cn,Qihoo 360,Technology
+360broadband.com,360 Broadband Oklahoma,ISP
 360group.es,360 group,Web Host
 365datacenters.com,365 Data Centers,Web Host
 3bb.co.th,3BB,ISP
@@ -73,6 +76,8 @@ base_reverse_dns,name,type
 6ptelecom.com.br,6P Telecom,ISP
 7-dj.com,Fujitsu Systems Applications,MSP
 702com.com,702 Communications,ISP
+7bull.net,7BullNet (MyTek Trading),ISP
+7stardigitalnetwork.com,Seven Star Digital Network,ISP
 84grams.se,84 Grams,ISP
 8x8.com,8x8,SaaS
 99cloudhosting.com,99CloudHosting,Web Host
@@ -91,6 +96,7 @@ a2mobile.pl,a2mobile,ISP
 a2telecomfibra.com.br,A2 Telecom Fibra,ISP
 a2webhosting.com,hosting.com,Web Host
 a2zcreatorz.ca,A2Z Creatorz,Technology
+aa.com,American Airlines,Travel
 aa.net.uk,Andrews & Arnold,ISP
 aaa.com,AAA,Travel
 aalto.fi,Aalto University,Education
@@ -114,8 +120,11 @@ abnamro.com,ABN AMRO,Finance
 abnormal-email.com,Abnormal AI,Email Security
 abogados.or.cr,Colegio de Abogados de Costa Rica,Legal
 abs.gov.au,Australian Bureau of Statistics,Government
+absatellite.com,ABS Satellite,ISP
+abstract.fi,Abstract,Web Host
 abv.bg,ABV Mail,Email Provider
 ac-net.se,AC-Net,ISP
+ac3.com.au,AC3 Australian Centre for Advanced Computing,MSP
 academiasupport.org,Academia Support Japan,Education
 acadiau.ca,Acadia University,Education
 acantho.it,Acantho,ISP
@@ -131,6 +140,7 @@ accesstel.net,AccessTEL,ISP
 accretive-networks.net,Accretive Technology Group,SaaS
 acd.net,ACD.net,ISP
 ace-fiber.com,ACE Fiber,ISP
+ace-host.net,Ace-Host,Web Host
 acedatacenter.com,Ace Data Centers,Web Host
 acedatacenters.com,Ace Data Centers,Web Host
 acelerate.net,AXS Bolivia S. A.,ISP
@@ -141,6 +151,7 @@ acentek.net,AcenTek,ISP
 aceredc.com,Acer e-Enabling Data Center,Web Host
 acessecomunicacao.com.br,Acesse,ISP
 acessoline.net.br,Alt Telecom,ISP
+acgov.org,Alameda County Government,Government
 ach.or.jp,Ageo Central General Hospital,Healthcare
 acim-pr.org.br,ACIM,Nonprofit
 aciworldwide.com,ACI Worldwide,SaaS
@@ -154,12 +165,15 @@ acropolis.org,New Acropolis,Education
 act.gov.au,ACT Government,Government
 actcorp.in,ACT Fibernet,ISP
 actionnetwork.org,Action Network,SaaS
+active-servers.com,active-servers,Web Host
 active24.cz,Active24,Web Host
 activecampaign.com,ActiveCampaign,Marketing
 activegate-ss.jp,Active! gate SS,Email Security
+activenetwork.it,Active Network Italy,ISP
 activetrail.biz,ActiveTrail,Marketing
 acu.edu,Abilene Christian University,Education
 acuperfectwebsites.com,AcuPerfect Websites,Web Host
+acxiom.com,Acxiom,Marketing
 ada.net.tr,AdaNET,ISP
 adabank.com.tr,Dünya Katılım,Finance
 adairit.com,Adair IT,MSP
@@ -172,16 +186,21 @@ adaptiv-networks.com,Adaptiv Networks,SaaS
 adc.net.ar,Aguas del Colorado,Utilities
 adcstack.com,ADC Group,Web Host
 additionnetworks.net,CherryRoad Technologies,MSP
+addsecure.se,AddSecure,SaaS
 adelaide.edu.au,University of Adelaide,Education
+adept.co.za,Adept ICT,ISP
 adient.com,Adient,Manufacturing
 adista.fr,Adista,ISP
+adman.com,Adman,Web Host
 admin.ch,Swiss Federal Government,Government
 admintek.net,Admintek,Web Host
 admintekcr.net,Admintek,Web Host
+adminvps.ru,AdminVPS,Web Host
 admiral.ne.jp,ASJ,ISP
 adnhosting.ca,ADN Communications,Web Host
 adnoc-development.com,ADNOC,Industrial
 adnsl.com,ADN Telecom,ISP
+adntel.com.bd,ADN Telecom Bangladesh,ISP
 adobe.com,Adobe,Technology
 adp.com,ADP,Finance
 adrz.nl,Adrz,Healthcare
@@ -192,6 +211,7 @@ advancedhosting.com,Advanced Hosting,Web Host
 advania.com,Advania,MSP
 advania.fi,Advania Finland,MSP
 advania.is,Advania Iceland,MSP
+advania.no,Advania Norway,MSP
 adventconstructions.co.tz,Advent Construction Limited,Industrial
 adventhealth.com,AdventHealth,Healthcare
 adyl.com.br,Adyl Telecom,ISP
@@ -204,6 +224,7 @@ aero.org,The Aerospace Corporation,Defense
 aeroinc.net,The Areo Group,Industrial
 aeronetpr.com,AeroNet Wireless Puerto Rico,ISP
 aesbg.net,AESNET,ISP
+aetna.com,Aetna,Healthcare
 aevengroup.com,Aeven,MSP
 aeza.net,Aeza,Web Host
 aeza.network,Aeza,Web Host
@@ -218,14 +239,18 @@ afnet.net,AFNET,ISP
 afp.com,Agence France-Presse,News
 afr-ix.com,AFR-IX Telecom,ISP
 afranet.com,Afranet,ISP
+afrarasa.com,Afra Rasa,ISP
 africaoncloud.net,Africa on Cloud,IaaS
+africaonline.na,Africa Online Namibia,ISP
 afrihost.com,Afrihost,ISP
 afriminesa.com,Afrimine Southern Africa,Industrial
 afternorth.com,After North,Technology
+agarik.com,Agarik,Web Host
 agatep.ca,Agatep Media,Marketing
 agatepmedia.net,Agatep Media,Marketing
 agencia-atlas.com,Groupo Atlas,Logistics
 agfa.com,Agfa HealthCare,Healthcare
+agilisnet.com,Agilis Networks Sudbury,ISP
 agnat.pl,Domena.pl,Web Host
 agni.com,Agni Systems Bangladesh,ISP
 agoda.com,Agoda,Travel
@@ -237,21 +262,27 @@ ahi.ca,Alexandra Hospital,Healthcare
 ahn.org,Allegheny Health Network,Healthcare
 ahold.com,Ahold,Retail
 aholddelhaize.com,Ahold Delhaize,Retail
+ahosting.net,Ahosting,Web Host
 ahrt.hu,4iG Telecommunications,ISP
 aichi-colony.jp,Aichi Developmental Disability Center,Healthcare
 aigmedical.com,Affiliates in Gastroenterology,Healthcare
+aiinformatics.com,ai informatics,MSP
 aila.org,American Immigration Lawyers Association,Nonprofit
+aims.com.my,AIMS Data Centre Malaysia,Web Host
 ainet.at,Ainet,ISP
 air-cargo.kiev.ua,Air-Cargo,Logistics
 airadvantage.net,Air Advantage,ISP
 airbus.com,Airbus,Defense
 aircleaningspecialists.com,"Air Cleaning Specialists, Inc.",Industrial
 aircomusa.com,FaxPipe (Formerly AirCom USA),SaaS
+airdata.ag,AIRDATA,ISP
 airenetworks.es,AIRE Networks,ISP
 airespring.com,AireSpring,MSP
 airetech.es,AIRE Networks,ISP
 airgas.com,Airgas,Industrial
 airlinkrb.com,Air Link Rural Broadband,ISP
+airnet.jp,Air Internet Service,ISP
+airnetnetworks.com,Airnet Networks,ISP
 airnewzealand.com,Air New Zealand,Travel
 airport.kr,Incheon International Airport,Travel
 airstreamcomm.net,Airstream Communications,ISP
@@ -270,7 +301,9 @@ airtelkenya.com,Airtel,ISP
 airulimited.com,Airu,Web Host
 ais.co.th,AIS,ISP
 ais.th,AIS,ISP
+aisicloud.net,HK AISI Cloud Computing,Web Host
 aist.go.jp,National Institute of Advanced Industrial Science and Technology,Government
+ait.ac.th,Asian Institute of Technology,Education
 ait.com,AIT,Web Host
 aitcom.net,AIT,Web Host
 aiwacorp.co.jp,Aiwa,Industrial
@@ -310,10 +343,13 @@ alcansservicos.com.br,Alcans Telecom,ISP
 alcanstelecom.com.br,Alcans Telecom,ISP
 alcom.ax,Alcom Aland,ISP
 alconn.it,Alconn,ISP
+alea.gov,Alabama Law Enforcement Agency,Government
 alembic.co.in,Alembic Pharmaceuticals,Healthcare
 alestra.com.mx,Alestra,ISP
 alestra.net.mx,Alestra,ISP
 alexhost.com,AlexHost,Web Host
+alfa.com.ni,ALFANUMERIC Nicaragua,ISP
+alfanet.az,Alfanet Azerbaijan,ISP
 alfatelecom.cz,Alfa Telecom,ISP
 alfenas.mg.gov.br,Prefeitura Municipal de Alfenas,Government
 alfred.edu,Alfred University,Education
@@ -337,6 +373,7 @@ allete.com,ALLETE,Utilities
 alliancebroadband.co.in,Alliance Broadband,ISP
 alliancebroadband.in,Alliance Broadband,ISP
 alliancecom.net,Alliance Communications,ISP
+allianz.com,Allianz,Finance
 allianzsna.com,SNA Insurance,Finance
 alliedtelecom.net,Allied Telecom,ISP
 alligacom.com,TrueCommerce,SaaS
@@ -360,12 +397,14 @@ alpha-mail.net,Otsuka Corporation,MSP
 alpha-prm.jp,Otsuka Corporation,MSP
 alphacron.de,AlphaCron Datensysteme,Web Host
 alphalink.fr,Alphalink,ISP
+alsatis.com,Alsatis,ISP
 alsatwireless.com,Air Link Rural Broadband,ISP
 alsk.com,Alaska Communications,ISP
 altafiber.com,altafiber,ISP
 altafibra.mx,Altafibra,ISP
 altarede.com.br,AltaRede,ISP
 altayer.om,Al-Tayer Engineering Services,Construction
+altecom.net,FIBRACAT Telecom,ISP
 altegrosky.ru,AltegroSky,ISP
 altel.kz,Atal,ISP
 altemica.net,Altemica,MSP
@@ -377,6 +416,7 @@ altimatel.com,Altima Telecom,ISP
 altmanadvisors.com,Altman Advisors,Finance
 altnet.md,Altnet,ISP
 altovalenet.com.br,Alto Vale Net,ISP
+alvsbyn.se,Alvsbyn Kommun,Government
 alwaysdata.com,alwaysdata,Web Host
 alwaysdata.net,alwaysdata,Web Host
 amadeus-it.com,Amadeus IT Group,SaaS
@@ -392,6 +432,7 @@ amberit.com.bd,Amber IT,ISP
 amberit.net,Amber IT,ISP
 ambisys.net,Ambisys,Healthcare
 ambit.com.tw,Ambit Microsystem,Manufacturing
+amd.com,AMD,Manufacturing
 amdintl.com.tw,Kangjian Biomedical Technology,Healthcare
 america-net.com.br,America-NET,ISP
 america.net,America.net,Web Host
@@ -406,7 +447,10 @@ amerinoc.com,AmeriNOC,Web Host
 ameslab.gov,Ames Laboratory,Government
 amethyst.co.jp,Amethyst,Healthcare
 amfam.com,American Family Insurance,Finance
+amherst.edu,Amherst College,Education
+amherstcomm.net,Amherst Communications,ISP
 amis.hr,A1 Croatia (Amis),ISP
+amnet.com.ni,Amnet Telecomunicaciones,ISP
 amobia.com,Amobia,ISP
 ampernet.com.br,Ampernet,ISP
 amplia.co.tt,AMPLIA,ISP
@@ -422,6 +466,7 @@ andritz.com,Andritz,Manufacturing
 anet.net.th,ANET,ISP
 anexia-it.com,Anexia,Web Host
 anexia.com,Anexia,Web Host
+angelo.edu,Angelo State University,Education
 angolatelecom.com,Angola Telecom,ISP
 anid.com.br,ANID,Nonprofit
 ankara.edu.tr,Ankara University,Education
@@ -443,11 +488,13 @@ antispamcloud.com,N-able,Email Security
 antispameurope.com,Hornetsecurity,Email Security
 anydigital.sg,AnyDigital,Web Host
 anylogic.com,AnyLogic,SaaS
+anz.com,ANZ Banking Group,Finance
 aoc.gov,Architect of the Capitol,Government
 aofidc.com,Aofei Data International,Web Host
 aoiot.ru,IOT (Skolkovo),IaaS
 aopa.org,AOPA,Travel
 aoyama.ac.jp,Aoyama Gakuin University,Education
+ap.org,Associated Press,News
 apa-it.at,APA-Tech,MSP
 apa.at,APA-Tech,MSP
 apaudit.eu,Transparent,Finance
@@ -472,6 +519,7 @@ apps-1and1.net,IONOS,Web Host
 appsfruit.com,AppsFruit,Marketing
 appspot.com,Google,PaaS
 aps-inc.co.jp,Arahi Polyslider,Industrial
+apsfl.in,APSFL Andhra Pradesh State FiberNet,ISP
 aptalaska.com,AP&T,ISP
 aptalaska.net,AP&T,ISP
 aptg.com.tw,APBT,ISP
@@ -483,12 +531,16 @@ aqmhost.net,AqmHost,Web Host
 aragon.es,Government of Aragon,Government
 araguaianetmt.com.br,ARAGUAIANET,ISP
 aramcoinc.com,Saudi Aramco,Industrial
+aranetplay.com.br,Aranet Play,ISP
 arapabruzzo.it,ARAP,Industrial
 arax.md,Arax-Impex,ISP
+arbital.ru,Arbital St. Petersburg,ISP
 archerirm.us,Archer GRC,SaaS
 archtopfiber.com,Archtop Fiber,ISP
 arcor-ip.net,Vodafone,ISP
+arcusnovus.com,Arcus Novus,Web Host
 ardc.net,Amateur Radio Digital Communications,Nonprofit
+ardmore.net,Ardmore Telephone (ATC),ISP
 arelion.com,Arelion,ISP
 arena.ne.jp,WebARENA,ISP
 arenatelecom.net.br,Arena Telecom,ISP
@@ -498,6 +550,7 @@ ariastelecom.com.br,Arias Telecom,ISP
 arij.org,ARIJ Institute,Nonprofit
 arikiinternet.com.br,Ariki Internet,ISP
 ariskisp.com,Arisk Communications,ISP
+arista.com,Arista Networks,Manufacturing
 aristotle.net,Aristotle Internet,ISP
 arizona.edu,University of Arizona,Education
 arkaden.se,Arkaden Konsult,MSP
@@ -506,12 +559,14 @@ arkdna.com,ARK Data Centers,Web Host
 arkitech.it,Arkitech,Technology
 arlingtonva.us,Arlington County Virginia,Government
 armstrongonewire.com,Armstrong,ISP
+arn.dz,CERIST Algeria,Government
 arnes.si,ARNES,Education
 arosscloud.com,AROSSCLOUD,Web Host
 arpinet.am,Arpinet,ISP
 arqiva.com,Arqiva,ISP
 arsat.com.ar,ARSAT,ISP
 arsys.net,Arsys,Web Host
+artcom.pl,ART-COM,ISP
 artectelecom.net,Artec Telecom,ISP
 artehosting.com.mx,Artehosting,Web Host
 artelecom.pt,AR Telecom,ISP
@@ -524,8 +579,11 @@ arvancloud.ir,Arvancloud,IaaS
 arvato-systems.de,Arvato Systems,MSP
 arvig.com,Arvig,ISP
 aryaka.com,Aryaka Networks,SaaS
+arznet.ru,KTVS Arzamas,ISP
 as1101.net,SURF,Education
 as29550.net,Simply Transit,ISP
+as34288.net,Kantonsschule Zug,Education
+as41378.net,Kirino Networks,ISP
 as42831.net,UK Dedicated Servers,Web Host
 as48500.net,Irpinia Net-Com,ISP
 as60011.net,Mythic Beasts,Web Host
@@ -542,6 +600,7 @@ ascensionhealth.org,Ascension,Healthcare
 ascenty.com,Ascenty,Web Host
 asdasd.it,ASDASD,ISP
 asem-tech.com,ASEMtech,Industrial
+asergo.com,Asergo,Web Host
 aserv.co.za,Afrihost,ISP
 asfsteelco.com,ASF Steel,Manufacturing
 ashtelstudios.com,Ashtel Studios,Healthcare
@@ -550,6 +609,7 @@ asiaitserver.com,Asia IT Solution Co.,MSP
 asianaidt.com,Asiana IDT,MSP
 asianet.co.th,Ttur Internet Corporation,ISP
 asianetbroadband.in,Asianet Broadband,ISP
+asianvision.com.ph,Asian Vision Cable Philippines,ISP
 asianvision.ph,Asian Vision,ISP
 asiatech.ir,Asiatech Data Transmission,ISP
 asiera.ie,Asiera,Education
@@ -570,14 +630,21 @@ astel.kz,Freedom Satellite (Astel),ISP
 asteria.com,Asteria,SaaS
 astound.com,Astound Broadband,ISP
 astralinfo.co.uk,Astral Informatics,Marketing
+astreaconnect.com,Astrea Communications,ISP
 asu-vei.ru,ASU-VEI,Industrial
 asu.edu,Arizona State University,Education
 asvt.ru,ASVT,ISP
 at-home.ru,еТелеком,ISP
+at.com.gh,AirtelTigo Ghana,ISP
 atb-nett.no,ATB-Nett (Telefiber),ISP
+atcbroadband.com,ATC Broadband,ISP
 atea.dk,Atea,MSP
+atea.no,Atea Norway,MSP
 ateky.net.br,Ateky Internet,ISP
+atel-rybinsk.ru,AtelRybinsk,ISP
+atel76.ru,Atel Yaroslavl,ISP
 atextelecom.com.br,ATEX Telecom,ISP
+atheer.net.sa,Atheer Net (Jeraisy),ISP
 athenet.net,NTD Networks (Athenet),ISP
 athleanx.com,ATHLEAN-X,Retail
 ati.org,ATI Advanced Technology International,Defense
@@ -588,6 +655,7 @@ atlantech.net,Atlantech Online,ISP
 atlantic.net,Atlantic.Net,Web Host
 atlanticmetro.net,365 Data Centers,Web Host
 atlas-elektronik.com,Atlas Elektronik,Defense
+atlasnet.com,Atlas Networks,ISP
 atlax.com,ATLAX,Web Host
 atlink.net,AtLink Services,ISP
 atmailcloud.com,atmail,Email Provider
@@ -599,6 +667,7 @@ atom86.net,atom86,ISP
 atomic.ac,Atomic,ISP
 atonementonline.com,Our Lady of the Atonement,Religion
 atos.net,Atos,Consulting
+atruvia.de,Atruvia,MSP
 ats.ca,ATS Healthcare,Healthcare
 att.com,AT&T,ISP
 att.net,AT&T,ISP
@@ -620,6 +689,7 @@ aup.edu.pk,"University of Agriculture, Peshawar",Education
 aura.dk,AURA Fiber,ISP
 aureon.com,Aureon,ISP
 auriga.com,Auriga,Technology
+ausgrid.com.au,Ausgrid,Utilities
 auspost.com.au,Australia Post,Logistics
 aussiebb.com.au,Aussie Broadband,ISP
 aussiebroadband.com.au,Aussie Broadband,ISP
@@ -630,6 +700,7 @@ autodesk.com,Autodesk,SaaS
 automattic.com,Automattic,SaaS
 autoplus.bg,Auto Plus Bulgaria,Automotive
 autotask.net,Kaseya,SaaS
+autozone.com,AutoZone,Retail
 avagotech.com,Broadcom,Manufacturing
 avalon.hr,cyber_Folks,Web Host
 avanta-telecom.ru,Аванта Телеком,ISP
@@ -659,6 +730,7 @@ axa.com,AXA,Finance
 axarnet.es,Axarnet,Web Host
 axelspringer.com,Axel Springer,Publishing
 axera.it,Axera,ISP
+axesat.com,AXESAT,ISP
 axioma24.ru,Axioma,ISP
 axione.fr,Axione,ISP
 axsbolivia.com,AXS Bolivia,ISP
@@ -677,6 +749,7 @@ azertelecom.az,AzerTelecom,ISP
 azintelecom.az,AzInTelecom,ISP
 azmoves.com,Coldwell Banker,Real Estate
 azregents.edu,Arizona Board of Regents,Education
+azstarnet.az,Azstarnet (Metronet),ISP
 azteca-comunicaciones.com,Aztec Communications Columbia,ISP
 aztecacomunicaciones.com,Aztec Communications Columbia,ISP
 aztelekom.az,Aztelekom,ISP
@@ -685,33 +758,44 @@ azureedge.net,Microsoft Azure,Technology
 azurestaticapps.net,Microsoft Azure,PaaS
 azurewebsites.net,Microsoft Azure,PaaS
 azza.net.br,Azza,ISP
+b2b2c.ca,B2B2C,ISP
 b4rn.org.uk,B4RN,ISP
 babilon-t.com,Babilon-T,ISP
 babson.edu,Babson College,Education
 backland.net,Backland Communications,MSP
+badrrayan.com,Badr Rayan Jonoob,ISP
 baesystems.com,BAE Systems,Defense
+bage.dev,BAGE CLOUD,Web Host
 bahnhof.se,Bahnhof,ISP
 baidu.com,Baidu,Search Engine
 balifiber.id,BaliFiber,ISP
 ball.com,Ball Corporation,Manufacturing
+balsamwest.net,BalsamWest FiberNET,ISP
 balt.net,Baltneta,ISP
 baltcom.lv,Bite,ISP
 balticom.lv,Balticom,ISP
 balticum.lt,Balticum TV,ISP
+bambroadband.com,BAM Broadband,ISP
 banchero.org,Bancharo Disability Services,Healthcare
 bancogalicia.com,Banco Galicia,Finance
 bandwidth.co.uk,Bandwidth Technologies,ISP
 bangla.net,ISN Bangla,ISP
+bangmod.cloud,Bangmod Cloud,Web Host
 bank-banque-canada.ca,Bank of Canada,Government
 bankofamerica.com,Bank of America,Finance
 banxico.org.mx,Banco de Mexico,Government
 barak-online.net,Netvision,ISP
 barclays.co.uk,Barclays,Finance
+barclayscapital.com,Barclays Investment Bank,Finance
+bardstowncable.net,City of Bardstown Cable,ISP
 baremetal.co.za,Baremetal,ISP
 barings.com,Barings,Finance
 barracuda.com,Barracuda,Email Security
+bart.gov,BART Bay Area Rapid Transit,Government
 barvanet.kz,Barvanet,MSP
+bas.bg,Bulgarian Academy of Sciences,Science
 basefarm.com,Orange Business (Basefarm),IaaS
+baseip.com,Base IP,ISP
 basf.com,BASF,Industrial
 bashtel.ru,Bashtel,ISP
 basicserver.io,Zitcom,Web Host
@@ -721,6 +805,7 @@ batelco.com,Batelco,ISP
 bates.edu,Bates College,Education
 battelle.org,Battelle Memorial Institute,Science
 bausch.com,Bausch and Lomb,Healthcare
+baxet.ru,Baxet Holding,Web Host
 baxetgroup.com,Baxet Group,Web Host
 bayada.com,BAYADA Home Health Care,Healthcare
 baycix.de,BayCIX,Web Host
@@ -730,6 +815,7 @@ baykonur.ru,Baykonur Svyazinform,ISP
 baylor.edu,Baylor University,Education
 baynet.ne.jp,Tokyo Bay Network,ISP
 bayobab.africa,Bayobab (MTN GlobalConnect),ISP
+bayonette.no,Bayonette (Nexthop),Web Host
 bayoulandcs.com,Bayouland Computer Solutions,MSP
 bb-niigata.jp,Niigata Communication Service,ISP
 bb.com.br,Banco do Brasil,Finance
@@ -741,6 +827,7 @@ bbned.nl,Odido,ISP
 bbnetup.com,BBNET UP,ISP
 bbnetup.com.br,BBNET UP,ISP
 bbraun.de,B. Braun Melsungen,Healthcare
+bbt.com.ar,BroadBandTech,ISP
 bbtel.com,BBTEL,ISP
 bbtower.co.jp,BroadBand Tower,Web Host
 bc.edu,Boston College,Education
@@ -765,6 +852,7 @@ beanfield.com,Beanfield,ISP
 bearingdepot.com,Bearing Depot & Supply,Retail
 beaumont.org,Corewell Health (Formerly Beaumont),Healthcare
 bec.uk,BE Computing,IaaS
+beccommunications.com,BEC Communications,ISP
 becfiber.com,BEC Fiber,ISP
 beckman.com,Beckman Coulter,Healthcare
 bedag.ch,Bedag Informatik,MSP
@@ -772,6 +860,7 @@ bedbathandbeyond.com,Bed Bath & Beyond,Retail
 bedge.com,BEDGE,Web Host
 bee.net.tn,Bee (Smart Solutions Tunisia),ISP
 beecreek.net,Bee Creek Communications,ISP
+beehive.net,Beehive Broadband,ISP
 beeline.kz,Beeline,ISP
 beeline.ru,Beeline,ISP
 beeline.uz,Beeline,ISP
@@ -786,19 +875,24 @@ belairinternet.com,Zentro Internet,ISP
 belcloud.net,Belcloud,Web Host
 bell.ca,Bell Canada,ISP
 bell.net,Bell Canada,ISP
+bell.net.mt,Bellnet Malta,ISP
 belnet.be,BELNET,Education
 belong.com.au,Belong (Telstra),ISP
 beltelecom.by,Beltelecom,ISP
+belwave.com,BelWave Communications,ISP
 belwue.de,BelWü,Education
+bendigotelco.com.au,Bendigo Telco,ISP
 benintelecoms.bj,SBIN Benin,ISP
 benkan.co.jp,Benkan,Industrial
 benlomandconnect.com,Ben Lomand Rural Telephone Cooperative,ISP
 beotel.net,BeotelNet,ISP
+bepc.com,Basin Electric Power Cooperative,Utilities
 berea.edu,Berea College,Education
 berkeley.edu,UC Berkley,Education
 bernco.gov,Bernalillo County,Government
 berneyassocies.com,Berney Associés,Consulting
 bernofarm.com,Bernofarm,Healthcare
+beskidmedia.pl,Beskid Media,ISP
 best.net.ua,Best ISP,ISP
 bestbuy.com,Best Buy,Retail
 bestel.com.mx,Bestel,ISP
@@ -848,11 +942,14 @@ bit-drive.ne.jp,NURO Biz,ISP
 bit.nl,BIT BV,Web Host
 bitco.co.za,BitCo,ISP
 bitcom.com.br,Bitcom Internet Fibra,ISP
+bitcom.se,Bitcom Goteborg,ISP
+bitcommand.com,BitCommand,Web Host
 bite.lt,Bite,ISP
 bite.lv,Bite,ISP
 bitel.com.pe,Bitel,ISP
 bitel.de,BITel Bielefeld,ISP
 biterika.ru,Biterika,Web Host
+bitfluxng.com,Bitflux Communications,ISP
 bitiora.com,Bitiora,ISP
 bitmail.com.br,Bitmail Telcom,ISP
 biznetgio.com,Biznet Gio,IaaS
@@ -883,10 +980,12 @@ bloomberg.com,Bloomberg,Finance
 blowtech.com.tw,Blowplas Technology,Manufacturing
 bls.gov,U.S. Bureau of Labor Statistics,Government
 bluebirdnetwork.com,Bluebird Fiber,ISP
+bluebridgenetworks.com,Blue Bridge Networks,Web Host
 bluegrassnetwork.com,Bluegrass Network,ISP
 bluehost.com,Bluehost,Web Host
 blueline.mg,Gulfsat (Blueline) Madagascar,ISP
 bluemission.net,Blue Mission,Web Host
+bluemountainnet.com,Blue Mountain Networks (Gorge),ISP
 bluesea.org,Blue Sea Foundation,Marketing
 bluestreamfiber.com,Blue Stream Fiber,ISP
 bluetie.com,BlueTie,MSP
@@ -897,10 +996,13 @@ blufibre.ca,BLU Fibre Networks,ISP
 bme.hu,Budapest University of Technology and Economics,Education
 bmhcc.org,Baptist Memorial Health Care,Healthcare
 bmjnet.com.br,BMJ Net,ISP
+bmw.com,BMW,Automotive
+bn-t.de,bn:t Blatzheim Networks Telecom,ISP
 bn.by,Business Network Belarus,ISP
 bnehost.com.au,Bnehosting,Web Host
 bnet-bd.com,Business Network,ISP
 bnet.com.br,Bnet Telecom,ISP
+bnet.ps,Bnet Palestine,ISP
 bnl.gov,Brookhaven National Laboratory,Government
 bnpparibas.com,BNP Paribas,Finance
 bnpparibas.fr,Banque BNP Paribas,Finance
@@ -911,10 +1013,12 @@ boavistanet.net.br,Boa Vista Net,ISP
 boeing.com,Boeing,Defense
 bof.fi,Bank of Finland,Government
 bofinet.co.bw,Botswana Fibre Networks,ISP
+bogons.net,Bogons,ISP
 bohc.co.jp,Benefit One Inc.,Retail
 boisestate.edu,Boise State University,Education
 boku.ac.at,University of Natural Resources and Life Sciences Vienna,Education
 bol-online.com,Bangladesh Online,ISP
+bol-online.net,Bangladesh Online (BOL),ISP
 bol.net.in,MTNL,ISP
 boldyn.com,Boldyn,ISP
 bolignet-aarhus.dk,Bolignet-Aarhus,ISP
@@ -928,6 +1032,7 @@ bookmyname.com,BookMyName,Web Host
 boostmobile.com,Boost Mobile,ISP
 boozallen.com,Booz Allen Hamilton,Consulting
 bosch.com,Bosch,Manufacturing
+bosnet.se,Bosnet Skaraborg,ISP
 boston.gov,City of Boston,Government
 bostrad.com,Bostrad Supply Chain Ltd,Logistics
 bounceme.net,No-IP,Web Host
@@ -935,6 +1040,7 @@ bouyguestelecom.fr,Bouygues Telecom,ISP
 bov.com,Bank of Valletta,Finance
 bowdoin.edu,Bowdoin College,Education
 box.ca,Whatbox,Web Host
+boxbroadband.co.uk,Community Fibre (Box Broadband),ISP
 bplaced.com,bplaced,Web Host
 bplaced.de,bplaced,Web Host
 bplaced.net,bplaced,Web Host
@@ -942,6 +1048,7 @@ bpweb.net,BPWEB,Web Host
 br.digital,BR Digital Telecom,ISP
 braathe.net,iteam Braathe,MSP
 bracnet.net,BRACNet Limited,ISP
+bradley.edu,Bradley University,Education
 brandeis.edu,Brandeis University,Education
 brandenburgtel.com,Brandenburg Telephone,ISP
 branet.com.br,Branet,MSP
@@ -961,11 +1068,13 @@ breezelineohio.net,Breezeline,ISP
 bren.bg,BREN Bulgarian Research and Education Network,Education
 brennanit.com.au,Brennan IT,MSP
 brennercom.it,Brennercom,ISP
+brescobroadband.com,Bresco Broadband,ISP
 brevo.com,Brevo (Sendinblue),Marketing
 bridgewater.edu,Bridgewater College,Education
 bright.net,CNI,ISP
 brightok.net,BrightNet Oklahoma,ISP
 brightridge.com,BrightRidge,Utilities
+brightsolid.com,Brightsolid,Web Host
 brightspace.com,D2l Brightspace,SaaS
 brightspeed.com,Brightspeed,ISP
 brightstar.uk,Brightstar,ISP
@@ -982,6 +1091,7 @@ broadbandidc.com,BROADBANDIDC,Web Host
 broadbandsolutions.com.au,Broadband Solutions Australia,ISP
 broadbandvision.net,Broadband Vision,ISP
 broadcom.com,Broadcom Enterprise Messaging Security,Email Security
+broadinstitute.org,Broad Institute,Science
 broadridge.com,Broadridge,Finance
 brockport.edu,SUNY Brockport,Education
 brocku.ca,Brock University,Education
@@ -989,19 +1099,24 @@ brown.edu,Brown University,Education
 brownrice.com,Brownrice Internet,Web Host
 brsk.co.uk,Brsk,ISP
 brucepower.com,Bruce Power,Utilities
+brucetelecom.com,Bruce Telecom,ISP
+bryant.edu,Bryant University,Education
 brynmawr.edu,Bryn Mawr College,Education
 bs-telecom.net,БС-Телеком (BS-Telecom),ISP
+bs.ch,Canton of Basel-Stadt,Government
 bsc.rw,Broadband Systems Corporation,ISP
 bsconect.com.br,BS Conect,ISP
 bsd.nl,BSD Software Development,Technology
 bsd405.org,Bellevue School District,Education
 bsdnetwork.com.br,MHNET Telecom,ISP
 bse.ch,SolNet,ISP
+bsh.ru,Business Sviaz Holding,MSP
 bsnews.com.br,BS News,ISP
 bsnl.co.in,BSNL,ISP
 bsnl.in,BSNL,ISP
 bsp.com.bn,Brunei Shell Petroleum,Industrial
 bsu.edu,Ball State University,Education
+bt-blue.com,Bretagne Telecom,Web Host
 bt.bt,Bhutan Telecom,ISP
 bt.com,BT,ISP
 bta.net.cn,China Networks Inter-Exchange,ISP
@@ -1017,6 +1132,7 @@ btussel.com,Bug Tussel,ISP
 btvm.ne.jp,BTV,ISP
 bu.edu,Boston University,Education
 buap.mx,Universidad Autonoma de Puebla,Education
+buchholz-digital.de,Buchholz Digital,ISP
 buckeye.com,Buckeye Partners,Utilities
 buckeyebroadband.com,Buckeye Broadband,ISP
 buckeyebusiness.net,Buckeye Business Solutions,MSP
@@ -1026,6 +1142,7 @@ buffalo.edu,University at Buffalo,Education
 buffalostate.edu,Buffalo State College,Education
 bugtusselwireless.com,Bug Tussel,ISP
 buildingmaterials.com.my,Building Materials,Construction
+buk.edu.ng,Bayero University,Education
 bulloch.net,Bulloch County RTC,ISP
 bulsat.com,Bulsatcom,ISP
 bumblebeelinens.com,Bumbletree Linens,Retail
@@ -1051,6 +1168,7 @@ bytes.co.za,Altron Bytes,MSP
 byu.edu,BYU,Education
 byui.edu,Brigham Young University Idaho,Education
 c-able.co.jp,Yamaguchi Cable Vision,ISP
+c-light.net,SC-REN (C-Light),Education
 c3.net.pl,C3 NET,ISP
 c3po3090.com.br,Núcleo Brasil Servidores,Web Host
 ca.gov,State of California,Government
@@ -1063,11 +1181,14 @@ cablecomm.ie,CableComm,ISP
 cablelink.at,Salzburg AG,Utilities
 cablelynx.com,Cablelynx,ISP
 cablenet.com.cy,Cablenet,ISP
+cablenett.net,Cablenett,ISP
 cableonda.com,Cable Onda,ISP
 cableonda.net,Cable Onda,ISP
+cableondaoriental.com,Cable Onda Oriental Dominican,ISP
 cableone.biz,Sparklight,ISP
 cables.com.tw,Yueh Feng Industrial,Manufacturing
 cabletel.com.mk,A1,ISP
+cablevideodigitalbionik.com.ar,Cablevideo Digital,ISP
 cablevision.at,Cablevision Nöhmer,ISP
 cablevision.com,Cablevision,ISP
 cablevision.net.mx,Izzi Telecom,ISP
@@ -1075,6 +1196,7 @@ cableworld.es,Cableworld,ISP
 cabonnet.com.br,Cabonnet,ISP
 cabotelecom.com.br,Alares,ISP
 cabq.gov,City of Albuquerque,Government
+cachefly.com,CacheFly,SaaS
 cairohost.com,Black Host,Web Host
 caiway.nl,Caiway,ISP
 caiweb.net.br,Caiweb,ISP
@@ -1111,6 +1233,7 @@ capetown.gov.za,City of Cape Town,Government
 capgemini.com,Capgemini,Consulting
 capinfo.com.cn,CAPNET,Government
 capita-cs.co.uk,Capita Business Services,MSP
+captel.ru,Capital Telecom,ISP
 carandainet.com.br,CN Internet,ISP
 cardhealth.com,Cardinal Health,Healthcare
 cardinal-health.com,Cardinal Health,Healthcare
@@ -1119,11 +1242,14 @@ cardinalhealth.com,Cardinal Health,Healthcare
 cardinalscriptnet.com,Cardinal Health,Healthcare
 carecentrix.com,CareCentrix,Healthcare
 cargill.com,Cargill,Agriculture
+caribserve.net,Caribserve (New Technologies Group),ISP
 carleton.ca,Carleton University,Education
 carleton.edu,Carlton College,Education
 carnet.hr,CARNET,Education
 carnivalcorp.com,Carnival Corporation,Travel
+carolinadigitalphone.com,Carolina Digital Phone,ISP
 carrd.co,Carrd,SaaS
+carrier-colo.com,IPB Carrier-Colo Berlin,Web Host
 carrierzone.com,carrierzone,Email Security
 carrytel.ca,Carrytel,ISP
 carsforkids.org,Cars For Kids,Nonprofit
@@ -1132,14 +1258,18 @@ casablanca.cz,Casablanca INT,Web Host
 case.edu,Case Western Reserve University,Education
 casscomm.com,CassComm,ISP
 castrum.com.br,Castrum Internet,ISP
+cat-v.jp,Sendai CATV,ISP
 cat.com,Caterpillar,Industrial
 cat.net.th,National Telecom (Thailand),ISP
 catawba.edu,Catawba College,Education
+catixs.com,Catixs,ISP
 catnet.jp,Honjo Cable,ISP
 catonetworks.com,Cato Networks,SaaS
+catv-ads.jp,advanscope,ISP
 catv296.co.jp,296 Broad Net,ISP
 catvmics.ne.jp,Mics Network,ISP
 cau.ac.kr,Chung-Ang University,Education
+cbccom.net,Beijing Tian Wei Xin Tong,ISP
 cbe.ae,CBE,Construction
 cbn.id,CBN Fiber,ISP
 cbsimaging.com,CBS Imaging,Retail
@@ -1147,6 +1277,7 @@ cbssports.com,CBS Sports,Entertainment
 cbtel.net.ar,CBTEL,ISP
 cbu.ca,Cape Breton University,Education
 cbwchc.org,Charles B. Wang Community Health,Healthcare
+cbxnet.de,CBXNET,ISP
 cc9.jp,Cable TV Tochigi (CC9),ISP
 ccac.edu,Community College of Allegheny County,Education
 ccapcable.com,CCAP Cable,ISP
@@ -1154,15 +1285,18 @@ ccc-group.com,Canada Colors and Chemicals Limited (CCC),Industrial
 ccc.co.il,Triple C Cloud Computing,Web Host
 cccd.edu,Coast Community College District,Education
 cccoe.k12.ca.us,Contra Costa County Office of Education,Education
+cccomm.net,CC Communications Nevada,ISP
 cccs.edu,Colorado Community Colleges System,Education
 ccinternet.cz,CC Internet,ISP
 ccr.net,CCR Solutions,MSP
 ccs.co.kr,CCS,ISP
 ccsd.net,Clark County School District,Education
 ccsleeds.co.uk,CCS Leeds,ISP
+ccsnet.ne.jp,City Cable Shunan,ISP
 cctv.com,China Central Television,News
 cdbhospital.com,CBD Hospital,Healthcare
 cdc.gov,US Centers for Disease Control and Prevention,Government
+cdc.ua,CDC SDS-Vostok,ISP
 cdkglobal.com,CDK Global,SaaS
 cdlan.it,CDLAN,Web Host
 cdm.com,CDM Smith,Consulting
@@ -1174,6 +1308,7 @@ cdt.ca,CDT Connexion,MSP
 cdt.cz,CD-Telematika,MSP
 cdu.edu.au,Charles Darwin University,Education
 cdw.com,CDW,MSP
+ce-tel.com,CETel (AXESS Networks),ISP
 cea.fr,CEA,Government
 cec-ltd.co.jp,Computer Engineering & Consulting,MSP
 cedia.edu.ec,CEDIA Ecuador R&E Network,Education
@@ -1190,6 +1325,7 @@ cellkabel.hu,Celldomolki Kabeltelevizio,ISP
 cello.co.nz,Cello Group,ISP
 celsiainternet.com,Celsia Internet,ISP
 cenet.catholic.edu.au,CEnet Catholic Education Network,Education
+cengagebrain.com,Cengage Learning,Education
 cenic.org,CENIC,Nonprofit
 cenitex.vic.gov.au,Cenitex,Government
 centene.com,Centene,Healthcare
@@ -1206,6 +1342,7 @@ centralnetx.com.br,Centralnet,ISP
 centralofertao.com.br,Central Ofertão,Retail
 centralserver.com,Central Server,IaaS
 centralserver.com.br,Central Server,IaaS
+centraluniversity.org,Central University College,Education
 centrilogic.com,Centrilogic,MSP
 centrin.net.id,Centrin Utama,ISP
 centurylink.com,CenturyLink,ISP
@@ -1244,6 +1381,7 @@ chaiyohosting.com,Chaiy oHosting,Web Host
 chalmers.se,Chalmers University of Technology,Education
 changethatup.com,Change That Up,Healthcare
 charlottecolo.com,Charlotte Colocation,Web Host
+charlottenc.gov,City of Charlotte,Government
 charter.com,Charter,ISP
 charter.net,Charter,ISP
 chartercom.com,Charter,ISP
@@ -1254,10 +1392,12 @@ chcmed.com,Family Medicine Orlando,Healthcare
 cheapairportparking.org,Cheap Airport Parking,Travel
 checkpoint.com,Check Point Software,Email Security
 cheetahmail.com,Marigold,SaaS
+cheiljedang.co.kr,CJ CheilJedang,Food
 chello.sk,UPC,ISP
 cherryservers.com,Cherry Servers,Web Host
 chesco.net,Chesconet,Education
 chess.no,Telia Norge,ISP
+chessict.com,Chess ICT,ISP
 chevron.com,Chevron,Industrial
 chiba-u.jp,Chiba University,Education
 chicago.gov,City of Chicago,Government
@@ -1275,6 +1415,7 @@ chinatietong.com,China TieTong,ISP
 chinaunicom.cn,China Unicom,ISP
 chinaunicomglobal.com,China Unicom Global,ISP
 chinaxingye.com,Suzhou Sinye Materials Technology,Industrial
+chinguitel.mr,Chinguitel,ISP
 chl.com,CHL,ISP
 chop.edu,Children's Hospital of Philadelphia,Healthcare
 chosun.ac.kr,Chosun University,Education
@@ -1305,6 +1446,8 @@ cinia.fi,Cinia,ISP
 cinternetbycat.com,National Telecom,ISP
 cinvestav.mx,Cinvestav,Education
 cipherwave.co.za,Cipherwave,ISP
+cirbn.org,CIRBN Central Illinois Regional Broadband Network,ISP
+circana.com,Circana,SaaS
 circit.de,CircIT,MSP
 circleamedical.com,Circle A Medical,Healthcare
 cirrushosting.com,Cirrus Hosting,Web Host
@@ -1312,10 +1455,15 @@ cisco.com,Cisco,Technology
 cisp.com,CISP Community ISP,ISP
 citadel.edu,The Citadel,Education
 citec.com.au,CITEC (Queensland Government),Government
+citechco.net,Grameen CyberNet,ISP
+citenet.net,Citenet Telecom,ISP
 citic.com,CITIC,Conglomerate
 citictel-cpc.com,CITIC Telecom CPC,ISP
 citigroup.com,Citi (Citigroup),Finance
+citizens.coop,Citizens Telephone Cooperative,ISP
 citizensmemorial.com,Citizens Memorial Hospital,Healthcare
+citra.net.id,Jembatan Citra Nusantara,ISP
+city-link.info,CityLink,ISP
 citycable.ch,Lausanne SiL Multimedia,ISP
 citycom-austria.com,Citycom Austria,ISP
 cityemail.com,CityEmail,Email Provider
@@ -1325,6 +1473,7 @@ citynet.kg,Citynet KG,ISP
 citynet.net,Citynet,ISP
 cityoftacoma.org,City of Tacoma,Government
 cityonlinebd.net,City Online,ISP
+cityonlines.com,CityOnline,ISP
 cityu.edu.hk,City University of Hong Kong,Education
 citywest.ca,CityWest,ISP
 ciu.com.uy,Cámara de Industrias del Uruguay,Nonprofit
@@ -1356,6 +1505,8 @@ claytonindustries.com,Clayton Industries,Industrial
 cldin.eu,Yourhosting,Web Host
 cleannet.com.br,Clean Net Telecom,ISP
 clearaccess.co.za,Clear Access,ISP
+clearpath.net.ph,ClearPath Networks Philippines,ISP
+clearrate.com,Clear Rate Communications,ISP
 clearwave.com,Clearwave Fiber,ISP
 clearwavefiber.com,Clearwave Fiber,ISP
 clemson.edu,Clemson University,Education
@@ -1378,6 +1529,7 @@ cloud-sec-av.com,Check Point Avanan,Email Security
 cloud.ru,Cloud.ru,IaaS
 cloudaccess.net,CloudAccess.net,Web Host
 cloudapp.net,Microsoft Azure,IaaS
+cloudcix.com,Cork Internet Exchange (CloudCIX),Web Host
 cloudddos.com,CloudDDoS,Web Host
 cloudezapp.io,EmailHeads.NET,Marketing
 cloudferro.com,CloudFerro,IaaS
@@ -1407,6 +1559,7 @@ cloudwebhosting.com,NameHero,Web Host
 cloudwm.com,Kamatera (CloudWM),Web Host
 cloudzy.com,Cloudzy,Web Host
 clouvider.com,Clouvider,Web Host
+clovertv.jp,Clover TV (Nisiowari CATV),ISP
 clp.com.hk,CLP Power Hong Kong,Utilities
 clsvrsystems.net,GMO Cloud,IaaS
 clubexpress.com,ClubExpress,SaaS
@@ -1468,6 +1621,7 @@ cogeco.com,Cogeco,ISP
 cogeco.net,Cogoco,ISP
 cogentco.com,Cogent,ISP
 cognizant.com,Cognizant,Technology
+coh.org,City of Hope Medical Center,Healthcare
 coj.net,City of Jacksonville,Government
 colby.edu,Colby College,Education
 coldwellbankerhomes.com,Coldwell Banker,Real Estate
@@ -1479,6 +1633,7 @@ collectorsaddition.com,The Collector's Addition,Retail
 collinsaerospace.com,Collins Aerospace,Defense
 colo4jax.com,colo4jax,Web Host
 coloblox.com,Coloblox Data Centers,Web Host
+colocall.net,Colocall Kyiv,Web Host
 colocationamerica.com,Colocation America,Web Host
 colocrossing.com,ColoCrossing,ISP
 cologix.com,Cologix,IaaS
@@ -1486,6 +1641,7 @@ cologlobal.com,Cologlobal,Web Host
 colorado.edu,University of Colorado Boulder,Education
 colorkrew.com.br,Colorkrew,SaaS
 colos.kz,IFC COLOS,Logistics
+colosseum.com,Colosseum Online,IaaS
 colostate.edu,Colorado State University,Education
 colsecor.com.ar,Colsecor,ISP
 colt.net,Colt,ISP
@@ -1501,14 +1657,17 @@ comcast.com,Comcast,ISP
 comcast.net,Comcast,ISP
 comcastbusiness.net,Comcast Business,ISP
 comcel.com.co,Claro Colombia,ISP
+comclark.com,ComClark,ISP
 comcor.ru,AKADO Telecom,ISP
 comentum.com,Comentum,Technology
+comeser.it,Comeser,ISP
 comfori.com,Comfori,SaaS
 comfortel.pro,Comfortel,ISP
 comline.com,West Coast Internet (WCI),ISP
 commbank.com.au,Commonwealth Bank of Australia,Finance
 commerce.gov,US Department of Commerce,Government
 commerzbank.com,Commerzbank,Finance
+commnetbroadband.com,Commnet Broadband,ISP
 commnetwireless.com,Commnet Wireless,ISP
 commonwealthu.edu,Commonwealth University of Pennsylvania,Education
 comms365.com,Comms365,ISP
@@ -1533,10 +1692,13 @@ computerdoctor-usa.com,The Computer Doctor,MSP
 computerguyz.ca,Computer Guyz,MSP
 computerstlouis.com,Computer St. Louis,MSP
 computronics.com,Computronics,Technology
+comsats.net.pk,COMSATS Internet Services,ISP
+comsol.co.za,Comsol Networks,ISP
 comteco.com.bo,Comteco,ISP
 comtrance.net,comtrance,Web Host
 comune.livorno.it,Città di Livorno,Government
 comunitel.net,Vodafone,ISP
+comvive.es,Comvive,Web Host
 comwave.net,Comwave (Rogers),ISP
 concentrix.com,Concentrix,MSP
 concordia.ca,Concordia University,Education
@@ -1561,10 +1723,12 @@ conexonconnect.com,Conexon Connect,ISP
 conncoll.edu,Connecticut College,Education
 connect.net.pk,Connect Communications Pakistan,ISP
 connect10.com.br,Connect 10,ISP
+connecta.net,connecta ag,ISP
 connectalagoas.com.br,Connect Alagoas,ISP
 connectctc.com,Consolidated Telephone (CTC),ISP
 connectit.com.au,Connect I.T.,MSP
 connectmax.com.br,Algar Mogi (ConnectMax),ISP
+connectria.com,Connectria,Web Host
 connectrio.com.br,Connect Rio,ISP
 connectsul.com.br,Connectsul,ISP
 connectwave.co.kr,ConnectWave,SaaS
@@ -1572,6 +1736,7 @@ connectworld.psi.br,Connect World Telecom,ISP
 connectzone.in,Connect Broadband,ISP
 connesi.it,Connesi,ISP
 connextelecom.com.br,Connex Fibra,ISP
+conocophillips.com,ConocoPhillips,Industrial
 conoha.ne.jp,ConoHa,Web Host
 consideredcreative.com,Considered Creative,Marketing
 consilio.com,Consilio,Legal
@@ -1579,6 +1744,7 @@ consol.com,Consolidated Edison (ConEd),Utilities
 consolidated.com,Consolidated Communications,ISP
 consolidatedlabel.com,Consolidated Label,Print
 consolidatednd.com,Consolidated Telcom,ISP
+consolidatedsmart.com,Smartaira (Consolidated Smart Systems),ISP
 constant.com,Vultr,Web Host
 constantcontact.com,Constant Contact,Marketing
 consumermedsafety.org,Institute for Safe Medication Practices,Healthcare
@@ -1596,7 +1762,10 @@ convergentindia.com,Convergent Wireless,MSP
 convergentwireless.com,Convergent Wireless,MSP
 convergenze.it,Convergenze,ISP
 convergeone.com,C1 (ConvergeOne),MSP
+convotis.ch,CONVOTIS Swiss,IaaS
 conwaycorp.com,Conway Corp,ISP
+cooksonhillsconnect.com,Cookson Hills Connect,ISP
+coolhousing.net,Coolhousing,Web Host
 coolideas.co.za,Cool Ideas,ISP
 coolwavecom.com,Coolwave Communications,ISP
 cooolbox.bg,Cooolbox,ISP
@@ -1613,6 +1782,7 @@ corbina.ru,PJSC VimpelCom,ISP
 corblock.com,Corblock,Industrial
 cordialmail.net,Cordial,Marketing
 core-backbone.com,Core-Backbone,ISP
+coreit.se,Aderian CoreIT,MSP
 coreix.net,Coreix,Web Host
 corenetcloud.com,CORENETCLOUD,Web Host
 corephp.com,corePHP,Marketing
@@ -1626,7 +1796,9 @@ cornell.edu,Cornell University,Education
 cornellcollege.edu,Cornell College,Education
 cornerstoneondemand.com,Cornerstone,SaaS
 corp-email.com,Shanghai Qingyu Computer Technology,Email Security
+corpiconet.com.ar,CORPICO,ISP
 corporativafiber.com.br,Corporativa Fiber,ISP
+correo.gob.es,Spanish Ministry of Digital Transformation,Government
 cortland.edu,SUNY Cortland,Education
 cosmonova.net,Cosmonova,ISP
 cosmopolitanlasvegas.com,The Cosmopolitan of Las Vegas,Travel
@@ -1635,9 +1807,12 @@ cotas.com,Cotas,ISP
 cotas.com.bo,Cotas,ISP
 cotea.com.ar,COTEA,ISP
 cotecal.com.ar,Cotecal,ISP
+cotel.com.ar,Cotel Villa Gesell,ISP
 cotelcam.com.ar,Cotelcam Argentina,ISP
+cotesma.coop,Cotesma San Martin de los Andes,ISP
 cotton-warehouse.com,Cotton Warehouse Classic Cars,Automotive
 coucou-networks.fr,Free Mobile,ISP
+countybroadband.co.uk,County Broadband,ISP
 countyofriverside.us,County of Riverside,Government
 covage.com,Covage,ISP
 cox.com,Cox Communications,ISP
@@ -1649,8 +1824,10 @@ cpanelhost.cl,cPanelHost,Web Host
 cpcc.edu,Central Piedmont Community College,Education
 cpi.ad.jp,CPI,Web Host
 cpi340b.com,Contract Pharmacy Insight,Healthcare
+cpit.co.nz,Christchurch Polytechnic Institute (Ara),Education
 cpp.edu,Cal Poly Pomona,Education
 cprapid.com,cPanel,Web Host
+cpsboe.k12.oh.us,Cincinnati Public Schools,Education
 cpserver.com,A2 Hosting,Web Host
 cpsinet.com,TruBridge,Healthcare
 cqu.edu.au,Central Queensland University,Education
@@ -1666,6 +1843,7 @@ credo-telecom.ru,Credo Telecom,ISP
 creehan.com,Inovalon (Formerly Creehan & Company),Healthcare
 creighton.edu,Creighton University,Education
 crelcom.ru,Crelcom,ISP
+creolink.cm,Creolink Communications,ISP
 creolink.com,Creolink Communications,ISP
 crim.ca,Centre de Recherche Informatique de Montréal,Education
 crisis24.com,Crisis24,SaaS
@@ -1673,10 +1851,13 @@ criticalcase.com,Criticalcase,Web Host
 criticalhub.com,Critical Hub Networks,ISP
 cromptonpartners.com,Crompton Partners Abu Dhabi,Real Estate
 cronomagic.com,Cronomagic,Web Host
+cronon.net,Cronon,Web Host
 crossinx.com,Unifiedpost Group,SaaS
 crowncastle.com,Crown Castle,ISP
 crowncloud.net,CrownCloud,Web Host
+crusoe.ai,Crusoe,IaaS
 crxmgmt.com,The Medicine Shoppe Franchisee,Healthcare
+csbnet.se,CSBNET Chalmers Studentbostader,Education
 csc.fi,CSC Finland,Science
 csf.ne.jp,Cable Station Fukuoka (CSF),ISP
 cshl.edu,Cold Spring Harbor Laboratory,Education
@@ -1688,6 +1869,7 @@ cslox.com,CS LoxInfo,ISP
 csloxinfo.com,CSL,MSP
 csloxinfo.net,CS Loxinfo,ISP
 csnet.inf.br,CSNET,ISP
+cso.com.ua,CSO Ukraine,ISP
 csod.com,Cornerstone,SaaS
 cspire.com,C Spire,ISP
 cspirefiber.com,C Spire,ISP
@@ -1698,9 +1880,12 @@ csuc.cat,CSUC,Education
 csufresno.edu,California State University Fresno,Education
 csuohio.edu,Cleveland State University,Education
 csus.edu,California State University Sacramento,Education
+cswg.com,C and S Wholesale Grocers,Logistics
+ct-consulting.ru,CT Consulting,Web Host
 ct.edu,Connecticut State Colleges and Universities,Education
 ct.gov,Connecticut Government,Government
 ct1000.com,China Telecom,ISP
+ctb.jp,CTB Media Beppu,ISP
 ctbcbank.com.ph,CTBC Bank (Philippines) Corp.,Finance
 ctbctelecom.com.br,Algar Telecom,ISP
 ctc-g.co.jp,ITOCHU Techno-Solutions (CTC),MSP
@@ -1731,6 +1916,8 @@ curtin.edu.au,Curtin University,Education
 customer.speedpartner.de,SpeedPartner,Web Host
 customercontrolpanel.de,netcup,Web Host
 cut.net,Central Utah Telephone,ISP
+cuttingedgecomm.com,Cutting Edge Communications,ISP
+cvecfiber.com,CVEC Fiber,Utilities
 cvent-planner.com,Cvent,SaaS
 cvent.com,Cvent,SaaS
 cvtelecom.cv,Cabo Verde Telecom,ISP
@@ -1752,6 +1939,7 @@ cyber.net.pk,Cybernet,ISP
 cybera.ca,Cybera Alberta,Education
 cybera.net,Cybera,ISP
 cybercon.com,Digital Space (Cybercon),Web Host
+cyberec.com,Cyber Express Communication,ISP
 cyberfolks.hr,cyber_Folks,Web Host
 cyberfolks.pl,cyber_Folks,Web Host
 cyberfolks.ro,cyber_Folks,Web Host
@@ -1781,13 +1969,16 @@ cyon.link,cyon,Web Host
 cyon.net,Cyon,Web Host
 cyon.site,cyon,Web Host
 cyrusone.com,CyrusOne,IaaS
+cyso.com,Cyso Group,Web Host
 cyta.com.cy,Cyta,ISP
 d-hosting.de,d-hosting,Web Host
+d-net.kiev.ua,Delta-Net Kyiv,ISP
 d-pcomm.com,D and P Communications,ISP
 d2l.com,D2l Brightspace,SaaS
 d2s.cloud,d2s.cloud,Web Host
 daakbabu.com,Daak Babu,Email Provider
 dacor.de,suc dacor,ISP
+dada.eu,Register.it (Dada),Web Host
 dadabroadband.com,DaDa Broadband,ISP
 daegu.ac.kr,Daegu University,Education
 daemonmail.ner,DaemonMail,Email Provider
@@ -1812,27 +2003,37 @@ darientel.net,Darien Telephone,ISP
 darpa.mil,DARPA,Defense
 dartmouth-hitchcock.org,Dartmouth-Hitchcock,Healthcare
 dartmouth.edu,Dartmouth College,Education
+dartpoints.com,DartPoints,Web Host
 darysoft.com,Dary Web Designs,Web Host
 data-tronics.com,ArcBest Technologies,Logistics
+data.cr,American Data Networks Costa Rica,ISP
 data102.com,Hivelocity (Data102),Web Host
 data443.com,Data443,Email Security
 databank.com,DataBank,Web Host
 datacamp.co.uk,CDN77,Web Host
+datacate.com,Datacate,Web Host
+datacenter.eu,Datacenter Luxembourg,Web Host
 datacentrum.sk,DataCentrum Slovakia,Government
+datacheap.ru,Datacheap,Web Host
 datacom.com,Datacom,MSP
 datacom.com.au,Datacom,MSP
 datacorpore.com.br,DataCorpore,Web Host
 datafabrik.de,meerfarbig (datafabrik),Web Host
 dataforest.net,dataforest,Web Host
 datagroup.ua,Datagroup,ISP
+datahouse.ru,DataHouse Citytelecom,Web Host
 datak.ir,Datak,ISP
+dataline.ua,Dataline Ukraine,ISP
 datanat.com,Datanational Corporation,MSP
 datapark.ch,Datapark,ISP
 datapipe.com,Rackspace,Web Host
 dataplace.com,Eurofiber Cloud Infra,IaaS
 dataport.de,Dataport,Government
+datasource.ch,Datasource,Web Host
+datatility.com,NSI Hosting (Datatility),Web Host
 datawagon.com,DataWagon,Web Host
 datawagon.net,DataWagon,Web Host
+dataweb.nl,DataWeb,ISP
 datayard.us,DataYard,MSP
 datazonenetworks.net,DataZone Networks,ISP
 datev.de,DATEV,SaaS
@@ -1845,10 +2046,12 @@ dauphintelecom.com,Dauphin Telecom,ISP
 daystar.io,Daystar Email Service,Email Provider
 db.com,Deutsche Bank,Finance
 dbcity.com,Waller Creek Communications,ISP
+dbd-breitband.de,DBD Breitband,ISP
 dbl-group.com,DBL Group,Conglomerate
 dbug.com.br,DBUG Telecom,ISP
 dc.gov,District of Columbia Government,Government
 dc37.net,District Council 37,Nonprofit
+dc74.com,Segra (DC74),ISP
 dca.net,DCANet,ISP
 dcblox.com,DC BLOX,Web Host
 dcboces.org,Dutchess BOCES,Education
@@ -1856,6 +2059,7 @@ dcc.bg,Cifrova Kabelna Korporacia,ISP
 dcceew.gov.au,Australian Department of Climate Change Energy Environment Water,Government
 dcdi.net,Direct Communications Rockland (DCDI),ISP
 dcfa.net,Douglas College,Education
+dcmcable.com,DCM Cable,ISP
 dcn.to,DCN Corporation,ISP
 dcsmanage.com,DCS Pacific Star,MSP
 dcta.mil.br,DCTA Brazil Aerospace Science and Technology,Defense
@@ -1876,11 +2080,13 @@ deanza.edu,Foothill-DeAnza Community College District,Education
 deasil.works,Deasil Networks,MSP
 dec.net.ua,Donbass Electronic Communications,ISP
 dec.nsw.edu.au,NSW Department of Education,Education
+dedfiber.com,DedFiber,Web Host
 dedicado.com,Dedicado Uruguay,ISP
 dedicated.com,Dedicated.com,Web Host
 deere.com,John Deere,Agriculture
 deerfieldhosting.net,Deerfield Hosting,Web Host
 default-host.net,INHOSTED LP,Web Host
+degnet.com,DegNet,ISP
 deic.dk,DeiC,Education
 delaware.gov,State of Delaware,Government
 delhi.edu,SUNY Delhi,Education
@@ -1903,6 +2109,7 @@ democrats.com,Democrats.com,Nonprofit
 denonline.in,DEN Networks India,ISP
 denvergov.org,City and County of Denver,Government
 depaul.edu,DePaul University,Education
+descartes.com,Descartes Systems,SaaS
 deshaw.com,D. E. Shaw,Finance
 designerstudio.it,Designer Studio,Marketing
 desjardins.com,Desjardins,Finance
@@ -1929,9 +2136,11 @@ dh.bytemark.co.uk,Bytemark,Web Host
 dhamma.org,Vipassana Meditation,Nonprofit
 dhiraagu.com.mv,Dhiraagu,ISP
 dhl.com,DHL,Logistics
+dhs.gov,US Department of Homeland Security,Government
 diako-dresden.de,Diakonissenanstalt Dresden,Healthcare
 diakovere.de,DIAKOVERE,Healthcare
 dialego.de,Dialego,Marketing
+dialnet.net,Dialnet Colombia,ISP
 dialog.lk,Dialog Axiata,ISP
 didichuxing.com,DiDi,Travel
 difesa.it,Ministero della Difesa,Defense
@@ -1949,14 +2158,17 @@ digimobil.es,DIGI Spain,ISP
 digital-fortress.com,Digital Fortress,IaaS
 digital808.com,Digital808,Marketing
 digitalairstrike.com,Digital Air Strike,Marketing
+digitaledgedc.com,Digital Edge,Web Host
 digitalmotion.co,Digital Motion Events,Event Planning
 digitalmotionevents.com,Digital Motion Events,Event Planning
 digitalnetms.com.br,DigitalNet MS,ISP
 digitalocean.com,DigitalOcean,Web Host
 digitaloceanspaces.com,DigitalOcean,IaaS
+digitalone.com,DigitalOne,Web Host
 digitalonline.com.br,Digital Tecnologia & Telecomunicação,ISP
 digitalpacific.com.au,Digital Pacific,Web Host
 digitalpath.net,DigitalPath,ISP
+digitalpolicy.gov.hk,Hong Kong Digital Policy Office,Government
 digitalrealty.com,Digital Realty,Web Host
 digitalredzone.com,Digital Red Zone,Marketing
 digitalspace.co.uk,Digital Space,MSP
@@ -1978,6 +2190,7 @@ dinaserver.com,Dinahosting,Web Host
 dipelnet.com.br,Dipelnet,ISP
 direct-booker.com,Direct Booker,Travel
 directcomfiber.com,Direct Communications Cedar Valley,ISP
+directinternet.com.br,Direct Wifi Telecom,ISP
 directnic.com,Directnic,Web Host
 directnic.net,Directnic.com,Web Host
 directnode.nl,DirectNode,Web Host
@@ -1993,6 +2206,7 @@ dito.ph,DITO Telecommunity,ISP
 ditscloud.com,DITSCloud,MSP
 divdav.com,DIV DAV,Marketing
 divide0.net,Divide Zero Networks,Web Host
+divomail.ru,DIVO,Email Provider
 dixieepa.com,Dixie EPA,Utilities
 djaweb.dz,Telecom Algeria,ISP
 dji.com,DJI,Technology
@@ -2002,11 +2216,14 @@ dkw-akademie.com,DKW Akademie,Education
 dlife.cn,21CN,Email Provider
 dlive.kr,DLIVE,ISP
 dlivry.co,Twilio SendGrid,Marketing
+dlreoil.co.kr,Daelim,Industrial
 dls.net,DLS Internet Services,ISP
 dmc.org,Detroit Medical Center,Healthcare
 dmctelecom.com.br,DMC Telecom,ISP
 dmit.com,DMIT Cloud Services,Web Host
+dmm.com,DMM.com,Entertainment
 dmmhosts.com,DMM Hosts,Web Host
+dmwireless.com,DM Wireless,ISP
 dna.fi,DNA,ISP
 dnchosting.com,Directnic,Web Host
 dnet.net.id,DNET Indonesia,ISP
@@ -2040,6 +2257,8 @@ domdom.hu,DomDom,Web Host
 domena.pl,Domena.pl,Web Host
 domene.shop,Domeneshop,Web Host
 domeneshop.no,Domeneshop,Web Host
+domicilium.com,Domicilium,Web Host
+dominionenergy.com,Dominion Energy,Utilities
 domru.ru,ER-Telecom,ISP
 domtel.com.pl,DOMTEL,ISP
 donga.ac.kr,Dong-A University,Education
@@ -2062,6 +2281,8 @@ dotname.co.kr,Dotname Korea,Web Host
 dotroll.com,DotRoll,Web Host
 douzone.com,Douzone Bizon,SaaS
 downloaddatarecovery.com,KernelApps,Technology
+doylestowncommunications.com,Doylestown Communications,ISP
+dpsk12.org,Denver Public Schools,Education
 dqecom.com,DQE Communications,ISP
 dragon.cz,Dragon Internet,ISP
 draminski.com,Dramiński Technology,Healthcare
@@ -2087,7 +2308,9 @@ drjapan-jp.com,"Dr. Japan Co., Ltd.",Healthcare
 dropboxinc.com,Dropbox,SaaS
 drpeng.com.cn,Dr. Peng,ISP
 drreddys.ro,Dr. Reddy's,Healthcare
+drtel.com,DRN Dickey Rural Networks,ISP
 dscga.com,Digital Service Consultants,Web Host
+dsi.net,DSI Daten Service Informationssysteme,ISP
 dsi.net.br,DSI Defferrari,ISP
 dsidata.sk,DSI DATA Slovakia,ISP
 dslmobil.de,DSLmobil,ISP
@@ -2100,6 +2323,7 @@ dsu.edu,Dakota State University,Education
 dsv.com,DSV,Logistics
 dsw.com,DSW,Retail
 dtac.co.th,dtac,ISP
+dtccom.com,DTC Communications,ISP
 dtctelecom.com.br,DTC Telecom,ISP
 dtel.com.br,Dtel Telecom,ISP
 dtel.ru,Dagomys Telecom (Dtel),ISP
@@ -2135,6 +2359,7 @@ dwmhosting.com,DWM Hosting,Web Host
 dwtelecom.com.br,DW Telecom,ISP
 dxc.com,DXC Technology,MSP
 dxc.technology,DXC Technology,MSP
+dyfend.net,Dyfend,ISP
 dyn-ip24.de,DDNSS,Web Host
 dynadot.com,Dynadot,Web Host
 dynamic-mytachyon.in,Tachyon Communications,ISP
@@ -2155,8 +2380,10 @@ e-catv.ne.jp,Ehime CATV,ISP
 e-i.com,Euro-Information,MSP
 e-kei.pl,Kei,Web Host
 e-know.net,TRAVCHIS (E-Know),Web Host
+e-large.cc,E-Large HK,ISP
 e-mmunity.net,VIPRE,Email Security
 e-quest.nl,e-Quest,MSP
+e-vergent.com,e-vergent,ISP
 e1b.org,Erie 1 BOCES,Education
 e2enetworks.com,E2E Networks,IaaS
 e2ma.net,Emma,Marketing
@@ -2164,9 +2391,12 @@ e4.cz,E4YOU,Web Host
 ea.com,Electronic Arts,Entertainment
 eagerweb.com,Eager Web Services,Web Host
 eaglecom.net,Vyve Broadband,ISP
+earth.net.bd,Earth Telecommunication Bangladesh,ISP
 earthlink-vadesecure.net,Vade Secure,Email Security
 earthlink.iq,Earthlink Iraq,ISP
 earthlink.net,EarthLink,ISP
+east.net.ua,EAST-NET Ukraine,ISP
+eastcentralenergy.com,East Central Energy,Utilities
 eastern-tele.com,Eastern Communications,ISP
 eastern.com.ph,Eastern Telecoms,ISP
 easterndsl.com.ph,Eastern Communications,ISP
@@ -2179,11 +2409,13 @@ easy-hebergement.net,Easy-Hébergement,Web Host
 easydns.com,easyDNS,Web Host
 easydns.net,easyDNS,Web Host
 easyhost.be,Easyhost,Web Host
+easyhost.com,Easyhost (EASYHOST SRL),Web Host
 easykeys.com,EasyKeys,Retail
 easymail.ca,easyMail,Email Provider
 easyname.com,easyname,Web Host
 easyonnet.io,Easy on Net,Web Host
 easyseo.com.my,SEO Services Malaysia,Marketing
+easyweb.co.za,Easyweb (Xnet),Web Host
 easyweb.com,easyDNS,Web Host
 eatel.com,REV,ISP
 eaton.com,Eaton,Industrial
@@ -2206,22 +2438,26 @@ ecn.co.za,ECN South Africa,ISP
 ecn.net.au,ECN Internet,ISP
 ecohost.la,ecohost Latinoamerica,Web Host
 ecolink.com,Ecolink,Manufacturing
+econocom.es,Econocom Cloud,IaaS
 econsave.com.my,Econsave,Retail
 ecosoft.com,Ecosoft,Industrial
 ecotech.cy,Ecotech,ISP
 ecotel.de,ecotel,ISP
+ecotelecom.ru,Ecotelecom (Altagen),ISP
 ecount.com,Ecount ERP,SaaS
 ecounterp.com,Ecount ERP,SaaS
 ecritel.fr,Ecritel,MSP
 ecritel.net,Ecritel,MSP
 ecu.edu,East Carolina University,Education
 edera.cz,Edera Group,ISP
+edf.fr,Electricite de France (EDF),Utilities
 edge.uol,Edge UOL,IaaS
 edgecenter.ru,EdgeCenter,IaaS
 edgecompute.app,Fastly,Technology
 edgekey.net,Akamai,Technology
 edgenext.com,EdgeNext,Web Host
 edgepark.com,Edgepark,Healthcare
+edgesec.info,EDGESEC (air2bite),Web Host
 edgesuite.net,Akamai,Technology
 edgetelecom.com.br,Edge Telecom,ISP
 edgeuno.com,EdgeUno,ISP
@@ -2235,6 +2471,7 @@ edpnet.be,EDPnet,ISP
 edpnet.net,EDPnet,ISP
 edu.com,InstructionalAssistant,SaaS
 eduneering.com,UL EHS training,SaaS
+edutech.org,EduTech BOCES,Education
 edwardjones.com,Edward Jones,Finance
 edwardrose.com,Edward Rose Manifold Services,Real Estate
 ee.net,eNET,ISP
@@ -2245,6 +2482,7 @@ egasolutions.com.br,EGA Solutions,Logistics
 egate.net,E-Gate Communications,ISP
 ege.edu.tr,Ege University,Education
 egihosting.com,EGIHosting,Web Host
+eglobalreach.net,Globalreach eBusiness Networks,ISP
 egov.com,Tyler Technologies,SaaS
 egregistry.eg,EUN Egyptian Universities Network,Education
 egress.cloud,Egress Software,Email Security
@@ -2252,6 +2490,7 @@ egress.com,"Egress, a KnowBe4 Company",Email Security
 egrisi.ge,System Net,ISP
 egrnet.com.br,EGR NET,ISP
 egs-seg.gc.ca,Canada Government Electronic Directory Services (GEDS),Government
+egyptian.net,Egyptian Telephone,ISP
 ehaf.com,EHAF Consulting Engineers,Construction
 ehafconsulting.org,EHAF Consulting Engineers,Construction
 ehime-u.ac.jp,Ehime University,Education
@@ -2271,12 +2510,14 @@ ek.co,Ekco,MSP
 ekoline.net.pl,Eko-Line,ISP
 eku.edu,Eastern Kentucky University,Education
 elasticbeanstalk.com,Amazon AWS,PaaS
+elauwitnetworks.com,WhiteSky (Elauwit),ISP
 elcat.kg,ElCat,ISP
 elcom.ru,Rostelcom,ISP
 elcuatro.com,El Cuatro,ISP
 electric.coop,NRECA,Nonprofit
 electric.net,VIPRE,Email Security
 electriclightwave.com,Allstream,ISP
+elektrafi.com,ElektraFi,ISP
 elementa.com,Elementa,MSP
 elementcritical.com,Element Critical,Web Host
 elementmedia.com,ElementMedia,Web Host
@@ -2289,6 +2530,7 @@ elim.net,Elimnet,MSSP
 elisa.ee,Elisa,ISP
 elisa.fi,Elisa,ISP
 elisteka.lt,Serveriai.lt (Elisteka),Web Host
+elite.net.uk,Elite Limited,MSP
 elitechgroup.com,ELITechGroup,Healthcare
 elitework.com,EliteWork,SaaS
 elive.net,Elive,Web Host
@@ -2296,10 +2538,12 @@ elkdata.ee,Elkdata,Web Host
 elkem.com,Elkem,Manufacturing
 ellipse.net,Ellipse,MSP
 ello.ch,Ello Communications,ISP
+ellum.net,EllumNet,ISP
 elmecnet.net,Elmec Informatica,MSP
 elnk.net,Earthlink,ISP
 elntelecom.com.br,ELN Telecom,ISP
 elon.edu,Elon University,Education
+elpos.net,ELPOS,ISP
 elte.hu,Eötvös Loránd University,Education
 eltele.no,Serit Eltele,ISP
 email-od.com,SocketLabs,SaaS
@@ -2311,6 +2555,8 @@ emailservice.io,Mailprotector,Email Security
 emailsrv.net,Mailprotector,Email Security
 emailsrvr.com,Rackspace Email,Email Security
 emberpoint.com,Ember Point,SaaS
+embou.com,Embou,ISP
+embrapa.br,Embrapa Brazilian Agricultural Research Corporation,Government
 embratel.net.br,Embratel,ISP
 embriq.no,Embriq,MSP
 emcali.com.co,EMCALI,Utilities
@@ -2326,9 +2572,11 @@ empaquesmundiales.com,Empaques Mundiales,Industrial
 empireaccess.com,Empire Access,ISP
 emporiaresearch.com,Emporia,SaaS
 empower-retirement.com,Empower Retirement,Finance
+empsecure.com,EMP Secure,MSP
 emsecure.net,Selligent,Marketing
 emsend2.com,ActiveCampaign,Marketing
 emtel.com,Emtel,ISP
+emtel.net.co,EMTEL Colombia,ISP
 enagroup.net,ENA Group,Construction
 encrypttitan.net,EncryptTitan,Email Security
 endoffice.com,EndOffice,Web Host
@@ -2346,6 +2594,8 @@ enet.ie,Enet,ISP
 enetworks.co.za,Datacentrix eNetworks,ISP
 enfo.fi,Enfo,MSP
 eng.it,Engineering,Consulting
+engeplus.com.br,Engeplus,News
+enginefresh.net,EngineFresh,Web Host
 enginet.az,Birlink,ISP
 enguard.com,EnGuard,Email Security
 eni.com,Eni,Industrial
@@ -2382,7 +2632,9 @@ epb.com,EPB,ISP
 epb.net,EPB,ISP
 epbfi.com,EPB,ISP
 epbnet.com,Russellville Electric Plant Board,ISP
+epcan.de,epcan,ISP
 epfl.ch,EPFL,Education
+epic.com,Epic Systems,Healthcare
 epic.com.cy,Epic Cyprus,ISP
 epic.com.mt,Epic (Formerly Vodafone Malta),ISP
 epichs.org,Epic Health,Healthcare
@@ -2390,6 +2642,7 @@ epicpc.com,Epic Health,Healthcare
 epicura.be,EpiCURA,Healthcare
 epldt.com,ePLDT,IaaS
 epmltd.com,Express Publications,Publishing
+epo.org,European Patent Office,Government
 epri.com,Electric Power Research Institute,Science
 epsilon.com,Epsilon,Marketing
 epsl1.com,Publicis Groupe,Marketing
@@ -2411,11 +2664,15 @@ ertelecom.ru,ER-Telecom,ISP
 es.net,ESnet,Education
 esa.int,European Space Agency,Government
 esavezone.co.kr,SaveZone,Retail
+esboces.org,Eastern Suffolk BOCES,Education
 esc.net.au,EscapeNet,ISP
+esc11.net,Education Service Center Region 11,Education
 escom.bg,Escom Bulgaria,ISP
+esecuredata.com,eSecureData,Web Host
 esited.com,eSited,Web Host
 eskerondemand.com,Esker,SaaS
 eskom.co.za,Eskom,Utilities
+esnet.kz,Esnet Kazakhstan (Eurasia-Star),ISP
 eso.org,European Southern Observatory,Science
 esolutionsgroup.ca,Govstack (eSolutions Group),Technology
 esosoft.net,EcoSoft,Web Host
@@ -2438,6 +2695,7 @@ ethiotelecom.et,Ethio Telecom,ISP
 ethunder-hosting.com,Ethunder Hosting,Web Host
 etik-cloud.com,Infomaniak,IaaS
 etipres.com,ETIPRES,Print
+etisalat.ae,e& (Etisalat),ISP
 etisalat.com.eg,Etisalat Egypt,ISP
 etius.jp,WebArena,Web Host
 etl.co.ls,Econet Lesotho,ISP
@@ -2448,6 +2706,7 @@ etronsol.com,Etron Solutions,MSP
 etsmtl.ca,École de technologie supérieure,Education
 etsu.edu,East Tennessee State University,Education
 eudonet.com,Eudonet,SaaS
+eumetsat.int,EUMETSAT,Government
 eunetworks.com,euNetworks,ISP
 euro-net.pl,Euronet Bialystok,ISP
 eurobyte.ru,EuroByte,Web Host
@@ -2483,14 +2742,17 @@ evolink.com,Evolink,ISP
 evolus-it.com,Evolus IX,ISP
 evolus-ix.com,Evolus IX,ISP
 evolusfibre.com,Evolus IX,ISP
+evolutio.com,Evolutio Cloud Enabler,IaaS
 evonik.de,Evonik,Manufacturing
 evoxt.com,Evoxt,Web Host
 ewe-ip-backbone.de,EWE,ISP
 ewe.com,EWE,ISP
+eweka.nl,Eweka,ISP
 ewp.live,EasyWP,Web Host
 ewu.edu,Eastern Washington University,Education
 eww.at,eww,Utilities
 exa.net.uk,Exa Networks,ISP
+exabytes.sg,Exabytes Singapore,Web Host
 exacthosting.com,Exact Hosting,Web Host
 exactt.com,Salesforce Marketing Cloud (Formerly ExactTarget),Marketing
 exacttarget.com,Salesforce Marketing Cloud (Formerly ExactTarget),Marketing
@@ -2523,8 +2785,11 @@ expositltd.com,Exposit Ltd.,MSP
 express-scripts.com,Express Scripts,Healthcare
 express.com.ar,Express Telecomunicaciones,ISP
 expressinformatica.art.br,Express Fibra,ISP
+expressotelecom.com,Expresso (Sudatel),ISP
+extendbroadband.com,Extend Broadband,ISP
 extendedcare.com,CarePort,Healthcare
 extra-lan.com.tw,Extra-Lan Technologies,ISP
+extrasec.de,Extrasec,ISP
 extrememt.com.br,Extreme Provedor de Internet,ISP
 extremeserv.net,extremeserv,Web Host
 ey.com,Ernst and Young,Consulting
@@ -2533,6 +2798,7 @@ ezeefiber.com,Ezee Fiber,ISP
 ezhostingserver.com,Hostek,Web Host
 ezinternetsolutions.com,EZ Internet Solutions,Web Host
 ezorg.nl,E-Zorg,Healthcare
+eztech.com.vn,EZ Technology,Web Host
 ezzi.net,EZZI.net,Web Host
 f-i.de,Finanz Informatik,MSP
 f-integra.org,Fundacion Integra,Nonprofit
@@ -2544,6 +2810,7 @@ faciliti.net.br,Faciliti Telecom,ISP
 fahrenheit88.com,fahrenheit88,Retail
 faiba.co.ke,Jamii Telecommunications,ISP
 fairfax.va.us,"Fairfax County, Virginia",Government
+fairpoint.com,Fidium Fiber (FairPoint),ISP
 fairview.org,Fairview Health Services,Healthcare
 famu.edu,Florida A and M University,Education
 fanaptelecom.ir,Fanap Telecom,ISP
@@ -2562,10 +2829,12 @@ farmside.co.nz,Farmside,ISP
 fast.net.id,Linknet-Fastnet,ISP
 fast.net.kg,Skynet Telecom,ISP
 fast.net.uk,FASTNET,ISP
+fastcom.co.nz,Fastcom NZ,MSP
 faster.cz,Faster CZ,ISP
 fasternet.com.br,Desktop,ISP
 fastfortechnologies.com,FastForTechnologies,ISP
 fastinternet.inf.br,Fast Web,ISP
+fastlink.lt,Fastlink (Consilium Optimum),ISP
 fastly.com,Fastly,SaaS
 fastlylb.net,Fastly,Technology
 fastmail.com,Fastmail,Email Provider
@@ -2590,6 +2859,7 @@ fc-net.fr,fcnet,ISP
 fccn.pt,FCCN,Education
 fcconnexion.com,Fort Collins Connexion,ISP
 fcnet.fr,fcnet,ISP
+fcoe.org,Fresno County Office of Education,Education
 fcps.edu,Fairfax County Public Schools,Education
 fdcservers.net,FDC Servers,Web Host
 fdu.edu,Fairleigh Dickinson University,Education
@@ -2602,6 +2872,7 @@ ferris.edu,Ferris State University,Education
 feslegen.com.tr,Feslegen Catering,Food
 festo.com,Festo,Manufacturing
 fetnet.net,FETNet,ISP
+ffastfill.com,ION Group (FFastFill),SaaS
 fgl.com.mx,Francisco Garcia Lopez,Healthcare
 fhcrc.org,Fred Hutchinson Cancer Research Center,Healthcare
 fhptelecom.com.br,FHP Telecom,ISP
@@ -2609,15 +2880,21 @@ fiber-operator.nl,Fiber Operator,ISP
 fiber.net,Fibernet Utah,Web Host
 fiber.net.id,Fiber Networks Indonesia,ISP
 fibercop.it,FiberCop,ISP
+fibergreen.es,Fibergreen,ISP
 fibergrid.net,Fiber Grid,ISP
+fiberhost.com,Fiberhost,ISP
 fiberhub.com,FiberHub,ISP
 fiberinternet.com.br,SpeedNet Telecom,ISP
 fiberlight.com,FiberLight,ISP
 fibernetics.ca,Fibernetics,ISP
 fibernetms.com.br,Fibernet,ISP
+fiberocity.co.uk,Fiberocity,ISP
+fiberopticalnetwork.com,Fiber Optical Network,ISP
 fibertel.com.ar,Personal,ISP
+fibertown.com,Fibertown,Web Host
 fiberup.com.br,Fiber UP,ISP
 fiberway.com.ar,Fiberway,ISP
+fiberwide.com,Fiberwide,ISP
 fibextelecom.net,Fibex Telecom,ISP
 fibia.dk,Fibia,ISP
 fibralider.com.br,Lider Fibra,ISP
@@ -2645,10 +2922,12 @@ finanzaworld.it,FinanzaWorld,Finance
 finanzaworld.net,FinanzaWorld,Finance
 finegroupservers.com,Fast Servers (FineGroup),Web Host
 fiocruz.br,Fiocruz Oswaldo Cruz Foundation,Education
+fiord.net,Fiord Networks,ISP
 fiord.ru,NTC FIORD,ISP
 firebaseapp.com,Google,PaaS
 fireeyecloud.com,FireEye,Email Security
 fireeyegov.com,FireEye (Government),Email Security
+firelinebroadband.com,Fireline Broadband,ISP
 firenettelecom.com.br,FireNet Telecom,ISP
 firmenich.com,dsm-firmenich,Manufacturing
 first-server.net,FirstServer,Web Host
@@ -2660,6 +2939,7 @@ firstenergycorp.com,FirstEnergy,Utilities
 firstlight.net,FirstLight Fiber,ISP
 firstmarketingservices.in,First Marketing Services,Marketing
 firstmedia.com,First Media,ISP
+firstnet.co.za,FirstNet South Africa,MSP
 firstsourceweb.com,1st Source Web,Marketing
 firsttrust.cm,First Trust,Finance
 firsttrust.online,First Trust,Finance
@@ -2670,6 +2950,7 @@ fisquare.com,Infince,SaaS
 fit.edu,Florida Institute of Technology,Education
 fittelecom.com.br,FIT Telecom (Vero),ISP
 fiu.edu,Florida International University,Education
+fivenetwork.co.in,Five Network India,ISP
 fixnet.com.tr,FixNet,ISP
 fiz-karlsruhe.de,FIZ Karlsruhe,Science
 fl.gov,State of Florida,Government
@@ -2684,11 +2965,13 @@ flemingcollege.ca,Fleming College,Education
 flexanet.com.br,Flexa Internet,ISP
 flexential.com,Flexential,Web Host
 flexnetwork.fr,Flex Network,ISP
+flexnetworks.ca,FlexNetworks,ISP
 flexnetworks.co.kr,Flex Networks,MSP
 flextronics.com,Flex (Flextronics),Manufacturing
 flhsi.com,FLHSI Florida High Speed Internet,ISP
 flinnsci.com,Flinn Scientific,Healthcare
 floridablue.com,Florida Blue,Finance
+floridasupremecourt.org,Florida Supreme Court,Government
 floridaurologypartners.com,Florida Urology Partners,Healthcare
 flroofingcompany.com,Florida Roofing Company,Construction
 fluency.net.uk,Commsworld (Fluency),ISP
@@ -2716,6 +2999,7 @@ foaaa.com,Federal Online Group,Web Host
 foconet.net.br,Foconet Telecom,ISP
 focusbroadband.com,FOCUS Broadband,ISP
 fogel-group.cr,Fogel Group,Industrial
+foliateam.com,Foliateam Group,ISP
 fonabosque.gob.bo,FONABOSQUE,Government
 fonacit.gob.ve,Fonacit,Government
 foodtecsolutions.com,FoodTec Solutions,SaaS
@@ -2742,6 +3026,7 @@ fortressitx.com,FortressITX,Web Host
 forwardemail.net,ForwardEmail.net,Email Provider
 fotbo.com,Fotbo,Web Host
 fourseasonspediatrics.com,Four Seasons Pediatrics,Healthcare
+fox.com,Fox Corporation,Entertainment
 foxconn.com.cn,Foxconn,Manufacturing
 foxinfo.net.br,FOXINFO Telecom,ISP
 foxnetbrasil.com.br,FoxNet Brasil,ISP
@@ -2762,6 +3047,7 @@ franweb.net.br,FRAN WEB,ISP
 fraport.de,Fraport,Travel
 fraunhofer.de,Fraunhofer,Science
 frazmtn.com,Frazier Mountain Internet,ISP
+freddiemac.com,Freddie Mac,Finance
 fredonia.edu,SUNY Fredonia,Education
 free.fr,Free,ISP
 free.org,Free,ISP
@@ -2780,6 +3066,7 @@ freepro.com,Free Pro,ISP
 freerangecloud.com,Free Range Cloud,Web Host
 freetls.fastly.net,Fastly,Technology
 fregat.com,Fregat,ISP
+frente.com.br,Frente (M.P. Telecom),ISP
 freseniusmedicalcare.com,Fresenius Medical Care,Healthcare
 frgp.net,Front Range GigaPoP,Education
 frinet.com.br,Frinet,ISP
@@ -2789,10 +3076,13 @@ fronteirainternet.com.br,Fronteira Internet,ISP
 frontier.com,Frontier,ISP
 frontiernetworks.ca,Frontier Networks Inc,Web Host
 frontiir.com,FRONTiiR,MSP
+fsi.co.jp,Fuji Soft,MSP
+fsr.com,First Step Internet,ISP
 fsu.edu,Florida State University,Education
 ft.fo,Faroese Telecom,ISP
 ftc-i.net,Farmers Telephone Cooperative,ISP
 ftc.gov,Federal Trade Commission,Government
+ftel.kz,Freedom Telecom Kazakhstan,ISP
 ftiwifi.com,Farmers Telephone (FTI),ISP
 fuertehoteles.com,Fuerte Group Hotels,Travel
 fujibake.co.jp,Fuji Bakelite,Industrial
@@ -2805,6 +3095,7 @@ fulcrumcorp.com,Fulcrum Software,SaaS
 fulldata.com.ve,Fulldata,ISP
 fullnet.com.br,Fullnet,ISP
 fullnetfibra.com.br,Full Net Fibra,ISP
+fullsave.com,Eurofiber Business (FullSave),ISP
 fundaments.nl,Fundaments,Web Host
 funeralone.net,funeralOne,SaaS
 furman.edu,Furman University,Education
@@ -2812,14 +3103,18 @@ furrera.ps,Furrera,ISP
 fuse.net,Altafiber (Formerly Cincinnati Bell),ISP
 fusionconnect.com,Fusion Connect,MSP
 fusionet.srv.br,Fusion Telecom,ISP
+fusionnet.in,Fusionnet Web Services,Web Host
 fusionnetworks.net,Fusion Networks,ISP
 future-bridge.eu,Future Bridge Events,Marketing
+fwnetworks.co.uk,F and W Networks,ISP
 fxclickinsight.co.za,FXClick Insight,Finance
+fxdana-dns.com,Corporacion Dana,ISP
 fybercom.net,FyberCom,ISP
 fyfeweb.com,FyfeWeb,Web Host
 fyfeweb.uk.net,FyfeWeb,Web Host
 fzi.de,FZI Forschungszentrum Informatik,Science
 g.network,G.Network Communications,ISP
+g2gtelecom.com.br,G2G Telecom,ISP
 g2netsul.com.br,G2NetSul,ISP
 g6internet.com.br,G6 Internet,ISP
 g8.net.br,SAMM,ISP
@@ -2836,6 +3131,7 @@ galls.com,Galls,Retail
 gamania.com,Gamania,Entertainment
 gamma.co.uk,Gamma,ISP
 gammagroup.co,Gamma,ISP
+gamtel.gm,Gamtel Gambia,ISP
 gandi.net,Gandi.net,Web Host
 gannett.com,Gannett (USA Today),News
 gaoland.net,SFR,ISP
@@ -2861,7 +3157,10 @@ gazprom.ru,Gazprom Telecom,ISP
 gba.gob.ar,Provincia de Buenos Aires,Government
 gbic.mx,GBIC Comunicaciones,ISP
 gblnet.net,Global Network Management,MSP
+gbnc.com.cn,Golden-Bridge Netcom,ISP
+gbnetwork.my,GB Network Solutions,Web Host
 gbsn.com.br,GbsNet,ISP
+gbta.net,Golden Belt Telephone (GBT),ISP
 gci.com,GCI,ISP
 gci.net,GCI,ISP
 gci.net.br,GCI Net,ISP
@@ -2870,6 +3169,7 @@ gciservicios.com.ar,Merco Comunicaciones,ISP
 gcmcomputers.com,GCM Computers,MSP
 gcn.bg,Global Communication Net Bulgaria,ISP
 gcore.com,Gcore,Web Host
+gcpud.org,Grant County PUD,Utilities
 gcrcompany.com,GCR Company,MSP
 gcs.co.kr,Green Cable Television Station,ISP
 gctrials.com,GCT,Healthcare
@@ -2884,9 +3184,13 @@ geckonet.pl,Geckonet,ISP
 gegnet.com.br,GGNet Telecomunicações,ISP
 gehirn.ne.jp,Gehirn,Web Host
 geisinger.org,Geisinger,Healthcare
+gelsen-net.de,GELSEN-NET,ISP
+gemnet.mn,Gemnet Mongolia,ISP
+gemzo.ps,Gemzo IT,ISP
 gen2fund.com,Gen II,Finance
 gencat.cat,Generalitat de Catalunya,Government
 gene.com,Genentech,Healthcare
+generacja.pl,GENERACJA.pl Wroclaw,ISP
 generali.de,Generali Deutschland,Finance
 generalinformatix.net,General Informatix,Technology
 generalmills.com,General Mills,Food
@@ -2894,12 +3198,16 @@ geneseo.com,Geneseo Communications,ISP
 geneseo.edu,SUNY Geneseo,Education
 genie-networks.com,Genie Networks,Technology
 genoray.com,GENORAY,Healthcare
+genpact.com,Genpact,MSP
 genstarnetcable.com,Gennstar Network Solutions,ISP
+geo.hosting,GEO.Hosting,Web Host
 geolinks.com,GeoLinks,ISP
 georgetown.edu,Georgetown University,Education
 georgia.gov,State of Georgia,Government
 georgiasouthern.edu,Georgia Southern University,Education
 gerberlife.com,Gerber Life Insurance,Finance
+gerrys.net,GIT Gerry's Information Technology,MSP
+getechbrothers.com,Getechbrothers,ISP
 getkeepsafe.com,Keepsafe Software,SaaS
 getordained.org,Universal Life Church,Religion
 getresponse.com,GetResponse,Marketing
@@ -2907,20 +3215,25 @@ getronics.com,Getronics,MSP
 getty.edu,J. Paul Getty Trust,Education
 gettysburg.edu,Gettysburg College,Education
 getunwired.com,unWired Broadband,ISP
+gevernova.com,GE Vernova,Manufacturing
+gfb.com.mx,BBVA Mexico (Grupo Financiero Bancomer),Finance
 gfiber.com,Google Fiber,ISP
 gga.ch,GGA Maur,ISP
 ggsv.jp,Techorus,Web Host
 ghm-grenoble.fr,Groupe hospitalier mutualiste de Grenoble,Healthcare
 ghnet.com.br,GHNet,ISP
+ghofi.com,GhoFi,ISP
 ghostnet.de,GHOSTnet,Web Host
 giantpartners.com,Giant Partners,Marketing
 gib-solutions.ch,GIB Solutions,ISP
+gibfibre.com,GIBFIBRE,ISP
 gibir.net.tr,GIBIRNet,ISP
 gibsonemc.com,Gibson Connect (Gibson EMC),Utilities
 gibtele.com,Gibtelecom,ISP
 gifu-u.ac.jp,Gifu University,Education
 giga.ly,Giga Libya,ISP
 gigabytetelecom.com.br,Gigabyte Telecom,ISP
+gigacable.com.mx,Gigacable Aguascalientes,ISP
 gigaclear.com,Gigaclear,ISP
 gigahost.dk,GigaHost,Web Host
 gigahost.no,Gigahost,Web Host
@@ -2935,12 +3248,14 @@ gigstreem.com,Gigstreem,ISP
 gijima.com,Gijima,MSP
 gilat.net,Gilat Telecom,ISP
 gipnetworks.com,Global IP Networks,Web Host
+gist.ac.kr,GIST Gwangju Institute of Science and Technology,Education
 git-repos.de,LCube,Web Host
 github.com,GitHub,SaaS
 github.io,GitHub,SaaS
 githubusercontent.com,GitHub,SaaS
 gitlab.com,GitLab,SaaS
 gitlab.io,GitLab,SaaS
+gitn.com.my,GITN Malaysia,ISP
 glasfaser-ruhr.de,Glasfaser Ruhr,ISP
 glasgow-ky.com,Glasgow EPB,ISP
 glasgowepb.com,Glasgow EPB,ISP
@@ -2968,6 +3283,7 @@ globalnoc.net,equada network,ISP
 globalsecurelayer.com,Global Secure Layer,ISP
 globaltelecom-mt.com.br,Global Telecom,ISP
 globalways.net,Globalways,ISP
+globalxtreme.net,GlobalXtreme Bali,ISP
 globconnex.com,Global Connectivity Solutions,ISP
 globe.com.ph,Globe Telecom,ISP
 globo.com,Globo,News
@@ -2977,6 +3293,7 @@ gloworld.com,Globacom (Glo),ISP
 gm.com,General Motors,Automotive
 gmailify.com,Gmailify,Email Provider
 gmdp.net.id,GMDP,ISP
+gmedia.id,GMedia Indonesia,ISP
 gmntelecom.com.br,GMN Telecom,ISP
 gmobb.jp,GMO BB,ISP
 gmogshd.com,GMO GlobalSign,Technology
@@ -2992,6 +3309,7 @@ gnet.cc,GNET,Web Host
 gnetworkve.com,G-Network,ISP
 gnomen.co.uk,Gnomen,Real Estate
 gnu.ac.kr,Gyeongsang National University,Education
+go.com,Disney Go.com,Entertainment
 go.com.jo,Orange Jordan,ISP
 go.com.mt,GO p.l.c.,ISP
 go.com.sa,GO Telecom,ISP
@@ -3000,6 +3318,7 @@ goco.ca,TELUS,ISP
 godaddy.com,GoDaddy,Web Host
 goetel.de,Goetel,ISP
 goip.de,GoIP,Web Host
+gojade.org,Jade Communications (Fone.net),ISP
 goknet.com.tr,GÖKNET,ISP
 gol.com,Gol,Travel
 golddata.net,Gold Data,ISP
@@ -3015,16 +3334,20 @@ goodline.info,Good Line,ISP
 google.com,Google (Including Gmail and Google Workspace),Email Provider
 googlefiber.net,Google Fiber,ISP
 googleusercontent.com,Google Cloud Platform (GCP),PaaS
+gorcom.ru,Gorcom Gorset,ISP
 gore.com,W. L. Gore and Associates,Manufacturing
 gorgiphoto.com,Gabriel Gorgi,Photography
 gorillaservers.com,GorillaServers,Web Host
 gosecure.ai,GoSecure,Email Security
 gosecure.net,GoSecure,Email Security
+gosemo.com,GoSEMO Fiber (SEMO Electric),Utilities
 goskope.com,Netskope,Email Security
 gospellight.sg,Gospel Light Christian Church,Religion
+gotanet.se,Gotanet (Gotalandsnatet),ISP
 gotdns.com,DynDNS,Web Host
 gotdns.org,DynDNS,Web Host
 goteborg.se,City of Gothenburg,Government
+goth-project.io,Thales (GoTH Project),Defense
 gotpantheon.com,Pantheon,Web Host
 gouv.qc.ca,Government of Quebec,Government
 gov-dooray.com,Dooray,SaaS
@@ -3050,6 +3373,7 @@ granitenet.com,Granite Telecommunications,ISP
 graysmark.net,Graysmark Business Systems,MSP
 greatforti.com,Anpple Tech,Web Host
 greatmail.com,Greatmail,Email Provider
+greatwestlife.com,Canada Life (Great-West Life),Finance
 gree.co.jp,GREE,Entertainment
 green.ch,green.ch,ISP
 greenarrowemail.com,GreenArrow,SaaS
@@ -3074,6 +3398,7 @@ group.bnpparibas,BNP Paribas,Finance
 group.ntt,NTT Group,ISP
 groupe-asten.fr,Groupe Asten,MSP
 groupe-convergence.com,Groupe Convergence,MSP
+groupe-infoclip.com,INFOCLIP,MSP
 groupon.com,Groupon,Retail
 grsolucoestelecom.com.br,GR Soluções Telecom,ISP
 gru.com,Gainesville Regional Utilities,Utilities
@@ -3093,13 +3418,17 @@ gsi.de,GSI Helmholtzzentrum für Schwerionenforschung,Education
 gss-security.ca,GSS Security,Physical Security
 gsu.edu,Georgia State University,Education
 gta.net,GTA Teleguam,ISP
+gtb.net,Xtel Communications,ISP
 gtd.cl,Gtd,ISP
 gtdcolombia.com,GTD Colombia,ISP
 gtdmanquehue.com,Gtd,ISP
+gtdperu.com,GTD Peru,ISP
 gtel.in,Gigantic Infotel,ISP
+gtel.net.mx,Axtel (gtel),ISP
 gthost.com,GTHost,Web Host
 gtnexus.com,Infor Nexus (Formerly GT Nexus),SaaS
 gtpl.net,GTPL,ISP
+gtplkcbpl.com,GTPL KCBPL,ISP
 gts.ro,GTS Telecom,ISP
 gts.sk,GTS Slovakia,ISP
 gtt.net,GTT Communications,ISP
@@ -3114,20 +3443,26 @@ gustavus.edu,Gustavus Adolphus College,Education
 gva.africa,GVA (Canal+),ISP
 gva.es,Generalitat Valenciana,Government
 gvec.net,GVEC Internet Services,ISP
+gvm.ro,GVM Networks,ISP
 gvt.net.br,Telefônica Brasil,ISP
 gvtc.com,GVTC,ISP
+gvtel.net,Garden Valley Telephone,ISP
 gwblawfirm.com,Gallivan White and Boyd,Legal
 gwdg.de,GWDG,Education
 gwi.net,GWI,ISP
+gwnu.ac.kr,Gangneung-Wonju National University,Education
 gwt.net.br,Gateway Telecom,ISP
 gwu.edu,The George Washington University,Education
 h-isac.org,H-ISAC,Healthcare
 h4ahosting.com,H4A Hosting,Web Host
 h4y.us,H4Y Technologies,Web Host
+h5datacenters.com,H5 Data Centers,Web Host
 ha-vel.cz,ha-vel internet,ISP
 hab-inc.com,Berkheimer,Finance
 hackney.gov.uk,London Borough of Hackney,Government
+hale-center.k12.tx.us,Region 17 Education Service Center,Education
 hallmark.com,Hallmark,Retail
+halotel.co.tz,Halotel Tanzania (Viettel),ISP
 halservice.it,WiC (HAL Service),ISP
 hamilton.edu,Hamilton College,Education
 hamline.edu,Hamline University,Education
@@ -3162,6 +3497,7 @@ haverford.edu,Haverford College,Education
 hawaii.edu,University of Hawaii,Education
 hawaiian.net,Sitestar (Hawaiian),ISP
 hawaiiantel.com,Hawaiian Telcom,ISP
+hawaiidt.com,Xiber Hawaii (Dialogix),ISP
 hawetelekom.com,Hawe Telekom,ISP
 hay.net,Hay Communications,ISP
 haynesboone.com,Haynes and Boone,Legal
@@ -3174,6 +3510,8 @@ hcinet.net,Hanson Communications,ISP
 hcltech.com,HCLTech,MSP
 hcltechnologies.com,HCL Technologies,MSP
 hcn.co.kr,Hyundai HCN,ISP
+hcn.gr,HCN Hellenic Cable,ISP
+hct.ac.ae,Higher Colleges of Technology UAE,Education
 hctc.net,Hill County Telephone Cooperative (HXTC),ISP
 hdems.com,HENNGE Mail Archive,SaaS
 hdsupply-email.com,HD Supply,Retail
@@ -3185,10 +3523,12 @@ healthplan.com,HealthPlan Services,Healthcare
 healthproductsforyou.com,Health Products For You,Healthcare
 healthtouch.com,Cardinal Health,Healthcare
 healthyvision.org,Healthy Vision Institute,Healthcare
+hearst.com,Hearst,Publishing
 heartinternet.uk,Heart Internet,Web Host
 hebergementadn.ca,ADN Communications,Web Host
 hehe.si,Hehe,Web Host
 hel.fi,City of Helsinki,Government
+heliantis.fr,Heliantis,ISP
 helinet.de,HeLi NET Telekommunikation,ISP
 helioho.st,HelioHost,Web Host
 heliohost.org,HelioHost,Web Host
@@ -3213,14 +3553,17 @@ hermes-telecom.net,Hermes Telecom Belgium,ISP
 herning.dk,Herning Municipality,Government
 herokuapp.com,Heroku,PaaS
 herotel.com,Herotel,ISP
+hessenkom.de,Hessenkom,ISP
 heteml.jp,GMO,Web Host
 hetzner.com,Hetzner,Web Host
 hetzner.de,Hetzner,Web Host
+hexanet.fr,HEXANET,ISP
 hey.com,HEY,Email Provider
 heyflow.page,Heyflow,Marketing
 heyflow.site,Heyflow,Marketing
 heywoodhill.com,Heywood Hill,Retail
 hgc-intl.com,HGC,ISP
+hgctr.com.hk,BDX DC Services HK (HGC),Web Host
 hged.com,Holyoke Gas and Electric,Utilities
 hh.nm.cn,China Unicom,ISP
 hhs.gov,U.S. Department of Health & Human Services,Government
@@ -3238,6 +3581,7 @@ highspot.com,Highspot,Marketing
 hightechbroadband.net,Hightech Broadband,ISP
 highwire.org,HighWire,SaaS
 highwirepress.com,HighWire,SaaS
+hikari-net.ne.jp,Hikarinet,ISP
 hinet.net,HiNet,ISP
 hip-hosting.com,HIP-Hosting,Web Host
 hiper.dk,Hiper,ISP
@@ -3269,14 +3613,18 @@ hkt.cc,Forewin Telecom Group,ISP
 hku.hk,The University of Hong Kong,Education
 hmall.com,Hyundai Home Shopping,Retail
 hmcaguas.com,Puerto Rico Telephone Company,ISP
+hmrc.gov.uk,HM Revenue and Customs,Government
 hmu.gr,Hellenic Mediterranean University,Education
 hns.com,Hughes Network Systems,ISP
 hoaspace.com,HOA Space,SaaS
 hofstra.edu,Hofstra University,Education
 hokudai.ac.jp,Hokkaido University,Education
 hol.gr,Vodafone,ISP
+holdconet.com,Holdco Networks,ISP
+holistica.com.br,Holistica Provedor Internet,ISP
 holistictech.net,Holistic Technologies,MSP
 hollandc.pe.ca,Holland College,Education
+holstonelectric.com,Holston Electric Cooperative,Utilities
 holz.net.br,Holz Network,ISP
 home-webserver.de,DDNSS,Web Host
 home.cern,CERN,Science
@@ -3289,6 +3637,7 @@ homeftp.org,DynDNS,Web Host
 homeip.net,DynDNS,Web Host
 homelinux.net,DynDNS,Web Host
 homelinux.org,DynDNS,Web Host
+homenet.ua,HomeNet Ukraine,ISP
 homeoffice.gov.uk,UK Home Office,Government
 homeplus.net.tw,Hoshin Multimedia,ISP
 homesc.com,Home Telecom,ISP
@@ -3302,14 +3651,18 @@ hondutel.hn,Hondutel,ISP
 honest.net,Honest Networks,ISP
 honeycomb.net,Honeycomb Internet,ISP
 honeycrm.com,HoneyCRM,SaaS
+honeywell.com,Honeywell,Manufacturing
 hongik.ac.kr,Hongik University,Education
 hongkongserver.net,Hong Kong Server,Web Host
 hood.edu,Hood College,Education
+hoodcanal.net,Hood Canal Communications,ISP
 hop-electric.com,Hopkinsville Electric (EnergyNet),Utilities
+hope.edu,Hope College,Education
 hopitaleuropeendeparis.fr,Hôpital Européen de Paris,Healthcare
 hopone.net,HopOne Internet,Web Host
 hopto.me,No-IP,Web Host
 hopto.org,No-IP,Web Host
+hopus.net,HOPUS,ISP
 horizonscope.com,Horizon Scope Telecom,ISP
 horizonstelecom.com,Horizons Telecom,ISP
 horizontel.com,Horizon Telcom,ISP
@@ -3358,6 +3711,9 @@ hostings.com.sg,Web Commerce Communications,Web Host
 hostingspeed.net,Hosting Speed,Web Host
 hostingturkiye.com.tr,Hosting Turkiye,Web Host
 hostinguk.net,Hosting UK,Web Host
+hostingyard.net,HostingYard,Web Host
+hostiran.net,Hostiran,Web Host
+hostireland.com,Elio Networks (HostIreland),ISP
 hostkey.com,HOSTKEY,Web Host
 hostkey.ru,HostKey,Web Host
 hostland.ru,HostLand,Web Host
@@ -3366,7 +3722,9 @@ hostlife.net,HOSTLIFE,Web Host
 hostmetro.com,HostMetro,Web Host
 hostmonster.com,Hostmonster,Web Host
 hostnet-vps.nl,Hostnet,Web Host
+hostnet.de,hostNET,Web Host
 hostnet.nl,Hostnet,Web Host
+hostnetworks.com.au,Host Networks,Web Host
 hostneverdie.com,Hostneverdie,Web Host
 hostopia.com,Hostopia,Web Host
 hostpacific.com,HostPacific.com,Web Host
@@ -3374,12 +3732,14 @@ hostpapa.com,HostPapa,Web Host
 hostpapavps.net,HostPapa,Web Host
 hostpoint.ch,Hostpoint,Web Host
 hostresolver.net,Stack Harbor,Web Host
+hostrocket.com,HostRocket,Web Host
 hostroyale.com,HostRoyale,Web Host
 hosts.co.uk,Namesco Limited,Web Host
 hostsalus.com.br,Salus Hosting,Web Host
 hostsecure.us.com,WordPress US Hosting,Web Host
 hostsevenplus.com,HostSevenPlus,Web Host
 hostsg.com,HostSG,Web Host
+hostsnap.net,HostSNAP,Web Host
 hostspeedy.com,Host Speedy,Web Host
 hosttook.com,Hosttook,Web Host
 hostuniversal.com.au,Host Universal Australia,Web Host
@@ -3389,10 +3749,12 @@ hostway.co.kr,Hostway IDC,Web Host
 hostway.com,Hostway,Web Host
 hostwinds.com,Hostwinds,Web Host
 hostwindsdns.com,Hostwinds,Web Host
+hostycare.com,Hostycare (SRMAK),Web Host
 hostyhosting.io,HostyHosting,Web Host
 hostzealot.com,HostZealot,Web Host
 hotel-icon.com,Hotel ICON,Travel
 hotelhugony.com,Hotel Hugo New York,Travel
+hotlink.com.br,Hotlink Internet,ISP
 hotnet.co.jp,HOTnet Hokkaido Telecommunications,ISP
 hotnet.net.il,Hot Net Internet Services,ISP
 hotwirecommunication.com,Hotwire Communications,ISP
@@ -3404,6 +3766,7 @@ howchin.com.my,How Chin Engineering,Industrial
 hp.com,HP,Technology
 hpe.com,Hewlett Packard Enterprise,Technology
 hringdu.is,Hringdu,ISP
+hsbc.com.hk,HSBC Hong Kong,Finance
 hse-medianet.de,ENTEGA,ISP
 hsl.org.br,Hospital Sírio-Libanês,Healthcare
 hslda.net,Home School Legal Defense Association (HSLDA),Education
@@ -3418,10 +3781,13 @@ htdc.org,HTDC Hawaii Technology Development Corporation,Government
 htmlservices.it,HTMLServices.it,MSP
 htnet.co.jp,Hokuriku Telecommunication Network,ISP
 htp.net,htp,ISP
+httvserver.com,HTTVSERVER,Web Host
 htuidc.com,Dianliantongxin,Web Host
+htv-net.ne.jp,HTV-Net Hachinohe Cable,ISP
 huaweicloud.com,Huawei Cloud,IaaS
 hubone.fr,Hub One,ISP
 hubspotemail.net,HubSpot,Marketing
+hufs.ac.kr,Hankuk University of Foreign Studies,Education
 hugel-inc.com,Hugel,Healthcare
 hugetns.com,Huge TNS,ISP
 hughes.com,Hughes,ISP
@@ -3430,7 +3796,10 @@ hughston.com,Hughston Clinic,Healthcare
 hugstelecom.com,Hugs Telecom,ISP
 hull.ac.uk,University of Hull,Education
 hulum.iq,Hulum Almustakbal,ISP
+humana.com,Humana,Healthcare
 humanservices.gov.au,Services Australia,Government
+humber.ca,Humber Polytechnic,Education
+hunancatv.com,Hunan CATV,ISP
 huntercomm.net,Hunter Communications,ISP
 huntington.com,Huntington Bancshares,Finance
 huntsvillehospital.org,Huntsville Hospital,Healthcare
@@ -3440,17 +3809,22 @@ hut8.com,Hut 8,IaaS
 hut8mining.com,Hut 8,IaaS
 hvacwebsites.com,Online Access,Marketing
 hvcc.edu,Hudson Valley Community College,Education
+hvtv.co,HV Television Multipay,ISP
 hvvc.us,Hivelocity,Web Host
 hya.com.tw,Taiwan Optical Platform,ISP
 hydro.com,Norsk Hydro,Industrial
 hyonix.com,Hyonix,Web Host
 hyosung.com,Hyosung,Conglomerate
+hypeenterprises.com,Hype Enterprises,Web Host
 hypernode.com,Hypernode,Web Host
 hypernode.io,Hypernode,Web Host
 hyperoptic.com,Hyperoptic,ISP
 hytron.io,Hytron Network,Web Host
 hyundai-autoever.com,Hyundai Autoever,MSP
+hyve.com,Hyve Managed Hosting,Web Host
+hzd.de,Hessische Zentrale fur Datenverarbeitung,Government
 i-cable.com,i-Cable,ISP
+i2bnetworks.com,I2B Networks,Web Host
 i2ts.ne.jp,i2ts,Web Host
 i3d.net,i3D.net,IaaS
 i4i.com,i4i,Technology
@@ -3458,6 +3832,7 @@ iabgteleport.de,IABG Teleport,IaaS
 iadvantage.net,SUNeVision iAdvantage,Web Host
 iaea.org,International Atomic Energy Agency,Government
 iam.ma,Maroc Telecom,ISP
+iasl.com,Internet Access Solutions,ISP
 iastate.edu,Iowa State University,Education
 ibindley.com,Cardinal Health,Healthcare
 ibm.com,IBM,Technology
@@ -3465,6 +3840,8 @@ iboss.com,iboss,SaaS
 ibrowse.com,iBrowse,ISP
 ibw.com.ni,IBW Nicaragua,ISP
 ibx.com,Independence Blue Cross,Healthcare
+ic.co.uk,Internet Central,ISP
+ic.km.ua,KhmelnitskInfocom,ISP
 icc-media.co.jp,ICC Corporation,ISP
 ice.co.cr,Grupo ICE,Industrial
 icehosting.nl,IceHosting,Web Host
@@ -3475,26 +3852,34 @@ ici.ro,ICI București,Government
 iclicktelecom.net.br,iClick Telecom,ISP
 iclix.co.za,Iclix,ISP
 icloud.com,Apple iCloud,Email Provider
+icn-tv.ne.jp,Iwakuni Cable Network,ISP
 ico.net,ICOnetworks,ISP
 icomtex.ru,Intercomtex,ISP
+iconnect.zm,AfriConnect Zambia (inq.),ISP
 iconnectsa.co.za,iConnect SA,ISP
 iconnecttelecom.com.br,Connect Telecom,ISP
 iconz.net,ICONZ,ISP
 icoremail.net,Coremail,Email Provider
 icosnet.com,ICOSNET,ISP
 icostelecom.com.br,ICOS Telecom,ISP
+ics-llc.net,ICS Advanced Technologies,ISP
 ict.jp,IGAUENO Cable Television,ISP
+ictbulut.com,ICT Bulut Turkey,Web Host
 ictglobe.com,ICTGlobe,ISP
 ictk.com,ICTK,Technology
+ictv.jp,Iruma CATV,ISP
 icuk.net,ICUK,Web Host
 ida.org,Institute for Defense Analyses,Defense
 idaho.gov,State of Idaho,Government
 idcf.jp,IDC Frontier,Web Host
 idcloudhost.com,IDCloudHost Indonesia,Web Host
+iddis.com,IDD Enterprises (Fidelity),Finance
 idealinsurancebrokersng.com,Ideal Insurance Brokers,Finance
 idealwebpiaui.com.br,Ideal Web,ISP
 ideaservers.net,Hetzner,Web Host
+ideastackmail.com,Ideastack,Web Host
 ideatek.com,IdeaTek,ISP
+ideay.com,Ideay Equipos y Sistemas,ISP
 identibitsuisse.ch,identibit suisse,Marketing
 identity.digital,Identity Digital (Afilias),Technology
 idig.net,Canadian Web Hosting,Web Host
@@ -3503,10 +3888,13 @@ idm.net.lb,IncoNet IDM,ISP
 idnet.net,IDNet,ISP
 idodns.com,IDO DNS,MSP
 idt.net,IDT Corporation,ISP
+ied.edu.hk,Education University of Hong Kong,Education
 ieee.org,IEEE,Nonprofit
 ielo.net,ielo,ISP
 ientc.com,IENTC Telecom,ISP
 ieso.ca,Independent Electricity System Operator (Ontario),Utilities
+ifb.net,IFB Aberdeen,MSP
+ifc.edu.br,Instituto Federal Catarinense,Education
 ifeelfree.co.nz,I Feel Free,MSP
 ifibertelecom.com.br,iFiber Telecom,ISP
 iforte.co.id,iForte Global Internet,ISP
@@ -3519,6 +3907,8 @@ iglou.com,IgLou Internet Services,ISP
 ignitedigital.com,Ignite Digital,Marketing
 igpfibra.com.br,IGP Fibra,ISP
 ihc.com,Intermountain Health,Healthcare
+ihc.host,Iron Hosting Centre,Web Host
+ihk-gfi.de,IHK Gesellschaft fur Informationsverarbeitung,Government
 ihnetworks.com,IHNetworks,Web Host
 ihor-hosting.ru,IHOR Hosting,Web Host
 ihor.online,IHOR Hosting,Web Host
@@ -3534,6 +3924,7 @@ iitb.ac.in,Indian Institute of Technology Bombay,Education
 iitr.ac.in,Indian Institute of Technology Roorkee,Education
 ik2.com,Spamflare,Email Security
 ikb.at,IKB Innsbrucker Kommunalbetriebe,Utilities
+ikeja.co.za,Ikeja Wireless,ISP
 ikoula.com,Ikoula,Web Host
 iks.ru,InterKamService,ISP
 ilap.com,ILAP,ISP
@@ -3544,8 +3935,10 @@ ilink.net,VDC Powerbase,IaaS
 illinois.edu,University of Illinois,Education
 illinois.net,Illinois Century Network,Education
 illinoisstate.edu,Illinois State University,Education
+iloxtelecom.com,ilox Telecom,ISP
 ilpt.com,Independence Light & Power Telecommunications,ISP
 im3.id,IM3,ISP
+ima.sp.gov.br,IMA Informatica de Municipios Associados,Government
 imageonline.co.in,Image Online,Marketing
 imagine.ie,Imagine,ISP
 imanila.ph,iManila,Marketing
@@ -3557,8 +3950,10 @@ immomeister.com,Immomeister,Real Estate
 imnet.com.br,Imnet,ISP
 imobi.co.kr,imobi,ISP
 imon.net,ImOn Communications,ISP
+imos.net,imos,Web Host
 imp.ch,ImproWare,ISP
 impa.br,IMPA,Education
+imperiallogistics.com,Imperial Logistics,Logistics
 implantartelecom.com.br,Implantar Telecom,ISP
 improvmx.com,ImprovMX,Email Provider
 impulsahosting.com,Impulsa IT Solutions,Web Host
@@ -3600,12 +3995,14 @@ inet.co.th,INET,ISP
 inet.de,INTERNET AG,Web Host
 inet.vn,INET,Web Host
 inetcom.ru,Inetcom,ISP
+inets.ru,ZAO InT,ISP
 inettech.co.kr,iNet Technologies,ISP
 inetvl.ru,AlianceTelecom,ISP
 inexa.com.br,Inexa,ISP
 inexio.net,inexio,ISP
 inext.co.th,INET,ISP
 inf.com,Infosys,MSP
+infinityfiber.com,Infinity Fiber,ISP
 infinityfiber.com.br,Infinity Fibra,ISP
 infinivan.com,InfiniVAN,ISP
 infixnet.com.br,Infix Telecom,ISP
@@ -3619,6 +4016,7 @@ infolink.ru,Infolink,ISP
 infolinktelecom.com,Infolink Telecom,ISP
 infomaniak.ch,infomaniak,Web Host
 infomaniak.com,Infomaniak,Web Host
+infomil.com,INFOMIL,ISP
 infomir.com.ua,Infomir,ISP
 infonet-isp.com.br,Infonet Telecom,ISP
 infonetdc.com,Infonet,Web Host
@@ -3629,16 +4027,19 @@ inforang.com,Inforang,SaaS
 inforcloudsuite.com,Infor,SaaS
 informac.com.br,Informac,ISP
 infornetnetwork.net.br,I3 Telecomunicações,ISP
+infoserve.de,InfoServe,MSP
 infoservic.com.br,InfoServic Telecom,ISP
 infosetetelecom.com.br,Info Sete,ISP
 infosi.gov.ao,INFOSI Angola Information Society,Government
 infosys.com,Infosys,MSP
 infotec.com.mx,INFOTEC Mexico,Government
 infotec.psi.br,Infotec,ISP
+infotech.at,Infotech EDV-Systeme,MSP
 infotrade.gr,INFO-TRADE,Technology
 infowest.com,InfoWest,ISP
 infracom.se,InfraCom,ISP
 ing.com,ING,Finance
+ingate.ru,Ingate Group,Marketing
 ingenuitycloudservices.com,Ingenuity Cloud Services,Web Host
 ingenuityfilms.com,Ingenuity Films,Entertainment
 inha.ac.kr,Inha University,Education
@@ -3661,8 +4062,11 @@ inoc.com,INOC,MSP
 inovalon.com,inovalon,Healthcare
 inovanettelecom.net.br,InovaNet,ISP
 inpe.br,INPE Brazilian National Institute for Space Research,Science
+inq.co.za,inq. South Africa,ISP
 inq.inc,Inq. Digital,ISP
 inria.fr,INRIA,Science
+insiel.it,Insiel,Government
+insit.ru,InSit,ISP
 inspire.net.nz,Inspire Net Limited,ISP
 inspirebroadband.net,Inspire Broadband,ISP
 inspiren.my,Inspiren,Marketing
@@ -3686,10 +4090,12 @@ inter.edu,Interamerican University of Puerto Rico,Education
 inter.net.il,Internet Gold,ISP
 inter.net.th,Internet Thailand Company Limited,ISP
 intercolnet.com.br,Intercol,ISP
+intercon.ru,Intercon,ISP
 interconnect.cz,Interconnect,ISP
 interconnect.nl,Interconnect Netherlands,Web Host
 interdeal.co.il,Interdeal,Finance
 interfibras.net.br,Interfibras Telecomunicações,ISP
+interhost.com,InterHost,Web Host
 interhost.it,Genesys Informatica Srl,MSP
 interior.gov.cl,Chile Ministry of Interior,Government
 interkam.pl,Interkam,ISP
@@ -3708,12 +4114,14 @@ internet.gmo,GMO Internet,ISP
 internet.lu,Luxembourg Online,ISP
 internet.one,Internet ONE,ISP
 internet10.net.br,Internet 10,ISP
+internet2.edu,Internet2,Education
 internetlocal.com.ar,Internet Local,ISP
 internetmailserver.net,Internet Mail Server Networks,Email Provider
 internetnamesforbusiness.com,Internet Names For Business,Web Host
 internetparatodos.com.ar,Internet Para Todos La Rioja,Government
 internetport.se,Internetport Sweden,ISP
 internetsuper.com.br,Internet Super,ISP
+internetunion.pl,Internet Union,ISP
 internetvikings.com,Internet Vikings,Web Host
 internetway.com.br,Internet Way,ISP
 internetx.com,InterNetX,Web Host
@@ -3724,10 +4132,13 @@ internexus.co.uk,Internexus,ISP
 interphone.com.au,Interphone Australia,ISP
 interra.ru,Interra,ISP
 interserver.net,InterServer,Web Host
+intertech.net,InterTECH,ISP
 intervel.com.br,Intervel Telecom,ISP
 intervolve.com.au,New Era Technology (Intervolve),MSP
 interworks.co.za,Interworks,ISP
+interworld.net,InterWorld Communications,ISP
 interzet.ru,ER-Telecom,ISP
+intesasanpaolo.com,Intesa Sanpaolo,Finance
 inti.net.id,Inti Data Telematika,ISP
 intracom-telecom.com,Intracom Telecom,ISP
 intred.it,Intred,ISP
@@ -3737,9 +4148,11 @@ investpsp.ca,PSP Investments,Finance
 investpsp.com,PSP Investments,Finance
 inwi.ma,Inwi,ISP
 inxserver.de,Inxmail,Marketing
+io-global.com,IO Global Services,ISP
 ioflood.com,IOFLOOD,Web Host
 ioflood.net,I/O Flood,Web Host
 ioh.co.id,IM3,ISP
+ioinc.us,IO Inc,Web Host
 ioko.com,Redcentric (ioko),Web Host
 iomart.com,iomart,Web Host
 ionblade.com,IonBLADE,Web Host
@@ -3777,7 +4190,9 @@ ip-home.net,iP-Home,ISP
 ip-kyoto.ad.jp,Advanced Software Technology & Management Research Institute of Kyoto,Education
 ip-max.net,IP-Max,ISP
 ip-projects.de,IP-Projects,Web Host
+ip4isp.net,IP4ISP,ISP
 ipacct.com,IPACCT Cable,ISP
+ipandmore.de,ip and more,Web Host
 ipex.cz,IPEX,ISP
 iphmx.com,Cisco Cloud Email Security (CES),Email Security
 iphost.gr,IpHost,Web Host
@@ -3793,18 +4208,22 @@ ipn.mx,Instituto Politecnico Nacional,Education
 ipnet.ua,IPnet Kyiv,ISP
 ipnettelecom.com.br,IPNET,ISP
 ipnext.com.ar,IPNEXT,ISP
+ipng.com.au,Amaze Intelligence (IPNG),ISP
 ipnxnigeria.net,ipNX Nigeria,ISP
 ipost.com,iPost,Marketing
 ippathways.com,IP Pathways,MSP
 iprimus.com.au,iPrimus,ISP
 ipserverone.com,IP ServerOne,Web Host
+ipservice.in.ua,IP Service Ukraine,ISP
 ipstar.com.au,IPSTAR Australia,ISP
 iptel.com.ar,Iptel Argentina,ISP
 iptelecom.it,IP Telecom Italy,ISP
 iptp.com,IPTP Networks,ISP
 ipv.net.pl,Promedia,ISP
 ipvisie.com,IP Visie Networking,ISP
+ipvolume.net,IP Volume,ISP
 ipx.com.au,IP Exchange Australia,ISP
+ipxo.com,IPXO,SaaS
 ipxon.com,IPXON,Web Host
 iq.group,iQ Group Iraq,ISP
 iqcomputing.com,IQComputing,Web Host
@@ -3815,10 +4234,13 @@ iqon-global.com,IQON Global,Web Host
 irbr.ru,ИРБР,Web Host
 irib.ir,IRIB Islamic Republic of Iran Broadcasting,Government Media
 irinn.in,IRINN India Registry,Nonprofit
+iristel.com,Iristel,ISP
 irm.srl,IP.RO (Internet Resources Management),Web Host
 ironmountain.com,Iron Mountain,Technology
 ironwoodcrc.com,Ironwood Cancer & Research Centers,Healthcare
+irpinianetcom.it,Irpinia Net-Com,ISP
 irtelcom.ru,Irtelcom,ISP
+is.co.ke,Internet Solutions Kenya (NTT),ISP
 is.co.za,Internet Solutions,ISP
 is74.ru,Intersvyaz,ISP
 isc.org,Internet Systems Consortium,Nonprofit
@@ -3831,6 +4253,7 @@ isite.de,iWelt,MSP
 isnet.net.tr,Is Net,ISP
 isoceltelecom.com,Isocel,ISP
 isomediainc.com,Isomedia,ISP
+isosat.net,IsoTropic Networks,ISP
 isp.net,ISP.net Las Vegas,ISP
 ispalliance.cz,ISP Alliance,ISP
 ispgateway.de,domainfactory GmbH,Web Host
@@ -3850,9 +4273,11 @@ isu.net.sa,King Abdul Aziz City for Science and Technology,Science
 isvc.vn,Viet Digital Technology,Web Host
 isync.io,iSync.io,SaaS
 it-grad.ru,IT-GRAD,IaaS
+it-tv.org,IT TV (Information Technologies),ISP
 it7.net,IT7,Web Host
 itafiber.com.br,ITAFIBER,ISP
 itainternet.com.br,Ita Internet,ISP
+itaipuparquetec.org.br,Itaipu Parquetec,Science
 italiaonline.it,Italiaonline,Web Host
 itam.mx,ITAM Instituto Tecnologico Autonomo de Mexico,Education
 itanet.psi.br,ITANET,ISP
@@ -3863,12 +4288,15 @@ itcen.com,ITCenenTec,ISP
 itcsa.net,Informática y Telecomunicaciones,ISP
 itdz-berlin.de,IT-Dienstleistungszentrum Berlin,Government
 ite.net,IT&E Guam,ISP
+itecgroup.co.za,Itec,MSP
 itel.com,iTel Networks,ISP
 itenos.de,ITENOS,MSP
 iteso.mx,ITESO,Education
+itextron.com,Textron,Manufacturing
 itgate.it,IT.Gate,ISP
 itglobal.com,ITGLOBAL,IaaS
 ithaca.edu,Ithaca College,Education
+ithnet.com,ith Kommunikationstechnik,ISP
 ithostline.com,IT HOSTLINE,MSP
 iti-e.co.jp,ITI,Healthcare
 itility.co.uk,Itility,Web Host
@@ -3884,6 +4312,7 @@ itsa.pl,Intelligent Technologies,ISP
 itsbrasil.net,ITS Telecomunicacoes,ISP
 itscom.jp,its communications,ISP
 itscom.net,iTSCOM,ISP
+itsjefen.no,ITsjefen,MSP
 itstechnologygroup.com,ITS Technology Group,ISP
 itstriangle.com,Triangle Communications,ISP
 itu.edu.tr,Istanbul Technical University,Education
@@ -3892,12 +4321,14 @@ itvoice.com,IT Voice,MSP
 iu.edu,Indiana University,Education
 iucc.ac.il,IUCC,Education
 iuhw.ac.jp,International University of Health and Welfare,Education
+iunxi.com,iunxi,Web Host
 iup.edu,Indiana University of Pennsylvania,Education
 iusecom.com.br,Figueiredo e Silva,ISP
 iv.lt,Interneto vizija,Web Host
 iveco.com,Iveco,Manufacturing
 iveloz.net.br,Iveloz Telecom,ISP
 iver.com,Iver,MSP
+ivic.gob.ve,IVIC Venezuelan Institute for Scientific Research,Science
 iwashiya-nagai.co.jp,Iwashiya Nagai Co,Healthcare
 iway.ch,iWay,ISP
 iwelt.de,iWelt,MSP
@@ -3905,6 +4336,7 @@ iwhost.com,iWHOST,Web Host
 iwihost.net,Host Telecom,Web Host
 iworx-host.com,iWorx Host,Web Host
 ixreach.com,IX Reach,ISP
+izi.com.br,IZI Telecom (ScherrerNet),ISP
 izzi.mx,Izzi Telecom,ISP
 j-com.co.jp,J-Com Japan Communications,ISP
 j-server.jp,J-Server,Web Host
@@ -3945,7 +4377,9 @@ jcu.edu.au,James Cook University,Education
 jcv.co.jp,Joetsu Cable Vision,ISP
 jcwifi.com,JC WiFi,ISP
 jd.com,JD.com,Retail
+jecec.com,Jackson Electric Cooperative,Utilities
 jeebr.net,Jeebr Mumbai,ISP
+jefferies.com,Jefferies,Finance
 jefferson.edu,Thomas Jefferson University,Education
 jejunu.ac.kr,Jeju National University,Education
 jellyfish.systems,Namecheap,Email Security
@@ -3980,6 +4414,7 @@ jocarroll.com,Jo-Carroll Energy,Utilities
 johnshopkins.edu,Johns Hopkins University,Education
 joink.com,Joink,ISP
 joker-forward.com,Joker.com,Email Provider
+jon.cz,JON.CZ,ISP
 jonesday.com,Jones Day,Legal
 jonkoping.se,City of Jonkoping,Government
 joomlawired.com,Joomla Wired,Web Host
@@ -3995,6 +4430,7 @@ jpmchase.com,JPMorgan Chase,Finance
 jpmorgan.com,JPMorgan Chase,Finance
 jpmorganchase.com,JPMorgan Chase,Finance
 jprdigital.in,JPR Digital,ISP
+jpschools.org,Jefferson Parish Schools,Education
 jreast.co.jp,JR East,Logistics
 jrnetdns.net.br,JRNET,ISP
 jrtelecom.com.br,JR Telecom,ISP
@@ -4011,8 +4447,10 @@ junet.se,Junet,ISP
 jupiter.com.br,Jupiter Telecomunicacoes,ISP
 jupiterprovedor.com.br,Jupiter Provedor,ISP
 just-size.net,Just-Size Networks,Web Host
+justice.gov,US Department of Justice,Government
 justwebtelecom.com.br,JustWeb,ISP
 jvsnet.com.br,JVS Net,ISP
+jw.org,Jehovah's Witnesses,Religion
 jwa.or.jp,Japan Weather Association,Government
 jway.jp,JWAY Cable TV,ISP
 jweiland12.net,domainfactory GmbH,Web Host
@@ -4026,6 +4464,7 @@ k20wa.org,Washington K-20 Network,Education
 k2network.com.br,K2 Network,ISP
 kaas.gg,KaasHosting,Web Host
 kaashosting.nl,KaasHosting,Web Host
+kabel-braunau.tv,Kabel Braunau,ISP
 kabel-deutschland.de,Vodafone,ISP
 kabelplus.at,kabelplus,ISP
 kabelszat2002.hu,KabelszatNet,ISP
@@ -4057,6 +4496,7 @@ kansai-u.ac.jp,Kansai University,Education
 kansas.gov,State of Kansas,Government
 kansas.net,KansasNwt,MSP
 kaopucloud.com,Kaopu Cloud,IaaS
+kappa.net.in,Kappa Internet Services,ISP
 kari.re.kr,KARI Korea Aerospace Research Institute,Science
 karistelefon.fi,Karis Telefon,ISP
 kartelkomi.ru,Kartel,ISP
@@ -4088,6 +4528,7 @@ kcn.tv,Keumgang Cable Network,ISP
 kcom.com,KCOM,ISP
 kcs.co.jp,Sakura KCS,MSP
 kct.co.jp,Kurashiki Cable TV,ISP
+kctcs.edu,Kentucky Community and Technical College System,Education
 kctvjeju.com,KCTV Jeju,ISP
 kcweb.net,KC Web,ISP
 kddi-webcommunications.co.jp,KDDI Web Communications,Web Host
@@ -4105,31 +4546,47 @@ kennesaw.edu,Kennesaw State University,Education
 kennesawtrans.com,Kennesaw Transportation,Logistics
 kennypweb.com,Kenny P Computer Services,Web Host
 kent.edu,Kent State University,Education
+kent.k12.wa.us,Kent School District,Education
 kepco.co.kr,Korea Electric Power Corporation,Utilities
 keralavisionisp.com,Keralavision Broadband,ISP
+kern.org,Kern County Superintendent of Schools,Education
+ketis.ru,KETIS,ISP
 kevag-telekom.de,KEVAG Telekom,ISP
+keybank.com,KeyBank,Finance
 keycorpgroup.com,KeyCorp Financial,Finance
 keyinfo.com,Key Information Systems (Converge),MSP
 keymachine.de,Keyweb,Web Host
 keymail.com,KeyMail,Email Provider
 keyweb.de,Keyweb,Web Host
 keyyo.com,Keyyo,ISP
+kfglobal.hk,HK Kwaifong Group,Web Host
 kforce.com,Kforce,Staffing
 kg-graphics.net,KG Graphics,Print
 kggroup.eu,Kauno Grūdai,Food
 khalijfarsonline.net,Khalij Fars Online,ISP
 khalijonline.net,Khalij Online,ISP
+khalikov.ru,Internet-Pro (Khalikov),ISP
 khplay.nl,KaasHosting,Web Host
+kht.ru,Rostelecom (KHT),ISP
 khu.ac.kr,Kyung Hee University,Education
+ki.se,Karolinska Institutet,Education
 kicks-ass.net,DynDNS,Web Host
 kicks-ass.org,DynDNS,Web Host
 kicktech.com,KickTech,MSP
+kielce.pl,Swietokrzyskie Voivodeship,Government
+kievnet.ua,KievNet,ISP
 kilmarnock.ca,Kilmarnock Enterprise,Industrial
 kindlebio.com,Kindle Bioscinces,Healthcare
+kindredgroup.com,FDJ United (Kindred),Entertainment
+kinecta.org,Kinecta Federal Credit Union,Finance
+kinetix.net.au,Kinetix Networks,ISP
 kinexmedical.com,Kinex Medical Company,Healthcare
 king-good.com,Jinku Group,Industrial
+king-servers.com,King Servers,Web Host
+king.host,KingHost (LWSA),Web Host
 kingcounty.gov,King County,Government
 kinghost.net,KingHost,Web Host
+kingscoe.org,Kings County Office of Education,Education
 kingsoft.com,Kingsoft,SaaS
 kingswoodfacadesthailand.com,Kingswood Facades Thailand,Industrial
 kinx.net,KINX,ISP
@@ -4144,6 +4601,7 @@ kitano-hp.or.jp,Kitano Hospital,Healthcare
 kitcarson.com,Kit Carson Electric Cooperative,Utilities
 kjm6.de,kajomi MAIL,Email Provider
 kk-takano.co.jp,Takano,Industrial
+kkontech.com,KKONTech Nigeria,ISP
 kktcell.com,Kuzey Kibris Turkcell,ISP
 klimovsk.net,Klimovsk Network,ISP
 klinik-arlesheim.ch,Klinik Aresheim,Healthcare
@@ -4162,11 +4620,13 @@ knipp.de,Knipp Medien und Kommunikation,Web Host
 knockdesign.com,Knock Design,Marketing
 knowit.fi,Knowit,MSP
 knu.ac.kr,Kyungpook National University,Education
+knust.edu.gh,Kwame Nkrumah University KNUST,Education
 koba.pl,Koba,ISP
 kobe-u.ac.jp,Kobe University,Education
 kochi-u.ac.jp,Kochi University,Education
 kochind.com,Koch Industries,Conglomerate
 kodak.com,Kodak,Technology
+koddos.net,KoDDOS,Web Host
 kodiaksys.com,ARIOS,SaaS
 koerber.de,Korber,Conglomerate
 koesio.com,Koesio,MSP
@@ -4174,15 +4634,20 @@ kogakuin.ac.jp,Kogakuin University,Education
 kogite.fr,KoGite,Web Host
 kolsitegroup.com,Kolsite Group,Industrial
 komfort21vek.ru,Comfort XXI Century,ISP
+kommitt.de,KomMITT-Ratingen,ISP
 komro.net,komro,ISP
 kongkow.com,Kongkow,SaaS
 konicaminolta.us,Konica Minolta,Technology
 konkuk.ac.kr,Konkuk University,Education
+konnet.com.br,Konnet (Itabirana),ISP
+konstanz.de,City of Konstanz,Government
 konverto.eu,Konverto,MSP
+koping.net,Kopings Kabel-TV,ISP
 korbank.pl,Korbank,ISP
 kordia.co.nz,Kordia,ISP
 korea.ac.kr,Korea University,Education
 korea.kr,Government of South Korea,Government
+kos.net,Kingston Online Services,ISP
 koscom.co.kr,KOSCOM,Finance
 koshinomiyako.jp,Koshinomiyako Network,ISP
 kosovotelecom.com,Telekomi i Kosoves (Vala),ISP
@@ -4195,11 +4660,15 @@ kpmg.com,KPMG,Consulting
 kpn.com,KPN,ISP
 kpn.net,KPN,ISP
 kpu-m.ac.jp,Kyoto Prefectural University of Medicine,Education
+kpunet.net,KPU Telecommunications,ISP
+kraft-s.ru,Kraft-S,Web Host
 kreativemachinez.tech,Kreative Machinez,Marketing
 kreonet.net,KREONET,Education
 kroger.com,The Kroger Co,Retail
 kronoz.co.jp,kronos,MSP
 kryptronic.com,Kryptronic,SaaS
+krystal.uk,Krystal Hosting,Web Host
+ks.ac.kr,Kyungsung University,Education
 ksc.net,KSC,Web Host
 ksmship.com,Korea Eco Management,Logistics
 ksu.tj,Khujand State University,Education
@@ -4213,6 +4682,7 @@ ktis.net,Kingdom Networks,ISP
 ktk-sol.co.jp,KtK Solutions,Email Security
 ktnet.co.kr,Korea Trade Network,Government
 ktnet.kg,Кыргызтелеком,ISP
+ktpae.gr,KtP Greek Information Society,Government
 ktrn.rw,KT Rwanda,ISP
 ktu.edu,Kaunas University of Technology,Education
 ku.ac.th,Kasetsart University,Education
@@ -4225,9 +4695,12 @@ kursktelecom.ru,Kursktelecom,ISP
 kusunoki-hp.com,Kusunoki Hospital,Healthcare
 kutztown.edu,Kutztown University,Education
 kvant-telecom.ru,Kvant-Telecom,ISP
+kvchosting.com,KVCHosting,Web Host
 kvhasia.com,KVH Asia,ISP
+kvidex.ru,Kvidex Telecom,ISP
 kw.ac.kr,Kwangwoon University,Education
 kwaoo.com,K-NET (Kwaoo),ISP
+kwikom.com,KwiKom Communications (Gateway Fiber),ISP
 kyberio.com,Kyberio,Web Host
 kyivstar.ua,Kyivstar,ISP
 kylos.pl,Kylos,Web Host
@@ -4242,21 +4715,29 @@ la.net.ua,Lanet,ISP
 labcorp.com,Labcorp,Healthcare
 laboratoires-thea.fr,Laboratoires Théa,Healthcare
 laca.org,Licking Area Computer Association,Nonprofit
+laceibanetsociety.com,Laceibanetsociety,ISP
 lacoe.edu,Los Angeles County Office of Education,Education
 lacoste.com,Lacoste,Retail
 lacounty.gov,Los Angeles County,Government
 ladwp.com,LADWP Los Angeles Department of Water and Power,Utilities
 lafayette.edu,Lafayette College,Education
 lagoon.nc,Lagoon New Caledonia,ISP
+lakeheadu.ca,Lakehead University,Education
+lakelandnetworks.com,Lakeland Networks,ISP
 lakeregionfiber.com,Lake Region Technology,ISP
 lakotanetwork.com,CRST Telephone Authority (Lakota Network),ISP
 lamar.edu,Lamar University,Education
 lamrc.com,Lam Research,Manufacturing
+lan.ua,LocalNet Obolon (Aslanua),ISP
 lancastergeneralhealth.org,Penn Medicine Lancaster General Health,Healthcare
+lancom.gr,Lancom Greece,ISP
+lancronix.ru,Lancronix,ISP
 lane.edu,Eugene School District 4J,Education
 lanet.ua,Lanet,ISP
+langate.ua,Langate Chernivtsi,ISP
 lankacom.net,Lanka Communication Services,ISP
 lanl.gov,Los Alamos National Laboratory,Government
+lanline.com,LANline Communications,MSP
 lanoptic.ru,LAN-Optic,ISP
 lanset.com,Lanset America,ISP
 lanta-net.ru,LanTa,ISP
@@ -4266,6 +4747,8 @@ larkinhealth.com,Larkin Health System,Healthcare
 larkinhospital.com,Larkin Health System,Healthcare
 larrycomputerguy.com,Larry The Computer Guy,MSP
 larus.net,LARUS,ISP
+lasalle.edu,La Salle University,Education
+lasotel.fr,LASOTEL,ISP
 lasvegas.net,LasVegas.Net,ISP
 latech.edu,Louisiana Tech University,Education
 latineve.co.jp,LATIN EVE,Retail
@@ -4277,7 +4760,10 @@ latrobe.edu.au,La Trobe University,Education
 latvenergo.lv,Latvenergo,Utilities
 laurentian.ca,Laurentian University,Education
 lauruslabs.com,Lasarus Labs,Healthcare
+lausd.net,Los Angeles Unified School District,Education
 lawtendo.com,Lawtendo,Legal
+layerhost.com,LayerHost,Web Host
+layerstack.com,LayerStack,Web Host
 lazernet.com.br,Lazernet,ISP
 lb.go.gov.br,Government of Goias State Brasil,Government
 lbl.gov,Lawrence Berkeley National Laboratory,Government
@@ -4296,12 +4782,14 @@ leadergpu.com,LeaderGPU,IaaS
 leadpages.co,Leadpages,Marketing
 leadsystemsmarketing.com,Lead Systems Marketing,Marketing
 leaguelineup.com,LeagueLineup,Sports
+leapswitch.com,Leapswitch Networks,Web Host
 leaptel.com.au,Leaptel,ISP
 learn.ac.lk,Lanka Education and Research Network,Education
 learn.k12.ct.us,LEARN Connecticut,Education
 learningstream.com,Learning Stream,SaaS
 leaseweb.ca,Leaseweb,Web Host
 leaseweb.com,Leaseweb,Web Host
+leeschools.net,Lee County Schools Florida,Education
 leftor.ba,Leftor,Web Host
 leftor.com,Leftor,Web Host
 legenditsolutions.com,Legend IT Solutions,Web Host
@@ -4317,6 +4805,7 @@ lepida.net,Lepida,ISP
 lestetelecom.com.br,Leste,ISP
 letaba.net,Letaba Networks,ISP
 letsrev.com,REV,ISP
+leucom.ch,Leucom,ISP
 level-7.co.za,Level 7 Internet,ISP
 level3.com,Lumen,ISP
 level3.net,Lumen,ISP
@@ -4384,6 +4873,7 @@ link.net.pk,Jazz,ISP
 link.net.ua,Link Telecom Ukraine,ISP
 link11.com,Link11,Email Security
 link3.net,Link3 Technologies,ISP
+linkbermuda.com,Link Bermuda,ISP
 linkbrasil.net.br,Link Brasil,ISP
 linkedin.com,LinkedIn,Social Media
 linkfire.com.br,Linkfire Telecom,ISP
@@ -4394,8 +4884,10 @@ linksul.com.br,LinkSul,ISP
 linkt.fr,Linkt,ISP
 linode.com,Linode,Web Host
 linodeusercontent.com,Linode,Web Host
+linq.net.br,LinQ Telecomunicacoes,ISP
 linqtelecom.com.br,LinQ Telecom,ISP
 lintasarta.net,Lintasarta,ISP
+lintelco.net,Lintelco (Coastal Telco),ISP
 linxtelecom.com,CITIC Telecom CPC,ISP
 linzag-telekom.at,LINZ AG TELEKOM,ISP
 linznet.at,LinzNet,ISP
@@ -4413,6 +4905,7 @@ litiumdrift.se,Litium,SaaS
 litnet.lt,LITNET Lithuanian Research and Education Network,Education
 liu.edu,Long Island University,Education
 liu.se,Linköpings universitet,Education
+livas.lv,Livas,ISP
 live-servers.net,Fasthosts Internet Ltd,Web Host
 live-website.com,IONOS,Web Host
 live.com,Outlook (Personal and Microsoft 365),Email Provider
@@ -4424,6 +4917,7 @@ livenation.com,Live Nation,Entertainment
 liveoakfiber.com,LiveOak Fiber,ISP
 liveperson.net,LivePerson,SaaS
 liwest.at,LIWEST,ISP
+ljosleidarinn.is,Ljosleidarinn Iceland,ISP
 llnl.gov,Lawrence Livermore National Laboratory,Government
 lloydsbanking.com,Lloyds Banking Group,Finance
 lloydsbankinggroup.com,Lloyds Banking Group,Finance
@@ -4434,6 +4928,7 @@ lmi.net,LMi.net,ISP
 lmt.lv,LMT Latvia,ISP
 lmu.edu,Loyola Marymount University,Education
 ln.edu.hk,Lingnan University,Education
+lnc.com,Lincoln Financial,Finance
 lncc.br,LNCC Brazilian National Laboratory for Scientific Computing,Science
 loading.es,Loading,Web Host
 loblaw.ca,Loblaw,Retail
@@ -4471,13 +4966,17 @@ louisiana.gov,Louisiana Government,Government
 louisville.edu,University of Louisville,Education
 lounea.fi,Lounea,ISP
 lovelandpulse.com,Pulse Loveland,Utilities
+lovit.ru,Lovitel,ISP
 lowesthosting.com,Lowest Hosting,Web Host
 loyalty.com,LoyaltyOne,SaaS
+loyola.edu,Loyola University Maryland,Education
 lpages.co,Leadpages,Marketing
 lpcgov.org,La Plata County,Government
 lpn.co.th,L.P.N. Development PCL,Real Estate
 lpnet.com.br,Desktop Sigmanet,ISP
+lponet.fi,LPOnet,ISP
 lpusercontent.com,Leadpages,Marketing
+lrcommunications.com,LR Communications,ISP
 lrnetbandalarga.net.br,L & R Net,ISP
 lrz.de,LRZ,Education
 lsnetworks.net,Lightspeed Networks,ISP
@@ -4499,15 +4998,19 @@ lugtel.com,Lugansk Telephone Company,ISP
 lukoil-inform.ru,Lukoil-Inform,Industrial
 lumen.com,Lumen,ISP
 luminabroadband.com,Lumina Broadband,ISP
+luminatebroadband.com,Luminate Fiber,ISP
 lumison.net,Pulsant,Web Host
 lumos.net,Lumos,ISP
 lumosfiber.com,Lumos,ISP
 lumosnetworks.com,Lumos,ISP
+lunarnaut.com,Lunarnaut,Web Host
 lusfiber.net,LUS Fiber,ISP
 luxoft.com,Luxoft,Consulting
 luxsci.com,LuxSci,Email Security
+luz.edu.ve,Universidad del Zulia,Education
 lwlcom.net,LWLcom,ISP
 lws-hosting.com,LWS,Web Host
+lwsd.org,Lake Washington School District,Education
 lxcluster.at,LXCluster,Web Host
 lycatel.com,Lyca Group,ISP
 lycorp.co.jp,LY Corporation,SaaS
@@ -4535,6 +5038,7 @@ macrx.com,MAC Rx,Healthcare
 macstadium.com,MacStadium,Web Host
 mada.ps,Mada,ISP
 maddock.net,Maddock Films,Entertainment
+madgenius.com,Madgenius,Web Host
 maersk.com,Maersk,Logistics
 maestroit.com,Maestro IT Services,MSP
 maffin.ad.jp,"MAFF (Japan Ministry of Agriculture, Forestry and Fisheries)",Government
@@ -4546,6 +5050,8 @@ magnetplus.ie,Magnet Plus,ISP
 magnite.com,Magnite,Marketing
 magnoliarental.com,Magnolia Rental,Retail
 magticom.ge,Magticom,ISP
+mahaska.org,Mahaska Communication Group MCG,ISP
+mahidol.ac.th,Mahidol University,Education
 mail.baby,Mail Baby,Email Security
 mail.com,Mail.com,Email Provider
 mail.mil,Mail.mil,Government
@@ -4594,6 +5100,8 @@ man-da.de,MANDA Darmstadt,Education
 managedns.org,IBM Cloud,IaaS
 managedway.com,ManagedWay,Web Host
 manchetelecom.fr,Manche Telecom,ISP
+mandarin.it,Mandarin,ISP
+mandic.com.br,Claranet (Mandic),Web Host
 mandrillapp.com,Mailchimp Transactional,SaaS
 mango.com.bd,Mango Teleservices Bangladesh,ISP
 manh.com,Manhattan,SaaS
@@ -4610,6 +5118,7 @@ marist.edu,Marist University,Education
 mark-itt.net,Point Internet,ISP
 mark-net.co.jp,Mark Co,Marketing
 mark.ru,OOO NI,ISP
+marktwain.net,Mark Twain Communications,ISP
 marlink.com,Marlink,MSP
 marquette.edu,Marquette University,Education
 marriott-service.com,Marriott,Travel
@@ -4617,10 +5126,12 @@ marriott.com,Marriott,Travel
 mars-inc.com,Mars,Food
 marsh.com,Marsh,Finance
 marshall.edu,Marshall University,Education
+marstonstelecoms.com,Marston's Telecoms,ISP
 martinsnet.com.br,Martins.Net,ISP
 marubeni.com,Marubeni,Conglomerate
 maruyamakai.jp,Maruyamakai,Healthcare
 maruyamakai.or.jp,Maruyamakai,Healthcare
+marwan.ma,Marwan CNRST Morocco,Education
 maryland.gov,State of Maryland,Government
 mas-meb.ru,МастерМебель,Retail
 masergy.com,Masergy (Comcast Business),ISP
@@ -4636,6 +5147,7 @@ massivenetworks.com,Massive Networks,ISP
 massresponse.com,Mass Response,SaaS
 master.cz,MasterDC,Web Host
 mastercabo.com.br,Master Cabo,ISP
+mastercard.com,Mastercard,Finance
 masterdatanet.com.br,Master Data Net,ISP
 masterdc.com,MasterDC,Web Host
 masterhost.ru,Master Host,Web Host
@@ -4652,11 +5164,13 @@ matrixglobal.net.id,Matrixnet,ISP
 matrixnetglobal.com,Matrixnet,ISP
 mauriziano.it,Ordine Mauriziano,Healthcare
 maxaninteirorsystems.com,Maxan Interior Systems,Industrial
+maxima.net.id,Maxima,ISP
 maximtech.com,Maximtech,Web Host
 maximuma.net,MaximumNet,ISP
 maximweb.com,Maxim Management Services,Healthcare
 maxindo.net.id,Maxindo Mitra Solusi,ISP
 maxis.com.my,Maxis,ISP
+maxnet.ir,Bozorg Net-e Aria Maxnet,ISP
 maxnet.ru,Maxnet Kaluga,ISP
 maxnet.ua,Maxnet,ISP
 maxxsouth.com,MaxxSouth Broadband,ISP
@@ -4665,6 +5179,7 @@ mayoclinic.com,Mayo Clinic,Healthcare
 mbari.org,Monterey Bay Aquarium Research Institute,Education
 mbcokinawa.net,MBC Okinawa,ISP
 mbonetworks.com,MBO Networks,ISP
+mc.net,helpdesk365 (McHenryCom),MSP
 mc.net.co,Media Commerce Partners,ISP
 mcat.co.jp,MCAT,ISP
 mccooknet.com,McCookNet,Web Host
@@ -4716,10 +5231,12 @@ mediacomcable.com,Mediacom,ISP
 mediacommerce.com.co,Media Commerce Partners,ISP
 mediafuze.com,Mediafuze,Marketing
 mediaprint.at,Mediaprint,Publishing
+mediasat.ro,Media Sat Romania,ISP
 mediasolutionsco.com,Media Solutions,Marketing
 mediasolutionscorp.com,Media Solutions,Marketing
 mediateknik.net,Mediateknik,Web Host
 mediaticanet.it,Mediatica,Web Host
+mediaveneto.com,Media Veneto,ISP
 medical-surveys.com,Medical Surveys,Healthcare
 medicalcomputersystems.com,Medical Computer Systems,Healthcare
 medicalsurveynews.com,Global Healthcare Research,Healthcare
@@ -4731,7 +5248,9 @@ medline.com,Medline,Healthcare
 medtronic.com,Medtronic,Healthcare
 meduniwien.ac.at,Medical University of Vienna,Education
 medweb.net,Medweb,Healthcare
+meeq.com,MEEQ,SaaS
 meerfarbig.net,meerfarbig,Web Host
+mega-com.ru,MegaCom-IT Novosibirsk,ISP
 mega-m.net,Mega M MegaTel,ISP
 mega.kg,Maga-Line,ISP
 mega.mx,Megacable,ISP
@@ -4751,6 +5270,9 @@ megamailservers.com,MegaMailServers,MSP
 megamailservers.eu,MegaMailServers,MSP
 meganetrj.com.br,Meganet,ISP
 megared.net.mx,Megared,ISP
+megaspace.de,Megaspace,Web Host
+megatelecom.com.br,SAMM Megatelecom,ISP
+megatruenet.com,Mega Truenet,ISP
 megavision.net.id,Megavision,ISP
 meghbelabroadband.com,Meghbela Broadband,ISP
 meijer.com,Meijer,Retail
@@ -4787,6 +5309,7 @@ messagelabs.com,Broadcom Enterprise Messaging Security,Email Security
 messagexchange.com,MessageeXchange,SaaS
 messagingengine.com,Fastmail,Email Provider
 mesvr.com,ReadNotify,Email Provider
+meta10.com,META10,IaaS
 metalink.net,MetaLINK Technologies,ISP
 metanet.co.kr,Metanet DT,MSP
 metasolutions.net,META Solutions,Education
@@ -4839,6 +5362,7 @@ microchip.com,Microchip Technology,Manufacturing
 microchip.net.pl,Microchip s.c.,ISP
 microfocus-japan.com,Micro Focus,MSP
 microfocus.com,Micro Focus (OpenText),SaaS
+microlinknet.com,Microlink Networks,ISP
 micron.com,Micron Technology,Manufacturing
 micron21.com,Micron21 Datacentre,Web Host
 micronet.in,MicroNet Gigafiber,ISP
@@ -4856,12 +5380,15 @@ midi-loisirs.com,Midi Loisirs,Entertainment
 midrivers.com,Mid-Rivers Communications,ISP
 midsouthfiber.com,MidSouth Fiber,ISP
 mie-u.ac.jp,Mie University,Education
+mifibra.pe,MiFibra Peru,ISP
 migadu.com,Migadu,Email Provider
 migracion.go.cr,Costa Rica Migration,Government
 migros.ch,Migros,Retail
 mihandns.com,Netmihan Communication,Web Host
+mikrocenter.com.br,Mikrocenter,Web Host
 mil.se,Swedish Armed Forces,Defense
 mila.is,Míla,ISP
+milcom.co.th,Milcom Thailand,ISP
 milkcratesdirect.com,FARMPLAST,Retail
 milleni.com.tr,Millenicom,ISP
 millerken.com,Milliken,Manufacturing
@@ -4869,6 +5396,7 @@ millersville.edu,Millersville University of Pennsylvania,Education
 millicom.com,Tigo,ISP
 milliken.com,Milliken,Manufacturing
 millipore.com,Millipore,Healthcare
+mills.edu,Mills College (Northeastern Oakland),Education
 milton.ca,Town of Milton,Government
 mimecast-offshore.com,Mimecast,Email Security
 mimecast.com,Mimecast,Email Security
@@ -4878,6 +5406,8 @@ mines.edu,Colorado School of Mines,Education
 minigraphics.net,Mini Graphics,Print
 miniserver.com,Memset,Web Host
 minnstate.edu,Minnesota State Colleges and Universities,Education
+miohost.net,Internet Invest (Miohost),Web Host
+mipt.ru,MIPT Moscow Institute of Physics and Technology,Education
 mir9.co.kr,Mir9,Marketing
 mirai.ne.jp,Mirai NET,ISP
 miralogic.ru,MiraLogic,ISP
@@ -4893,6 +5423,7 @@ mistral.co.uk,Nasstar,MSP
 mistral.net,Nasstar,MSP
 mit.edu,MIT,Education
 mitec.net,Mitec Solutions,MSP
+mitel.com,Mitel,SaaS
 mitene.co.jp,Mitene Internet,ISP
 mitre.org,MITRE,Nonprofit
 mitsubishielectric.co.jp,Mitsubishi Electric,Manufacturing
@@ -4913,9 +5444,13 @@ mkt2527.com,Acoustic,Marketing
 mktdns.com,Marketo,Marketing
 mkto-ab070093.com,Adobe Marketo,Marketing
 mktomail.com,Marketo,Marketing
+mky.com,Mackay Telecommunication,ISP
+mld.id,Media Lintas Data,ISP
 mlec.com,Meriwether Lewis Electric Cooperative,ISP
 mlems.ca,Middlesex-London Paramedic Service,Healthcare
 mlps.ca,Middlesex-London Paramedic Service,Healthcare
+mls.com.br,MLS Wireless,ISP
+mls.nc,MLS New Caledonia,ISP
 mma.com.br,MMA Fibra,ISP
 mmm.com,3M,Technology
 mmprovedor.com.br,MM Telecom,ISP
@@ -4936,7 +5471,9 @@ mobily.com.sa,Mobily,ISP
 mobinet.mn,Mobinet Mongolia,ISP
 mobinil.com,Orange Egypt,ISP
 mobinnet.net,Mobinnet,ISP
+mobitel.lk,SLT Mobitel,ISP
 mobtelecom.com.br,Mob Telecom,ISP
+moc.edu,University of Mount Olive,Education
 modeldrug.com,Model Health Care,Healthcare
 modenesegastone.com,Modenese Gastone,Retail
 modis.com,AKKODiS,Staffing
@@ -4982,6 +5519,7 @@ morroonline.com.br,Morro Telecom,ISP
 mosaictelecom.com,Mosaic Technologies,ISP
 moselletelecom.fr,Moselle Télécom,ISP
 mostobene.com,Mostobene,Healthcare
+motenasu-hosting.biz,NHN Cloud Japan (Motenasu),Web Host
 motivtelecom.ru,Motiv,ISP
 motorola.com,Motorola,Technology
 mounet.com,MouNet,ISP
@@ -4997,28 +5535,37 @@ movistar.com.sv,Movistar El Salvador,ISP
 movistar.com.uy,Tigo,ISP
 movistar.es,Movistar,ISP
 movitel.co.mz,Movitel,ISP
+mowry.com.br,Mowry (Tascom),ISP
+moxrox.com,MoxRox Cloud,Web Host
 mpg.de,Max-Planck-Gesellschaft,Science
 mpi-iq.com,Al-Mansour,Healthcare
 mpsaz.org,Mesa Public Schools,Education
+mpschools.org,Minneapolis Public Schools,Education
+mpw.org,Muscatine Power and Water,Utilities
 mpy.fi,MPY Telecom,ISP
 mrgdigital.com,MRG Digital,Marketing
 mrhc.org,Magnolia Regional Health Center,Healthcare
 mrhost.biz,MrHost,Web Host
 mrit.gov.pl,Polish Ministry of Development and Technology,Government
 mrse.com.ar,Telefonica de Argentina,ISP
+msctv.ca,Mitchell Seaforth Cable TV,ISP
 msd-consulting.co.za,MSD Consulting,Finance
 mserwis.pl,MSERWIS,Web Host
 msfiber.net,Mainstream Fiber Networks,ISP
 msfibra.com.br,MS Fibra,ISP
 msgexch.com,Constant Contact,Marketing
+msh.de,MSH Medien System Haus,MSP
+msitelekom.pl,MSI Telekom,ISP
 msk-ix.ru,MSK-IX,ISP
 mskcc.org,Memorial Sloan Kettering Cancer Center,Healthcare
 msoe.edu,Milwaukee School of Engineering,Education
 mssm.edu,Icahn School of Medicine at Mount Sinai,Education
 msstate.edu,Mississippi State University,Education
 mst.edu,Missouri University of Science and Technology,Education
+mstelcom.co.ao,MSTelcom Angola (Sonangol),ISP
 msu.edu,Michigan State University,Education
 msu.ru,Moscow State University,Education
+mt-opticom.com,Montana Opticom,ISP
 mt.net,Montana Internet,ISP
 mta.info,MTA New York,Government
 mtaroutes.com,N-able,Email Security
@@ -5064,6 +5611,8 @@ muenchen.de,City of Munich,Government
 mufg.jp,MUFG,Finance
 multacom.com,MULTACOM,Web Host
 multi.net.pk,Multinet Pakistan,ISP
+multicare.org,MultiCare Health System,Healthcare
+multikom.at,xLINK (Multikom),ISP
 multimedia.pl,Multimedia Polska,ISP
 multiplay.pl,Multiplay Poland,ISP
 multipolar.co.id,Multipolar Technology,MSP
@@ -5081,6 +5630,7 @@ musfiber.com,Morristown Utilities (MUS Fiber),Utilities
 mutualofomaha.com,Mutual of Omaha,Finance
 muvnet.com.br,Muvnet Telecom,ISP
 mvd.ru,Ministry of Internal Affairs of Russia,Government
+mvnu.edu,Mount Vernon Nazarene University,Education
 mvps.net,MVPS,Web Host
 mwainternet.com.br,MWA Internet,ISP
 mweb.co.za,MWEB,ISP
@@ -5098,6 +5648,7 @@ myaisfibre.com,AIS Fibre,ISP
 myanmaposts.net.mm,Myanma Posts and Telecommunications,ISP
 mybluehost.me,Bluehost,Web Host
 mybluepeak.com,Bluepeak,ISP
+mycentra.ru,MyCentra,ISP
 myctgs.com,CTG Server,Web Host
 mydataknox.com,MyDataKnox,Web Host
 mydatto.com,Datto,MSP
@@ -5129,6 +5680,7 @@ mynet.it,MyNet,ISP
 mynextlight.com,Longmont NextLight,Utilities
 mypremieronline.com,Premier Communications,ISP
 myradweb.net,Rad Web Hosting,Web Host
+myrasecurity.com,Myra Security,Email Security
 myrdbx.io,Raidboxes,Web Host
 myregisteredsite.com,web.com,Web Host
 myrepublic.co.id,MyRepublic,ISP
@@ -5162,7 +5714,9 @@ mythic-beasts.com,Mythic Beasts,Web Host
 mywhc.ca,Web Hosting Canada,Web Host
 mywkt.net,WK&T West Ky Networks,ISP
 myworkday.com,Workday,SaaS
+mzrta.ru,RTA Svyaz,ISP
 n4telecom.com.br,N4 Telecom,ISP
+n963.com,N963,ISP
 na4u.ru,Netangles,Web Host
 nab.com.au,National Australia Bank,Finance
 nabthat.com,Nabthat,SaaS
@@ -5179,22 +5733,26 @@ namehero.net,NameHero,Web Host
 names.co.uk,names.co.uk (Team Blue),Web Host
 nameserver.sk,Webglobe,Web Host
 namespro.ca,Namespro,Web Host
+namibia.com.na,Republic of Namibia Government,Government
 nannugroup.com,Nannu Group,Conglomerate
 nano.lv,nano.lv,Web Host
 nano.uz,Nano Telecom,ISP
 nao.ac.jp,National Astronomical Observatory of Japan,Education
 nap.net.tw,Taiwan Network Access Point,ISP
 napinfo.co.id,NAP Info Indonesia,ISP
+naracom.hu,Naracom,ISP
 nasa.gov,NASA,Government
 nasboces.org,Nassau BOCES,Education
 nascoeducation.com,Nasco EDucation,Education
 nasdaq.com,Nasdaq,Finance
+nashnet.ua,Nashnet Ukraine,ISP
 nashville.gov,Nashville Davidson County,Government
 nask.pl,NASK,Education
 nasonline.org,National Academy of Sciences,Education
 nasstar.com,Nasstar,MSP
 nastech.bg,Nastech Plus,ISP
 natcom.com.ht,Natcom Haiti,ISP
+natcoweb.com,NatCoWeb,Web Host
 natecorp.com,NATE Communications,ISP
 nationalgeneral.com,National General (Allstate),Finance
 nationalhha.com,National Home Health,Healthcare
@@ -5209,6 +5767,7 @@ nau.edu,Northern Arizona University,Education
 naukanet.ru,Nauka-Svyaz,ISP
 navayuga.com,Navayuga,Industrial
 navega.com,Navega Guatemala,ISP
+navegalo.com,Navegalo Costa Rica,ISP
 naver.com,Naver,Search Engine
 navercorp.com,Naver,Technology
 naviexp.jp,NaviExp,MSP
@@ -5226,6 +5785,7 @@ nc.gov,State of North Carolina,Government
 ncbs.res.in,National Centre for Biological Sciences,Education
 ncell.com.np,Ncell,ISP
 nchc.org.tw,National Center for High-performance Computing,Government
+nckcn.com,NCKCN North Central Kansas Community Network,ISP
 ncr.com,NCR,Technology
 ncsl.ca,Northern Computer Solutions,MSP
 ncsu.edu,NC State University,Education
@@ -5251,17 +5811,20 @@ need-link-eng.co.jp,Need Link Engineering,Technology
 needles.co.kr,Tae Chang Industrial,Healthcare
 neencloud.it,NEEN,MSP
 negabaritika.ru,Negabaritika,Logistics
+nemont.com,Nemont,ISP
 neo-fiber.net,NeoFiber Communications,ISP
 neoclan.net,Neoclan Networks,ISP
 neoclan.net.mx,Neoclan Networks,ISP
 neocomisp.com,NeocomISP,ISP
 neocomisp.com.kh,NeocomISP Cambodia,ISP
+neonova.net,NeoNova,ISP
 neosnetworks.com,Neos Networks,ISP
 neotechprovedor.com.br,NeoTech,ISP
 neotel.co.za,Neotel,ISP
 neotel.mk,Neotel North Macedonia,ISP
 neovia.com.br,Neovia Solutions,ISP
 neovision.de,NEOVISION,Marketing
+nep.net,NEP North-Eastern Pennsylvania Telephone,ISP
 nephronpharm.com,Nephon,Healthcare
 nepustil.net,nepustil.net,ISP
 neric.org,Northeastern Regional Information Center,Education
@@ -5281,6 +5844,7 @@ netactuate.com,NetActuate,Web Host
 netage.jp,NETAGE,ISP
 netaki.com.br,Net Aki,ISP
 netanswer.fr,Eudonet,SaaS
+netapp.com,NetApp,Manufacturing
 netatonce.se,Net at Once,ISP
 netbox.cz,NETBOX,ISP
 netcabo.pt,NOS,ISP
@@ -5291,6 +5855,7 @@ netceu.com.br,TURBO 10 Telecom,ISP
 netcol.com.br,Netcol,ISP
 netcologne.de,NetCologne,ISP
 netcom-bw.de,NetCom BW,ISP
+netcom-group.fr,Netcom France,ISP
 netcom-kassel.de,Netcom Kassel,ISP
 netcom-r.ru,NetCom-R,ISP
 netcomafrica.com,Netcom Africa,ISP
@@ -5314,10 +5879,12 @@ nethinks.com,NETHINKS,MSP
 nethosting.com,NetHosting,Web Host
 netia.pl,Netia,ISP
 netifox.com,NETIFOX,ISP
+netinnovation.net,Net Innovation,ISP
 netinternet.tr,NetInternet,Web Host
 netiz.net.br,Netiz,ISP
 netlify.app,Netlify,PaaS
 netlify.com,Netlify,PaaS
+netline.net,Netline,ISP
 netlink.com.ar,Netlink,ISP
 netmaismg.com.br,Net Mais,ISP
 netmaispalmas.com.br,NetMais Telecom,ISP
@@ -5337,6 +5904,7 @@ netplus.ch,Net+,ISP
 netplus.co.in,Netplus Broadband,ISP
 netplusfr.net,netplusFR,ISP
 netpluz.asia,Netpluz Asia,ISP
+netprotect.ro,Netprotect MSP,MSP
 netrax.pl,Netrax,ISP
 netregistry.com.au,NetRegistry HELP,Web Host
 netregistry.net,Netregistry,Web Host
@@ -5370,7 +5938,9 @@ netventure.pl,Netventure,MSP
 netvigator.com,HKT,ISP
 netvisao.pt,NOWO Communications,ISP
 netvision.net.il,013 Netvision,ISP
+netvisit.nl,Netvisit,ISP
 netway.com.ar,Netway,ISP
+netwo.io,Netwo,SaaS
 network-host.net,Network-host,Web Host
 network-tech.com,Network Technologies International (NTI),SaaS
 network.kz,network.kz,ISP
@@ -5378,10 +5948,12 @@ network.lviv.ua,Network-Lviv,ISP
 network80.com,Network80,Web Host
 networkip.net,NetworkIP,ISP
 networknebraska.net,Network Nebraska,Government
+networkplatforms.co.za,Network Platforms ZA,ISP
 networksolutions.com,Network Solutions,Web Host
 networktransit.net,Network Transit,ISP
 networthtelecom.fr,Networth Telecom,ISP
 netzquadrat.de,netzquadrat,Web Host
+neu-medianet.de,fitflat (neu-medianet),ISP
 neu.edu,Northeastern University,Education
 neubox.com,Neubox,Web Host
 neubox.net,Neubox,Web Host
@@ -5389,6 +5961,7 @@ neuca.pl,NECUA Group,Healthcare
 neunet.com.ar,Neunet,ISP
 neustarsecurityservices.com,Vercara (Neustar Security Services),Email Security
 neutraldata.com,Neutral Data Centers,Web Host
+neuviz.net.id,Neuviz Net,ISP
 nevada.edu,Nevada System of Higher Education,Education
 nevalink.net,Nevalink,ISP
 new-life.com,New Life,Retail
@@ -5417,13 +5990,17 @@ nexeon.com,Nexeon,IaaS
 nexg.net,KX NexG,ISP
 nexicom.net,Nexicom,ISP
 nexlinx.net.pk,Nexlinx,ISP
+nexon.com,Nexon,Entertainment
 nexon.com.au,Nexon Asia Pacific,MSP
 nexstar.tv,Nexstar Media,News
 nexsul.net.br,Nexsul Conectividade,ISP
 next-gen.ro,NextGen,ISP
+nextconnex.com,Wifinity (NextConnex),ISP
 nexteratech.co,NexTeraTech,MSP
 nextgen.net,NextGen.Net,SaaS
 nextgentel.no,NextGenTel,ISP
+nextglobalservices.com,NextGlobalServices,ISP
+nexthop.com.au,Nexthop Australia,ISP
 nexthop.no,Nexthop,Web Host
 nextlayer.at,Next Layer,ISP
 nextlinkinternet.com,Nextlink,ISP
@@ -5431,10 +6008,12 @@ nextnet.pe,Nextnet Peru,ISP
 nextnetworks.net,NextNetworks,MSP
 nextpertise.nl,Nextpertise,ISP
 nexttelecom.net.br,Next Internet,ISP
+nexusds.com,NEXUSDS,ISP
 nexusguard.com,Nexusguard,Email Security
 nforce.com,NForce Entertainment,Web Host
 nfshost.com,NearlyFreeSpeech.NET,Web Host
 nftctelecom.com,NFTC North Frontenac Telephone,ISP
+nfx.cz,NFX czFree eXchange,ISP
 ngblunetworks.nl,NGBLU Networks,ISP
 ngenix.net,NGENIX,SaaS
 ngloba.com,Ngloba Devices,MSP
@@ -5458,12 +6037,14 @@ nicmail.ru,RU-CENTER,Email Provider
 nicnet.com.br,Nicnet,ISP
 nict.go.jp,NICT,Government
 niels-stensen-kliniken.de,Marienhospital Osnabrück,Healthcare
+nielseniq.com,NielsenIQ,SaaS
 nifs.ac.jp,National Institute for Fusion Science,Education
 nifty.com,@nifty,Web Host
 nigcomsat.gov.ng,NIGCOMSAT,Government
 nih.gov,National Institutes of Health,Government
 nihon-u.ac.jp,Nihon University,Education
 niigata-u.ac.jp,Niigata University,Education
+nike.com,Nike,Retail
 nikhef.nl,Nikhef,Science
 nikkei.co.jp,Nikkei,News
 nimsite.uk,Nimbus Hosting,Web Host
@@ -5474,9 +6055,11 @@ nip.io,nip.io,SaaS
 nipbr.com,NipBr Telecom,ISP
 nipbr.com.br,NipBr (NipCable),ISP
 nir-telecom.ru,NIR-Telecom,ISP
+nirai.ne.jp,OCN Okinawa Cable Network,ISP
 nissan.co.jp,Nissan,Automotive
 nist.gov,National Institute of Standards and Technology,Government
 nisz.hu,National Infocommunications Service Company,Government
+nita.gov.gh,NITA National Information Technology Agency Ghana,Government
 nitelusa.com,Comcast,ISP
 nititancommercial.com,Niti Tan Commercial,Industrial
 nitrado.net,Nitrado (marbis),Web Host
@@ -5491,6 +6074,7 @@ nkn.gov.in,National Knowledge Network,Education
 nktelco.com,NKTELCO,ISP
 nktelco.net,NKTELCO,ISP
 nktele.com,NkTelecom,Web Host
+nktv.info,Novonet (NKTV),ISP
 nlighten.com,nLighten,Web Host
 nls.kz,NLS Kazakhstan,ISP
 nmsu.edu,New Mexico State University,Education
@@ -5521,6 +6105,7 @@ nokia.com,Nokia,Technology
 nolegia.net,Nolegia,Web Host
 nomaden.tv,Nomaden TV,Travel
 nomotech.com,Nomotech,ISP
+nomura.com,Nomura,Finance
 nonstoponline.com,Starnet,ISP
 noor.net,Noor Group,ISP
 nordic.tel,Nordic Telecom,ISP
@@ -5540,6 +6125,7 @@ northcdatacenters.ch,NorthC Datacenters,Web Host
 northcdatacenters.com,NorthC Datacenters,Web Host
 northcentralelectric.com,Northcentral Electric Cooperative,Utilities
 northeastern.edu,Northeastern University,Education
+northerndata.de,Northern Data,IaaS
 northland.net,Northland Communications,ISP
 northlandcable.com,Vyve Broadband (Northland Cable),ISP
 northropgrumman.com,Northrop Grumman,Defense
@@ -5627,13 +6213,18 @@ nuro.jp,NURO Biz,ISP
 nus.edu.sg,National University of Singapore,Education
 nusa.net.id,Nusanet,ISP
 nusanet.id,Nusanet,ISP
+nuskin.com,Nu Skin,Retail
+nutritionclub.ca,Nutrition Club Canada,Retail
 nuvancehealth.org,Nuvance Health,Healthcare
 nuvera.net,Nuvera Communications,ISP
 nuveramail.net,Nuvera,Email Provider
+nuxt.cloud,Nuxt Cloud (International Hosting Company),Web Host
 nvc.net,Northern Valley Communications,ISP
 nvidia.com,Nvidia,Manufacturing
 nvtel.com.br,NovaNet,ISP
 nw027.com,Poppulo (Formerly Newsweaver),SaaS
+nwewn.com,Bluebox Broadband (Broadband NI),ISP
+nwic.ca,NWIC Niagara Wireless,ISP
 nwinetworks.com,NWINetworks,MSP
 nwtel.ca,Northwestel,ISP
 nwu.ac.za,North-West University,Education
@@ -5644,10 +6235,14 @@ nyc.gov,City of New York,Government
 nychealthandhospitals.org,NYC Health + Hospitals,Healthcare
 nychhc.org,NYC Health + Hospitals,Healthcare
 nycm.com,NYCM Insurance,Finance
+nycourts.gov,New York State Unified Court System,Government
 nycu.edu.tw,National Yang Ming Chiao Tung University,Education
 nyi.net,NYI,Web Host
+nyit.edu,New York Tech,Education
 nyp.org,NewYork-Presbyterian,Healthcare
+nypd.org,New York City Police Department,Government
 nysed.gov,New York State Education Department,Government
+nysernet.com,NYSERNet,Education
 nysif.com,New York State Insurance Fund,Government
 nyspta.org,New York State PTA,Nonprofit
 nyu.edu,New York University,Education
@@ -5659,6 +6254,8 @@ o2bs.sk,O2 Business Services Slovakia,ISP
 o2dc.com,Perviy TSOD (O2DC),Web Host
 oakland.k12.mi.us,Oakland Schools,Education
 oakwood.org,Oakwood Healthcare,Healthcare
+oar.net,OARnet,Education
+oati.com,OATI Open Access Technology International,SaaS
 oauife.edu.ng,Obafemi Awolowo University,Education
 oaxaca.gob.mx,Government of Oaxaca,Government
 obe.net,Obenet (Obehosting),ISP
@@ -5671,7 +6268,9 @@ oblak.host,Oblak Host,Web Host
 obninsk.com,CentrTelecom Kaluga,ISP
 oboi1.ru,Oboi no1,Retail
 obosnett.no,OBOS Nett,ISP
+ocalafl.gov,Ocala Fiber Network,ISP
 occtoplus.com.br,Occtoplus,SaaS
+ocde.us,Orange County Department of Education,Education
 oce.ne.jp,Osaki Computer Engineering,ISP
 oceanviewfunding.com,Ocean View Funding,Finance
 ociris.com,Ociris (G-Portal),Web Host
@@ -5688,7 +6287,9 @@ oderland.com,Oderland,Web Host
 odessa.tv,Sana Plus (Renome-Service),ISP
 odido.nl,Odido,ISP
 odn.ad.jp,ODN Asahi Kasei Networks,ISP
+odn.de,ODN OnlineDienst Nordbayern,Web Host
 odoo.com,Odoo,SaaS
+ods.vn,ODS,IaaS
 odu.edu,Ohio Dominican University,Education
 oecfiber.com,OEC Fiber,ISP
 oekb.at,Oesterreichische Kontrollbank,Government
@@ -5707,12 +6308,16 @@ okayama-u.ac.jp,Okayama University,Education
 okstate.edu,Oklahoma State University,Education
 okta.com,Okta,SaaS
 okvirtual.com.br,Ok Virtual,ISP
+ole.net.br,Ole Fibra,ISP
 oleane.fr,Oleane,ISP
 oleanwebhosting.com,Olean Web Hosting,Web Host
 olemiss.edu,University of Mississippi,Education
+olsztyn.net.pl,University of Warmia and Mazury Olsztyn,Education
+olypen.com,OlyPen,ISP
 omantel.om,Omantel,ISP
 omeda.com,Omedia,Marketing
 omeganetworks.com,Omega Networks Texas,ISP
+omegaplus.cz,OMEGA Plus Chrudim,ISP
 omegatech.cz,Nordic Telecom,ISP
 ometria.com,Ometria,Marketing
 ometria.email,Ometria,Marketing
@@ -5725,6 +6330,8 @@ omninet.co.nz,OmniNet,ISP
 omnis.com,Omnis,Web Host
 omniscient.com,Omniscient Technologies,Technology
 omnistep.com,OmniStep Incorporated,ISP
+omnitel.biz,OmniTel,ISP
+omu.org,Owensboro Municipal Utilities,Utilities
 on-web.fr,Planet-Work,Web Host
 onamae.ne.jp,GMO Internet,Web Host
 onastra.fr,SES Astra,ISP
@@ -5767,9 +6374,11 @@ online.tj.cn,China Unicom,ISP
 onlineagency.com,Online Agency,SaaS
 onlinehome-server.info,IONOS,Web Host
 onlinenetgo.com.br,Online Net Go,ISP
+onlinenw.com,Online Northwest,ISP
 onlinetelecomip.net.br,Online Telecom,ISP
 onlycable.es,Onlycable,ISP
 onnet21.com,LG Uplus,ISP
+onnetmais.com.br,OnNet Telecomunicacoes,ISP
 onnettelecom.com.br,OnNet Telecomunicações,ISP
 ono.com,Vodafone Ono,ISP
 onrender.com,Render,PaaS
@@ -5780,6 +6389,7 @@ ontash.com,Ontash & Ermac,Industrial
 onthenet.com.au,On The Net,ISP
 onvif.org,Onvif,Technology
 onx.com,OnX,MSP
+oocl.com,OOCL,Logistics
 ooma.com,Ooma,ISP
 oops.net.br,Oops Telecom,ISP
 ooredoo.com.kw,Ooredoo,ISP
@@ -5795,6 +6405,8 @@ openfiber.it,Open Fiber,ISP
 opentext.com,OpenText,SaaS
 opentransit.net,Orange,ISP
 openwave.ai,Openwave Messaging,Email Provider
+opera.com,Opera,SaaS
+opiquad.com,Opiquad (Southern Broadband),ISP
 opnet.it,OpNet (WindTre),ISP
 oppd.com,Omaha Public Power District,Utilities
 opt.nc,OPT-NC New Caledonia,ISP
@@ -5807,11 +6419,14 @@ optimum.com,Optimum,ISP
 optimum.net,Optimum,ISP
 optimus.si,Optimus IT d.o.o.,MSP
 optimusmedia.com,Optimus Media,Marketing
+optinet.bg,Optinet (Diana Net),ISP
 optipub.com,OptiPub,Publishing
+optisprint.net,5KOM (Optisprint),ISP
 optix.pk,Optix Pakistan,ISP
 optonline.net,Optimum,ISP
 optus.com.au,Optus,ISP
 optus.net.au,Optus,ISP
+oquei.net.br,Oquei Telecom,ISP
 oracle.com,Oracle,Technology
 oraclecloud.com,Oracle Cloud,IaaS
 oraclon.com.br,Oraclon,ISP
@@ -5821,6 +6436,7 @@ orange.be,Orange,ISP
 orange.bf,Orange,ISP
 orange.ci,Orange,ISP
 orange.cm,Orange Cameroun,ISP
+orange.co.bw,Orange Botswana,ISP
 orange.co.il,Partner,ISP
 orange.com,Orange,ISP
 orange.es,Orange,ISP
@@ -5860,6 +6476,7 @@ ose.gov.pl,OSE Polish National Education Network,Government
 oser.com,Oser Comunications Group,Marketing
 oshean.org,OSHEAN,Education
 osir.net.br,Osirnet,ISP
+osirnet.com.br,Osirnet,ISP
 oskolnet.ru,Osknolnet,ISP
 oslo.kommune.no,City of Oslo,Government
 osn.de,OSN Online Service,Web Host
@@ -5878,6 +6495,7 @@ oticasmarilia.com.br,Óticas Marília,Healthcare
 otnet.co.jp,OTNet,ISP
 otsuka-shokai.co.jp,Otsuka Shokai,MSP
 ottcmail.com,Ontario & Trumansburg Telephone Companies,ISP
+ottctel.com,GoNetspeed (OTTC),ISP
 ou.edu,University of Oklahoma,Education
 ourcommons.ca,Parliament of Canada House of Commons,Government
 ourinet.com.br,Ourinet,ISP
@@ -5925,6 +6543,7 @@ packetfabric.co.jp,PacketFabric Japan,ISP
 packetfabric.com,PacketFabric,ISP
 packethub.net,PacketHub,IaaS
 pactiv.com,Novolex (Pactiv),Manufacturing
+padi.net.id,PadiTech (PadiNet),ISP
 pahsco.com.tw,Pacific Hospital Supply,Healthcare
 pair.com,Pair Networks,Web Host
 pair.net,Pair Networks,Web Host
@@ -5937,6 +6556,7 @@ paltel.ps,Paltel,ISP
 panasonic.com,Panasonic,Technology
 panelserver.biz,panelserver.biz,ISP
 panelvps.net,PanelBox,Web Host
+pangea-group.net,Pangea Connected,ISP
 pangolin.com,Pangolin Laser,Entertainment
 panix.com,Panix,ISP
 panola.com,Complete Computers,MSP
@@ -5947,12 +6567,17 @@ pantheonsite.io,Pantheon,Web Host
 pantherex.com,Pantherex,Consulting
 papaki.com,Papaki,Web Host
 papaki.gr,Papaki,Web Host
+paperspace.com,DigitalOcean Paperspace,IaaS
 paperworks.com,Paperworks,Retail
 paradisenetworks.net,Paradise Networks,ISP
 paragould.com,Paragould Municipal Utilities,ISP
 paragould.net,Paragould Municipal Utilities,ISP
 paratus.africa,Paratus Telecom,ISP
+parisat.hu,PARISAT,ISP
+paritel.fr,Paritel,ISP
+parkerbroadband.net,Parker Broadband,ISP
 parkerinstitute.org,Parker Jewish Institute for Healthcare & Rehabilitation,Healthcare
+parkregion.com,Park Region Telephone,ISP
 parlament.gv.at,Austrian Parliament,Government
 parliament.gh,Parliament of Ghana,Government
 parsleysage.net,.ParsleySage Guest House,Travel
@@ -5966,6 +6591,7 @@ pasteur.fr,Institut Pasteur,Science
 patagoniaip.cl,Patagonia IP,ISP
 pathcom.com,Pathway Communications,MSP
 patmos.tech,Patmos,Web Host
+patxkj.com,Shenzhen Ping An Communication,ISP
 paubox.com,Paubox,Email Security
 paulbunyan.net,Paul Bunyan Communications,ISP
 pausd.org,Palo Alto Unified School District,Education
@@ -5980,6 +6606,7 @@ paypal.com,PayPal,Finance
 pbcgov.com,Palm Beach County,Government
 pbiaas.com,INOS,Web Host
 pbs.edu.pl,Politechnika Bydgoska,Education
+pbx-change.com,KUDUCOM,ISP
 pca.az,PASHA Capital,Finance
 pcc.in.th,President Chemical,Manufacturing
 pccw.com,PCCW,ISP
@@ -6020,9 +6647,11 @@ perenso.com,Perenso,Marketing
 perfectip.net,Perfect International,Web Host
 perfora.net,IONOS,Web Host
 performive.com,CloudFirst,Web Host
+perftech.si,Perftech Slovenia,MSP
 perimeterwatch.com,PerimeterWatch,MSSP
 personal.com.py,Personal Paraguay,ISP
 peteralan.co.uk,Peter Alan,Real Estate
+petitjeanfiber.com,Petit Jean Fiber,ISP
 petrobras.com.br,Petrobras,Industrial
 petroed.com,PetroEd,Education
 petronas.com,Petronas,Industrial
@@ -6033,6 +6662,7 @@ pfizer.com,Pfizer,Healthcare
 pfmsys.com,Professional Flight Management (PFM),Logistics
 pfnllc.net,Peninsula Fiber Network,ISP
 pg.com,Procter & Gamble,Manufacturing
+pg19.ru,PG-19,ISP
 pgcps.org,Prince George's County Public Schools,Education
 pge.com,PG&E,Utilities
 ph.net,PHNet Philippine Network Foundation,Education
@@ -6040,6 +6670,7 @@ phaselayer.com,Private Layer,Web Host
 phibee-telecom.net,Phibee Telecom,ISP
 phila.gov,City of Philadelphia,Government
 philasd.org,School District of Philadelphia,Education
+philcom.com,Philcom,ISP
 phmgmt.com,PhMgmt VyprVPN,Web Host
 phoenix-c.or.jp,Phoenix Communications Japan,ISP
 phoenixnap.com,phoenixNAP,Web Host
@@ -6056,6 +6687,7 @@ pima.edu,Pima Community College,Education
 pima.gov,Pima County Arizona,Government
 pindc.ru,Pindc Petersburg Internet Network,ISP
 pine-net.com,Pine Telephone,ISP
+pineland.net,Pineland Telephone Cooperative,ISP
 pinellascounty.org,Pinellas County,Government
 pink.co.rs,Mink Media Group,Marketing
 pinnaclecart.com,PinnacleCart,SaaS
@@ -6067,14 +6699,19 @@ pioneer.co.th,Pioneer Transportation,Logistics
 pioneer.net,Pioneer Connect,ISP
 pip.com.au,PIP Total IT Solutions,Web Host
 pipefy.com,Pipefy Inc,SaaS
+piranha.co.kr,Piranha Systems,Web Host
 pirxnet.pl,PirxNet,ISP
 pishgaman.net,Pishgaman,ISP
 pitchile.cl,PIT Chile,ISP
 pitt.edu,University of Pittsburgh,Education
+pittsburghpa.gov,City of Pittsburgh,Government
 pius-hospital.de,Pius-Hospital Oldenburg,Healthcare
 pixeledges.com,Pixel Edges Technologies,Marketing
+pj24.ir,Pishgaman Jonoub,ISP
 pknu.ac.kr,Pukyong National University,Education
 plala.or.jp,Plala,ISP
+planeetta.net,Planeetta,Web Host
+planet-ic.de,Planet IC,IaaS
 planet.net,Planet Networks,ISP
 planetel.it,Planetel,ISP
 planetfiber.com.br,Planet Fiber,ISP
@@ -6089,13 +6726,16 @@ play-internet.pl,Play,ISP
 play.pl,Play,ISP
 play2go.cloud,Play2Go,Web Host
 playbackmail.com,PlayBackMail,Email Provider
+playnet.it,Playnet,ISP
 playstation.com,Sony PlayStation,Entertainment
 playtech.ee,Playtech,Entertainment
 pldi.net,Pioneer Cellular,ISP
 pldt.com,PLDT,ISP
+pldt.com.ph,PLDT Home,ISP
 pldt.net,PLDT,ISP
 pldthome.com,PLDT,ISP
 plesk.page,Plesk,Web Host
+plinq.nl,PLINQ,ISP
 plis.net.br,Plis Telecom,ISP
 plniconplus.co.id,PLN Icon Plus,MSP
 plugartelecom.net.br,Plugar Telecom,ISP
@@ -6115,14 +6755,17 @@ pmcon.net,Premium Connectivity,ISP
 pmt.org,Project Mutual Telephone Cooperative,ISP
 pmweb.com.br,pmweb,Marketing
 pnc.com,PNC Bank,Finance
+pnpt.com,Pinpoint Fiber,ISP
 pobox.com,Pobox,Email Provider
 pocketinet.com,PocketiNet,ISP
 poda.cz,PODA,ISP
+podryad.tv,Podryad Vladivostok,ISP
 podzone.net,DynDNS,Web Host
 podzone.org,DynDNS,Web Host
 pogozone.com,PogoZone,ISP
 poig.ru,POIG (Schelkovo-net),ISP
 point-broadband.com,Point Broadband,ISP
+poka.com,Poka Lambro Telecommunications,ISP
 pol-online.com,Bangladesh Online,ISP
 pol.ir,ParsOnline,ISP
 polisen.se,Swedish Police,Government
@@ -6158,14 +6801,17 @@ posta.rs,Pošta Srbije (Serbian Post),Logistics
 postcodesoftware.co.uk,Postcode Software,SaaS
 postdanmark.dk,Post Danmark,Logistics
 postech.edu,Pohang University of Science and Technology,Education
+potato.ne.jp,Asahikawa Cable Television,ISP
 potsdam.edu,SUNY Potsdam,Education
 poupnet.com.br,Triunfo Fibra (Poupnet),ISP
 power1.com,PowerOne,MSP
+powereng.com,WSP (Power Engineers),Consulting
 powergrid.in,Powergrid Teleservices India,ISP
 powerline.hk,Power Line Datacenter,IaaS
 powertech.psi.br,Power Tech Telecom,ISP
 pox.com.br,Pox Network Telecomunicações,ISP
 poxley.com.br,Poxley,ISP
+poznan.pl,Poznan PSNC,Science
 ppe-hosted.com,Proofpoint Essentials,Email Security
 ppg.com,PPG Industries,Manufacturing
 pphosted.com,Proofpoint,Email Security
@@ -6178,7 +6824,9 @@ premierdc.com.tr,PremierDC,Web Host
 prempub.com,Premier Publishing,Marketing
 previder.com,Previder,Web Host
 prgmr.com,Tornado VPS,Web Host
+primacom.com,Primacom Indonesia,ISP
 primed-halberstadt.de,Primed Halberstadt,Healthcare
+primenet.in,Primesoftex,Web Host
 primetel.com.cy,PrimeTel,ISP
 primetelecom.ro,Prime Telecom Romania,ISP
 primorye.ru,Rostelecom,ISP
@@ -6202,21 +6850,30 @@ proagentwebsites.com,ProAgent Websites,Real Estate
 probe-networks.de,Probe Networks,Web Host
 procergs.rs.gov.br,PROCERGS Rio Grande do Sul,Government
 procopa.dk,Procopa IT,MSP
+prodeb.ba.gov.br,Prodeb Bahia,Government
+prodemge.gov.br,PRODEMGE Minas Gerais,Government
+prodepa.pa.gov.br,PRODEPA Para,Government
 proderj.rj.gov.br,PRODERJ Rio de Janeiro,Government
 prodesp.sp.gov.br,Prodesp,Government
 prodocom.com.au,Prodocom,SaaS
 produccion.gob.ec,Ecuador Ministry of Production,Government
 proen.co.th,PROEN,Web Host
 profitserver.ru,Profitserver,Web Host
+progressive.com,Progressive Insurance,Finance
 prohosting.com,ProHosting,Web Host
+proline.net.ua,Proline TM,ISP
+prolocation.net,Prolocation,Web Host
 promax.media.pl,Promax,ISP
+promtele.com,Promtelecom Donetsk,ISP
 prontomarketing.com,Pronto Marketing,Marketing
 proofhubmail.com,ProofHub,SaaS
 proofpoint.com,Proofpoint,Email Security
 propersupportmedia.com,Proper Support Media,Web Host
 prophase.es,Prophase Telecom,ISP
+proquest.com,ProQuest,SaaS
 prosites.com,ProSites,Web Host
 prosodie.com,Odigo,SaaS
+prosodie.es,Prosodie Iberica,MSP
 prospect.pl,Prospect,ISP
 proton.ch,Proton,Email Provider
 proton.me,Proton,Email Provider
@@ -6231,24 +6888,29 @@ provedortechnet.com.br,Technet Networks,ISP
 proveminas.com.br,Prime Fibra,ISP
 proventainternational.com,Proventa International,Healthcare
 proverlink.com.br,Provelink Telecom,ISP
+providerdienste.de,Bradler and Krantz Providerdienste,Web Host
 providers.com.ar,Experon (Providers),ISP
 proxad.net,Free,ISP
 proximus.com,Proximus,ISP
 proximus.lu,Proximus,ISP
 proxxima.net,PROXXIMA,ISP
+prtcnet.org,Peoples Rural Telephone Cooperative,ISP
 prtcom.ru,Pokrovsky Radiotelefon,ISP
 prtelecom.hu,PR-TELECOM,ISP
 prudential.com.sg,Prudential Singapore,Finance
 prudentpublishing.com,Prudent Publishing,Retail
 prvepa.com,PearlComm,ISP
 prw.net,Puerto Rico Webmasters,Web Host
+prz.edu.pl,Rzeszow University of Technology,Education
 ps.kz,PS Cloud Services,Web Host
 psc.edu,Pittsburgh Supercomputing Center,Education
+pscfiber.net,Perry-Spencer Communications PSC Fiber,ISP
 psdschools.org,Poudre School District,Education
 pserver.space,Profitserver,Web Host
 pskovline.ru,Pskovline,ISP
 pslightwave.com,PS Lightwave,ISP
 psn.co.id,Pasifik Satelit Nusantara,ISP
+psnc.pl,Poznan Supercomputing and Networking Center,Science
 pspinc.com,Pacific Software Publishing,Web Host
 psu.edu,Penn State,Education
 psychz.net,Psychz Networks,Web Host
@@ -6274,6 +6936,7 @@ pulsetv.com,Pulse TV,Retail
 puntonet.ec,Puntonet,ISP
 purbanigroup.com,Purbani Group,Manufacturing
 purdue.edu,Purdue University,Education
+purepeak.com,Purepeak,IaaS
 purevoltage.com,PureVoltage Hosting,Web Host
 purplecowinternet.com,Purple Cow Internet,ISP
 purtel.com,PURtel,ISP
@@ -6281,6 +6944,7 @@ pusan.ac.kr,Pusan National University,Education
 pvamu.edu,Prairie View A&M University,Education
 pvt.com,Penasco Valley Telecommunications,ISP
 pwc.com,PwC,Consulting
+pwc.com.au,PwC Australia,Consulting
 pwtinternet.com.br,PWT Internet,ISP
 pwuhui.com.tw,Perfect Medical,Healthcare
 pxc.co.uk,TalkTalk,ISP
@@ -6288,6 +6952,7 @@ pythonanywhere.com,PythonAnywhere,SaaS
 pyur.com,PŸUR,ISP
 qantas.com,Qantas,Travel
 qantas.com.au,Qantas,Travel
+qatar.net.qa,Qatar Telecom (Ooredoo),ISP
 qbeyond.de,q.beyond,MSP
 qcell.gm,Qcell Gambia,ISP
 qcell.sl,QCell Sierra Leone,ISP
@@ -6298,6 +6963,7 @@ qhoster.net,QHoster,Web Host
 qindiafund.com,Q India Fund,Finance
 qinetiq.com,QinetiQ,Defense
 qingcloud.com,QingCloud,IaaS
+qis.net,Quantum Internet and Telephone,ISP
 qlix.com.br,Qlix,Web Host
 qmul.ac.uk,Queen Mary University of London,Education
 qnsal.cn,Qn-Solar,Manufacturing
@@ -6315,7 +6981,10 @@ qualcomm.com,Qualcomm,Manufacturing
 quality-network.eu,QualityNetwork,ISP
 qualtrics.com,Qualtrics,SaaS
 quantcom.cz,Quantcom,ISP
+quantum.com,Quantum,Manufacturing
 quantum.net.id,Quantum Tera Network,ISP
+quartztelecom.ru,Quartz Telecom,ISP
+quattre.com,Quattre Internet,ISP
 quattrocom.mx,QuattroCom,ISP
 queensu.ca,Queen's University,Education
 questforum.org,Telecommunications Industry Association,Industrial
@@ -6336,6 +7005,8 @@ race.com,Race Communications,ISP
 race.net.bd,Race Online,ISP
 rack400.com,Rack400,Web Host
 rackdog.com,Rackdog,IaaS
+rackend.com,SwissHosting (Rackend Panaglobal),Web Host
+rackforest.com,RackForest,Web Host
 rackhost.hu,Rackhost,Web Host
 racklodge.com,Rack Lodge,Web Host
 rackmaze.com,Rackmaze,Web Host
@@ -6346,17 +7017,21 @@ racsa.co.cr,RACSA,ISP
 radarinternet.com.br,Radar Internet,ISP
 radford.edu,Radford University,Education
 radiant.net,TELUS,ISP
+radiantbd.com,Radiant Communications Bangladesh,ISP
 radiantsolutions.net,Radient Solutions,Web Host
+radio-canada.ca,Radio-Canada (CBC),Government Media
 radiocom.ro,Radiocom Romania,ISP
 radius-net.com,Radius-NET,ISP
 radore.com,Radore,Web Host
 radware.com,Radware,Email Security
 rafftechnologies.com,Raff Technologies,Web Host
 ragingwire.com,NTT Global Data Centers Americas (RagingWire),Web Host
+rai.it,RAI Italian Public Broadcasting,Government Media
 railtelindia.com,RailTel Corporation of India,ISP
 rain.co.za,Rain,ISP
 rainbowchemicals.ae,Rainbow Chemicals,Manufacturing
 rainbowisp.in,Rainbow Communications India,ISP
+rainbowtel.net,Rainbow Communications,ISP
 rainfocus.com,RainFocus,SaaS
 rainierconnect.com,Lightcurve (Rainier Connect),ISP
 raiolanetworks.com,Raiola Networks,Web Host
@@ -6373,7 +7048,9 @@ randomhouse.com,Penguin Random House,Publishing
 range.net,Range Internet,ISP
 ranksitt.net,Ranks ITT,MSP
 rapeedo.net.br,Rapeedo,ISP
+rapid-shield.com,Rapid Shield,Web Host
 rapidscale.net,RapidScale,Web Host
+rapidsys.com,Rapid Systems,ISP
 raschig.de,Raschig,Manufacturing
 ratiokontakt.de,Ratiokontakt,ISP
 rawbandwidth.com,Raw Bandwidth Communications,ISP
@@ -6401,8 +7078,10 @@ readthedocs-hosted.com,Read the Docs,SaaS
 readthedocs.com,Read the Docs,SaaS
 readthedocs.io,Read the Docs,SaaS
 real-net.pro,Real-net,ISP
+real.su,REAL Astrakhan,ISP
 realconnect.com,RealConnect,Web Host
 realnet.kg,Realnet,ISP
+reannz.co.nz,REANNZ NZ Research and Education Network,Education
 rebelnetworks.com,Rebel Networks,Web Host
 recast-it.com,recast IT,Web Host
 reconn.ru,Reconn,ISP
@@ -6419,17 +7098,23 @@ redecompunet.com.br,Rede Compunet,ISP
 redeconesul.com.br,Rede Conesul,ISP
 redeconexaonet.com.br,Rede ConexãoNet,ISP
 redeg2.com.br,G2 (Rede G2),ISP
+redehost.com.br,Umbler (RedeHost),Web Host
 redemineira.com.br,Rede Mineira Telecomunicações,ISP
+redenilf.com.br,Redenilf,ISP
 redeplanetanet.com.br,Planeta Net Telecom,ISP
 rederio.br,Rede-Rio,Education
 redesiminternet.com.br,Sim Fibra,ISP
+redestel.net,Redestel Networks,ISP
+redetelecom.com.br,Vero (Rede Telecom),ISP
 redetuxnet.com.br,Tuxnet,ISP
 redexpertos.com,RedExpertos,Web Host
 redfoxtelecom.com.br,Redfox Telecom,ISP
+rediff.com,Rediff,News
 rediffmailpro.com,Rediffmail Pro,Email Provider
 redirection.net,Redirectionet,Web Host
 redirectme.net,No-IP,Web Host
 rediris.es,RedIRIS,Education
+redit.com,IP Matrix (Redit),ISP
 rednesp.br,rednesp,Education
 redtailtechnology.com,Redtail Technology,SaaS
 redtone.com,REDtone,ISP
@@ -6443,6 +7128,7 @@ reg365.net,register365,Web Host
 regentbranding.co.uk,Regent Branding,Marketing
 regery.net,Regery,Web Host
 regiomed-kliniken.de,Sana Kliniken Oberfranken,Healthcare
+region16.net,Region 16 ESC Amarillo,Education
 regionaltelecom.net.br,Regional Telecom,ISP
 regiondemurcia.es,Region de Murcia,Government
 regione.toscana.it,Regione Toscana,Government
@@ -6468,8 +7154,10 @@ renal-md.com,Renal-MD,Healthcare
 renater.fr,RENATER,Education
 render.com,Render,PaaS
 renet.ru,Renet Com,ISP
+rentarack.no,Nexthop (RentaRack),Web Host
 renu.ac.ug,RENU,Education
 reportjourneyus.com,Report Journey US,News
+req.ro,ReQ (RoSite),ISP
 resa.net,Wayne County RESA,Education
 respina.net,Respina Networks,ISP
 responselogix.com,Digital Air Strike,Marketing
@@ -6480,9 +7168,13 @@ retn.net,RETN,ISP
 retn.ru,RETN Russia,ISP
 reuna.cl,REUNA,Education
 reverse-mundo-r.com,R Cable y Telecomunicaciones,ISP
+reynosord.com,Reynoso Internet,ISP
 reyrey.com,Reynolds and Reynolds,SaaS
 reytel.hn,Reytel Honduras,ISP
+rezocean.fr,REZOCEAN,ISP
+rfc.pl,RFC Internet Poland,ISP
 rftkabel.de,RFT Kabel,ISP
+rgcommunications.in,RG Communications India,ISP
 rge.com,Rochester Gas and Electric,Utilities
 rh-tec.de,rh-tec,Web Host
 rhcloud.com,Red Hat OpenShift,PaaS
@@ -6491,6 +7183,7 @@ rhein-it.de,RHEN IT,MSP
 rhnet.is,RHnet,Education
 rhsolutions.ca,RH Solutions,Web Host
 ri.gov,State of Rhode Island,Government
+ria.ee,Estonia Information System Authority,Government
 riberasaludmail.com,Ribera Salud,Healthcare
 rice.edu,Rice University,Education
 richmond.edu,University of Richmond,Education
@@ -6505,11 +7198,17 @@ rijksoverheid.nl,Government of the Netherlands,Government
 rijkswaterstaat.nl,Rijkswaterstaat,Government
 riken.jp,RIKEN,Science
 rikkyo.ac.jp,Rikkyo University,Education
+ril.com,Reliance Industries,Conglomerate
 rima-tde.net,"TELEFONICA, S.A.",ISP
+rimex-ltd.com,Rimex,ISP
 rimon.net.il,Internet Rimon,ISP
+ringcentral.com,RingCentral,SaaS
 ringsquared.com,RingSquared,ISP
 ringstad.no,Ringstad Consulting,MSP
+riotel.com.ar,Riotel Rio Tercero,ISP
 riotgames.com,Riot Games,Entertainment
+ripe.net,RIPE NCC,Nonprofit
+ripplefiber.com,Ripple Fiber,ISP
 risd.org,Richardson Independent School District,Education
 riseinternet.com,Rise Internet,ISP
 risetelecoms.co.za,Rise Telecoms,ISP
@@ -6519,6 +7218,7 @@ rit.edu,Rochester Institute of Technology,Education
 ritsumei.jp,Ritsumeikan University,Education
 ritternet.com,Ritter Communications,ISP
 riu.edu.ar,ARIU Argentine University Network,Education
+rjf.com,Raymond James Financial,Finance
 rm.com,RM Education,Education
 rmc.ca,Royal Military College of Canada,Education
 rminet.com.br,RM Informática,ISP
@@ -6534,17 +7234,22 @@ rockcom.co,Rockman Communications,ISP
 rockefeller.edu,The Rockefeller University,Education
 rockenstein.de,Rockenstein,Web Host
 rocketsoftware.com,Attachmate (Rocket Software),Technology
+rockisland.com,Rock Island Communications,ISP
 rockwellcollins.com,Collins Aerospace,Defense
 rodenyc.com,RODE Advertising,Marketing
 roedu.net,RoEduNet,Education
 rogers.com,Rogers,ISP
 rogerscapital.mu,Rogers Capital Mauritius,MSP
 roguevalleyurology.com,Rogue Valley Urology,Healthcare
+roketelkom.co.ug,Roke Telkom Uganda,ISP
+romarg.ro,ROMARG,Web Host
 rootlayer.net,RootLayer LTD.,Web Host
 ropa.de,ropa,Web Host
 rose-hulman.edu,Rose-Hulman Institute of Technology,Education
+roseville.mi.us,City of Roseville Michigan,Government
 rosintel.com,Rosintel,ISP
 rosnet.ru,OJSC Rosnet,ISP
+ross.com,Abbott (Ross Products),Healthcare
 rossoxweb.it,RossoXweb,MSP
 rostelecom.com.br,ROS Telecom,ISP
 rostelecom.ru,Rostelecom,ISP
@@ -6553,6 +7258,7 @@ router12.net,Router12 Networks,ISP
 routit.nl,RoutIT,ISP
 rowan.edu,Rowan University,Education
 royalehosting.net,RoyaleHosting,Web Host
+royalfloraholland.com,Royal FloraHolland,Agriculture
 rpi.edu,Rensselaer Polytechnic Institute,Education
 rpost.net,RPost,Email Security
 rptu.de,Rheinland-Pfalzische Technische Universitat,Education
@@ -6585,14 +7291,17 @@ rush.edu,Rush University,Education
 rusonyx.ru,Rysonyx Cloud,Web Host
 rutgers.edu,Rutgers University,Education
 ruukki.com,Ruukki SSAB,Manufacturing
+ruvds.com,RU VDS,Web Host
 rvurology.com,Rogue Valley Urology,Healthcare
 rwas.co.uk,Royal Welsh Agricultural Society,Agriculture
 rwth-aachen.de,RWTH Aachen University,Education
 rwts.com.au,Real World Technology Solutions,MSP
 rxlightning.com,RxLightning,Healthcare
+rybnet.pl,Rybnet,ISP
 ryoka.co.jp,Ryoka Denka Kasei,Manufacturing
 rzone.de,Strato AG,Web Host
 s-inform46.ru,Связьинформ (SvyazInform),ISP
+s-net.pl,S-NET,ISP
 sa-net.tj,Spitamen Alexander Internet,ISP
 saab.com,Saab,Defense
 saabgroup.com,Saab,Defense
@@ -6601,16 +7310,21 @@ sabyr.com,Sabyr Consulting,MSP
 sabyrconsulting.com,Sabyr Consulting,MSP
 saccounty.gov,Sacramento County,Government
 saccounty.net,Sacramento County,Government
+sachsen-gigabit.de,SachsenGigaBit,ISP
 sacredheart.edu,Sacred Heart University,Education
+sadv.co.za,SADV,ISP
 safari-productions.com,Safari Productions,Event Planning
 safaricom.co.ke,Safaricom,ISP
 safaricombusiness.co.ke,Safaricom,ISP
+safenames.net,Safenames,Web Host
 safeport.com,Safeport Network Services,Web Host
 safescreening.co.uk,The Access Group,SaaS
 safeway.com,Safeway,Retail
 safewebservices.com,NMI,SaaS
 sagenet.com,SageNet,MSP
+sagitta.dk,Sagitta,ISP
 sahara.com,Sahara Net,ISP
+sailinternet.com,Sail Internet,ISP
 sailthru.com,Sailthru,Marketing
 saimanet.kg,Saima Telecom,ISP
 saimatelecom.kg,Saima Telecom,ISP
@@ -6636,6 +7350,7 @@ samanage.com,SolarWinds Service Desk,SaaS
 samaralan.ru,SamaraLan,ISP
 samart.co.th,Samart Infonet,ISP
 samil-pharm.com,Samil,Healthcare
+sampo.ru,Sampo.ru Petrozavodsk,ISP
 samsa.com,SAMSA,MSP
 samsung.com,Samsung,Technology
 samsungsds.com,Samsung SDS,Technology
@@ -6650,6 +7365,7 @@ sanet.sk,SANET,Education
 sangchaimeter.com,Sangchai Meter,Industrial
 sangoma.com,Sangoma,SaaS
 sanjuan.edu,San Juan Unified School District,Education
+sanmina.com,Sanmina,Manufacturing
 sanofi.fr,Sanofi,Healthcare
 santa-barbara.ca.us,Santa Barbara County,Government
 santandergto.com,Santander Global Technology and Operations,Finance
@@ -6662,6 +7378,7 @@ saplbd.com,Summit Alliance Port,Logistics
 sapmed.ac.jp,Sapporo Medical University,Healthcare
 sapo.pt,SAPO,Email Provider
 sappa.se,Sappa,ISP
+sapphire.gi,Broadband Gibraltar (Sapphire),ISP
 saremail.com,SAREnet,ISP
 sarenet.es,Sarenet,ISP
 sargentlundy.com,Sargent and Lundy,Consulting
@@ -6692,11 +7409,13 @@ sbcglobal.net,AT&T,ISP
 sbcss.net,San Bernardino County Superintendent of Schools,Education
 sbin.bj,Celtiis (SBIN Benin),ISP
 sbn.co.th,Super Broadband Network,ISP
+sc.com,Standard Chartered,Finance
 sc.edu,University of South Carolina,Education
 sc.gov,South Carolina Government,Government
 scaladatacenters.com,Scala Data Centers,Web Host
 scalaxy.com,Scalaxy,IaaS
 scaledsystems.com,SimpleNet,Web Host
+scalematrix.com,ScaleMatrix,Web Host
 scaleuptech.com,ScaleUp Technologies,Web Host
 scaleway.com,Scaleway,Web Host
 scania.com,Scania,Manufacturing
@@ -6715,6 +7434,7 @@ schneider.com,Schneider National,Logistics
 schwab.com,Charles Schwab,Finance
 scinternet.net,South Central Communications,ISP
 scip.es,SCIP Soluciones Corporativas IP,ISP
+sciremc.com,SCI REMC,Utilities
 scis.gov.az,Special Communication Service of Azerbaijan,Government
 scjohnson.com,S.C. Johnson,Manufacturing
 scloud.sg,SCloud Singapore,IaaS
@@ -6728,6 +7448,8 @@ scrtc.com,South Central Rural Telecommunications Cooperative,ISP
 scrtc.net,South Central Rural Telecommunications Cooperative,ISP
 scs.co.kr,Seokyung Cable Television,ISP
 scsk.jp,SCSK,MSP
+sctcweb.com,SCTC Willamette Valley Internet,ISP
+scts.tv,Sakhalin Cable Telesystems,ISP
 sctv.com.vn,SCTV,ISP
 scu.edu,Santa Clara University,Education
 scw.cloud,Scaleway,IaaS
@@ -6737,6 +7459,7 @@ sdncommunications.com,SDN Communications,ISP
 sdsc.edu,San Diego Supercomputer Center,Education
 sdsmt.edu,South Dakota Mines,Education
 sdstate.edu,South Dakota State University,Education
+sdv.fr,SdV,Web Host
 seacom.co.za,SEACOM,MSP
 seacom.com,SEACOM,ISP
 sealbond.co.jp,Nippon Sealbond,Manufacturing
@@ -6770,7 +7493,9 @@ sedmultitel.it,SED Multitel,ISP
 seed.net.tw,Seednet,ISP
 seedshosting.jp,Seeds Hosting,Web Host
 seeweb.it,Seeweb,IaaS
+seflow.net,SeFlow,Web Host
 segasammy.co.jp,Sega Sammy,Entertainment
+segoviaip.com,Inmarsat (Segovia IP),ISP
 segra.com,Segra,ISP
 seicommunications.com,SEI Communications,ISP
 seinan-gu.ac.jp,Seinan Gakuin University,Education
@@ -6779,6 +7504,7 @@ sejong.ac.kr,Sejong University,Education
 sejongtelecom.net,Sejong Telecom,ISP
 selectel.com,Selectel,Web Host
 selectel.ru,Selectel,Web Host
+selectsystem.cz,SELECT SYSTEM,ISP
 selenebs.it,A2A Smart City,Utilities
 selfip.com,DynDNS,Web Host
 selfip.net,DynDNS,Web Host
@@ -6805,6 +7531,8 @@ sendio.com,Sendio,Email Security
 sendmetric.com,Sendmetric,Email Security
 sendnode.com,MAILINGWORK,Marketing
 sendoso.com,Sendoso,Marketing
+senecacollege.ca,Seneca Polytechnic,Education
+senko.digital,Senko Digital,ISP
 sensaphone.com,Sensaphone,SaaS
 senselan.ch,senseLAN,ISP
 sentara.com,Sentara,Healthcare
@@ -6812,6 +7540,7 @@ sentex.ca,Sentexx,ISP
 sentex.net,Sentex Communications,ISP
 sentia.com,Sentia,MSP
 seoul.go.kr,Seoul Metropolitan Government,Government
+sepanta.com,Sepanta Communication,ISP
 seqtek.net,SEQTEK,MSP
 sercomtel.com.br,Sercomtel,ISP
 serenitydayspaofmemphis.com,Serenity Day Spa,Beauty
@@ -6820,7 +7549,9 @@ serpro.gov.br,SERPRO,Government
 serrasultelecom.com.br,Serrasul,ISP
 serv-net.pl,Servcom,ISP
 serv.host,SERV.HOST,Web Host
+servarica.com,ServaRica,IaaS
 servconfig.com,InMotion Hosting,Web Host
+servcorp.com,Servcorp,SaaS
 serveblog.net,No-IP,Web Host
 servebolt.cloud,Servebolt,Web Host
 servebolt.com,Servebolt,Web Host
@@ -6861,12 +7592,17 @@ ses-astra.fr,SES Astra,ISP
 ses-stiftung.de,Schwester Euthymia Stiftung,Healthcare
 ses.com,SES (Formerly Intelsat),ISP
 setardsl.aw,SETAR,ISP
+setera.fi,Setera,SaaS
+setitagila.ru,Nizhnetagilskie Computer Networks,ISP
 seven-sky.net,Seven Sky,ISP
 sevennet.net,Goran Net (Sevennet),ISP
 severen.ru,Severen Telecom,ISP
 sevstar.net,Lancom,ISP
 sevtelecom.ru,Sevastopol Telecom,ISP
+sewan.be,Sewan Belgium,ISP
 sewan.fr,Sewan,ISP
+sewan.nl,Sewan Netherlands,ISP
+sewanee.edu,Sewanee University of the South,Education
 sewikom.de,sewikom,ISP
 sezampro.rs,Orion Telekom,ISP
 sf.gov,City and County of San Francisco,Government
@@ -6879,6 +7615,7 @@ sfu.ca,Simon Fraser University,Education
 sfusd.edu,San Francisco Unified School District,Education
 sfwmd.gov,South Florida Water Management District,Government
 sg.gs,SG.GS,ISP
+sgs.se,Goteborgs Studentbostader (SGS),Education
 sh.cz,SH.cz,Web Host
 sh27.com.br,SunHost,Web Host
 shabakah.com.sa,Shabakah Net,ISP
@@ -6888,18 +7625,23 @@ shamrog.com,Shamrog,Web Host
 shanxitele.com,China Telecom Shanxi,ISP
 share-international.us,Share International USA,Nonprofit
 shared-server.net,GMO Cloud,Web Host
+sharedsvcs.com,Block Line Systems,ISP
 sharehostserver.com,Sharehostserver,Web Host
 shareman.tv,Shareman,SaaS
 sharif.ir,Sharif University of Technology,Education
 sharktech.net,Sharktech,Web Host
+shastacoe.org,Shasta County Office of Education,Education
 shatel.ir,Shatel,ISP
 shaw.ca,Shaw,ISP
+shawu.edu,Shaw University,Education
 sheffieldpharma.com,Sheffield Pharmaceuticals,Healthcare
 shell.com,Shell,Industrial
 shentel.com,Shentel,ISP
+shenzhen.net.cn,Shenzhen Information and Network Center,Government
 sheridancollege.ca,Sheridan College,Education
 sherwin-williams.com,Sherwin-Williams,Retail
 sherwin.com,Sherwin-Williams,Retail
+shibaura-it.ac.jp,Shibaura Institute of Technology,Education
 shield.security,Mailprotector,Email Security
 shift4shop.com,Shift4Shop,SaaS
 shinbiro.com,Shinbiro,ISP
@@ -6931,11 +7673,13 @@ shuxun.net,Shanghai Data Solution,Web Host
 shyamgroup.org,Shyam Group,Conglomerate
 si.edu,Smithsonian Institution,Education
 siac.com,SIAC,Finance
+siait.si,siaIT,ISP
 sibset-team.ru,Sibirskie Seti,ISP
 sibset.ru,Sibirskie Seti,ISP
 sibyl.com,Sibl Design,MSP
 sickkids.ca,The Hospital for Sick Children,Healthcare
 siconect.com.br,Siconect,ISP
+siemens-healthineers.com,Siemens Healthineers,Healthcare
 siemens.com,Siemens,Industrial
 sierratel.com,Sierra Tel,ISP
 sifycorp.com,Sify,ISP
@@ -6956,6 +7700,8 @@ silknet.com,Silknet,ISP
 silpc.fr,SILPC,Healthcare
 silversky.com,Silversky,Email Security
 silverstar.com,Silver Star Communications,ISP
+silverstartelecom.com,Silver Star Telecom,ISP
+simbanet.co.ke,Simbanet Kenya,ISP
 simbanet.net,Simbanet Tanzania,ISP
 simcentric.com,Simcentric,Web Host
 simplesite.com,One.com,Web Host
@@ -6976,6 +7722,7 @@ sinergit.com.do,Sinergit,MSP
 sineris.net,Sineris,Web Host
 sinet.ad.jp,SINET,Education
 sinet.com.kh,SINET Cambodia,ISP
+sinet.ir,Sinet (Soroush Rasanheh),ISP
 sinfony6.com,Sinfony6,Web Host
 singingriver.com,Singing River Connect,Utilities
 singnet.com.sg,SingNet,ISP
@@ -6986,6 +7733,7 @@ siol.net,Telekom Slovenije,ISP
 sion.com,Sion Argentina,ISP
 sipartech.com,Sipartech,ISP
 siriuscom.com,Sirius (CDW),MSP
+siriustec.it,Sirius Technology Italy,ISP
 siriustelecom.uz,Sirius Telecom,ISP
 sita.aero,SITA,SaaS
 sita.co.za,SITA,Government
@@ -7021,14 +7769,17 @@ ski.net.id,PT Sumber Koneksi Indonesia,ISP
 skidmore.edu,Skidmore College,Education
 skku.edu,SungKyunKwan University,Education
 sknt.ru,Skynet,ISP
+sktc.net,Twin Valley (Southern Kansas Telephone),ISP
 sktelecom.com,SK Telecom,ISP
 sky.com,Sky,ISP
 sky.it,Sky,ISP
+skybandalarga.com.br,SKY Servicos de Banda Larga,ISP
 skybest.com,SkyLine SkyBest,ISP
 skybroadband.com,Sky,ISP
 skydsl.eu,skyDSL,ISP
 skydsl.it,skyDSL,ISP
 skyhighsecurity.com,Skyhigh Security,Email Security
+skyline.od.ua,Skyline Electronics Odesa,ISP
 skymail.com.br,Skymail,Email Provider
 skymesh.net.au,SkyMesh,ISP
 skynet.kg,Skynet Telecom,ISP
@@ -7036,7 +7787,9 @@ skynet.ru,Skynet,ISP
 skypoint.com,SkyPoint Communications,ISP
 skysdigital.net,SkyDigital,ISP
 skytv.co.nz,Sky NZ,Entertainment
+skywaywest.com,Skyway West,ISP
 sl-reverse.com,IBM Cloud,PaaS
+slav.dn.ua,Satellite Net Service Slavyansk,ISP
 slb.com,Schlumberger,Industrial
 slcc.edu,Salt Lake Community College,Education
 slgnt.eu,Selligent,Marketing
@@ -7058,13 +7811,16 @@ smartfren.com,Smartfren,ISP
 smarthost.pl,Smarthost,Web Host
 smartinternet.com.br,Smart Internet,ISP
 smartjobboard.com,Smartjobboard,SaaS
+smartkom.ru,Smartkom,ISP
 smartlinkfibra.com.br,Smartlink,ISP
+smartnet.kz,SmartNet Kazakhstan,ISP
 smartone.com,SmarTone,ISP
 smartservers.com.au,Hostopia Australia,Web Host
 smartspb.net,Smart Telecom,ISP
 smcjbz.nl,Jeroen Bosch Ziekenhuis,Healthcare
 smcjpn.co.jp,SMC Corporation,Manufacturing
 smcm.edu,St. Mary's College of Maryland,Education
+smgr.pl,Spoldzielnia Mieszkaniowa Grudziadz,ISP
 smile.com.bd,DBCOM Online,ISP
 smile.com.ng,Smile,ISP
 smileserv.com,Smileserv,Web Host
@@ -7073,12 +7829,14 @@ smithbucklin.com,Smithbucklin,Consulting
 smithville.com,Smithville Fiber,ISP
 smoltelecom.ru,Smoltelecom,ISP
 sms-teleport.com,SMS Teleport,ISP
+smsdatacenter.com,SMS Datacenter,MSP
 smsmasivos.com.ar,SMS Masivos,SaaS
 smsnet.pl,SMSnet,ISP
 smtp.com,SMTP.com,SaaS
 smtp.cz,Active24,Web Host
 smtp25.com,Zix,Email Security
 smtp2go.com,SMTP2GO,SaaS
+smu.ac.kr,Sangmyung University,Education
 smu.edu,Southern Methodist University,Education
 snafu.de,snafu,Web Host
 snapengage.com,SnapEngage,SaaS
@@ -7086,6 +7844,7 @@ snapfiles.com,SnapFiles,Technology
 snc.edu,St. Norbert College,Education
 sncc.co.kr,SNC Korea,Manufacturing
 snet.com,SNET,ISP
+snowd.com,Snowd Security VPN,SaaS
 snowflake.app,Snowflake,SaaS
 snthostings.com,SnTHostings,Web Host
 snu.ac.kr,Seoul National University,Education
@@ -7095,6 +7854,7 @@ sobralnet.com.br,Sobralnet,ISP
 socgen.com,Societe Generale,Finance
 socialfive.com,Social5,Marketing
 socialservices-ssmd.ca,Social Services Sault Ste. Marie,Government
+societegenerale.com,Societe Generale,Finance
 socket.net,Socket,ISP
 soco.net,SOCO,ISP
 socoolsolution.com,So Cool Solution,MSP
@@ -7116,6 +7876,7 @@ soipl.co.in,Shree Omkar Infocom,ISP
 sojitz.com,Sojitz,Conglomerate
 soka.ac.jp,Soka University,Education
 sol.com.py,Sol Internet,ISP
+sol.net.in,Solana Biofuels,Industrial
 sola.uz,Sola,ISP
 solarwinds.com,SolarWinds Service Desk,SaaS
 solcon.nl,Solcon,ISP
@@ -7128,6 +7889,7 @@ soltia.es,Soltia,Web Host
 solutions.com.sa,STC,ISP
 solvinity.com,Solvinity,MSP
 somelec.mr,SOMELEC,Industrial
+somosinternet.co,Somos Internet Colombia,ISP
 somyatrans.com,Somya Translators,Consulting
 sonatel.com,Sonatel,ISP
 sonatel.sn,Sonatel,ISP
@@ -7143,10 +7905,12 @@ soon.com.ar,Red Intercable Digital,ISP
 sooner.com,Sooner Technology,ISP
 sophos.com,Sophos,Email Security
 sorbonne-universite.fr,Sorbonne Université,Education
+soskol.com,Osknoltelecom,ISP
 sosnc.gov,North Carolina Secretary of State,Government
 sougo-group.jp,Camcom Group,SaaS
 soui9.com.br,i9 Telecom,ISP
 soumaster.com.br,Master Internet,ISP
+southcentralconnect.net,South Central Connect,ISP
 southern-comms.co.uk,SCG (Southern Communications),ISP
 southernco.com,Southern Company,Utilities
 southerncompany.com,Southern Company,Utilities
@@ -7191,6 +7955,7 @@ spectranet.in,Spectra,ISP
 spectrum.com,Spectrum,ISP
 spectrum.net,Charter,ISP
 spectrumhealth.org,Corewell Health (Spectrum Health),Healthcare
+speedbone.de,Speedbone,Web Host
 speedcast.com,Speedcast,ISP
 speeddns.net.br,Speed Planet Telecomunicações,ISP
 speedmax.inf.br,SpeedMax,ISP
@@ -7232,6 +7997,7 @@ sprious.com,Sprious,Web Host
 sps.net.sa,Gulf Computer Services,ISP
 spt.vn,Saigon Postel,ISP
 sptel.com,SPTel,ISP
+spu.edu,Seattle Pacific University,Education
 square-enix.com,Square Enix,Entertainment
 square7.ch,bplaced,Web Host
 square7.de,bplaced,Web Host
@@ -7243,7 +8009,9 @@ srpnet.com,Salt River Project,Utilities
 srt.com,SRT Communications,ISP
 srtc.coop,Santa Rosa Telephone Cooperative,ISP
 srvape.com,Smart Ape LLC,Web Host
+ssa.gov,US Social Security Administration,Government
 ssc-spc.gc.ca,Shared Services Canada,Government
+ssc.net,Nordlo IP Group,MSP
 ssdcloudindia.net,E2E Networks,Web Host
 ssimicro.com,SSi Canada,ISP
 sslmda.com,Maxar Space (Space Systems Loral),Defense
@@ -7257,7 +8025,9 @@ stack.net,Stackster,ISP
 stackit.de,STACKIT (Schwarz),IaaS
 stackmail.com,20i,Web Host
 stacksdiscovery.com,Stacks,Web Host
+stadt-koeln.de,City of Cologne,Government
 stadtnetz-bamberg.de,Stadtnetz Bamberg,ISP
+stadtwerke-kapfenberg.at,Stadtwerke Kapfenberg,Utilities
 stadtwerke-kufstein.at,Stadtwerke Kufstein,Utilities
 stadtwerke-neumuenster.de,SWN Stadtwerke Neumünster,Utilities
 stadtwerke-neustrelitz.de,Stadtwerke Neustrelitz,Utilities
@@ -7316,6 +8086,7 @@ stc.com.sa,STC,ISP
 stcable.net,ST Cable,ISP
 stealth.net,Stealth Communications,ISP
 stellantis.com,Stellantis,Automotive
+stellarbb.com,STELLAR Broadband,ISP
 stellarllc.net,Gardonville Cooperative Telephone Association,ISP
 stelogy.com,Stelogy (VoIP Telecom),ISP
 stemconnect.net,Stem Connect,MSP
@@ -7328,9 +8099,11 @@ sti.net,Sierra Tel,ISP
 stibo.com,Stibo,SaaS
 stiegeler.com,Stiegeler Internet,ISP
 stil.dk,STIL Denmark,Government
+stillwaterschools.org,Stillwater Area Public Schools,Education
 stjansdal.nl,Hospital St Jansdal,Healthcare
 stjohns.edu,St. John's University,Education
 stjude.org,St. Jude Children's Research Hospital,Healthcare
+stkate.edu,St. Catherine University,Education
 stlawu.edu,St. Lawrence University,Education
 stnc.cn,Shanghai Science and Technology Network,ISP
 stnet.co.jp,STNet,ISP
@@ -7340,6 +8113,7 @@ stokes.nc.us,"Stokes County, North Carolina",Government
 stomabags.com,Stomabags.com,Healthcare
 stonybrook.edu,Stonybrook University,Education
 storesonlinepro.com,StoresOnline,SaaS
+storm.ca,Storm Internet Services,ISP
 stova.io,Stova,SaaS
 stpi.in,STPI,Government
 stranzit.ru,Связьтранзит (Stranzit),ISP
@@ -7360,6 +8134,7 @@ strongtechnology.net,StrongVPN,Web Host
 stsci.edu,Space Telescope Science Institute,Science
 stsnet.ro,Romanian Special Telecommunications Service,Government
 sttelcom.com,S and T Communications,ISP
+stthomas.edu,University of St. Thomas,Education
 stu.edu.gh,Sunyani Technical University,Education
 studio4web.com,Studio4Web,Web Host
 stv.ee,STV Estonia,ISP
@@ -7380,14 +8155,18 @@ summit-broadband.com,Summit Broadband,ISP
 summithealthcare.net,Summit Healthcare,Healthcare
 summithq.com,Summit,Web Host
 sumofiber.com,Sumo Fiber,ISP
+sums.ac.ir,Shiraz University of Medical Sciences,Education
 sunet.se,SUNET,Education
 sunfield.ne.jp,Sun Field Internet,ISP
 sungardas.com,11:11 Systems,MSP
+sunline.net.ua,Sunline Ukraine,ISP
+sunlink.ru,SunLink Telecom Tula,ISP
 sunnybrook.ca,Sunnybrook Health Sciences Centre,Healthcare
 sunnyvision.com,SunnyVision,Web Host
 sunrise.ch,Sunrise,ISP
 sunucun.com.tr,Sunucun,Web Host
 sunway.com.br,Sunway,ISP
+sunwire.ca,Sunwire,ISP
 suny.edu,State University of New York,Education
 sunyempire.edu,SUNY Empire State University,Education
 sunypoly.edu,SUNY Polytechnic Institute,Education
@@ -7415,10 +8194,13 @@ supersonic.net.br,Super Sonic Telecom,ISP
 suportinet.com.br,Suportinet,ISP
 supportedns.com,MDD Hosting,Web Host
 supranet.com.br,Supranet,ISP
+supranet.net,SupraNet,ISP
 sura.ru,Rostelecom,ISP
 suralink.com,Suralink,SaaS
 sure.com,Sure,ISP
+sureline.net,Sureline Communications,ISP
 sureserver.com,SureSupport LLC,Web Host
+suresupport.com,ICDSoft Suresupport,Web Host
 surf.nl,SURF,Education
 surfairwireless.com,Surf Internet,ISP
 surfer.at,T-Mobile,ISP
@@ -7429,6 +8211,7 @@ sv-en.ru,Svyaz-Energo,ISP
 sverigesradio.se,Sveriges Radio,News
 svn-repos.de,LCube,Web Host
 svorka.no,Svorka,ISP
+svsu.edu,Saginaw Valley State University,Education
 swan.sk,SWAN,ISP
 swarthmore.edu,Swarthmore College,Education
 swat.coop,Southwest Arkansas Telephone,ISP
@@ -7450,6 +8233,7 @@ switch.com,Switch,Web Host
 swn.net,SWN Stadtwerke Neumünster,Utilities
 swoop.com.au,Swoop,ISP
 swri.org,Southwest Research Institute,Education
+swu.de,SWU TeleNet,Utilities
 swyftfiber.com,Swyft Fiber,ISP
 sxbctv.com,Shaanxi Broadcast & TV Network,ISP
 sycwin.com,Sycwin Coating & Wires,Manufacturing
@@ -7470,6 +8254,7 @@ synchronoss.net,Synchronoss,SaaS
 syncontel.net.br,Syncontel Telecomunicações,ISP
 syndeonetwork.com,Syndeo Networks,ISP
 synergywholesale.com,Synergy Wholesale,Web Host
+syniverse.com,Syniverse,SaaS
 synlinq.de,Synlinq,Web Host
 synoptek.com,Synoptek,MSP
 syntax.com,Syntax,MSP
@@ -7507,16 +8292,22 @@ t-pbs.net,Pacnet Business Solutions,ISP
 t-systems.at,T-Systems,MSP
 t-systems.com,T-Systems,MSP
 t-systems.de,T-Systems,MSP
+t1-cloud.ru,T1 Cloud,IaaS
 t2.ru,T2 Mobile,ISP
+t3com.com,Verve (T3 Communications),ISP
+t72.ru,Russian Company Tyumen (T72),ISP
 tachc.org,Texas Association of Community Health Centers (TACHC),Healthcare
 tachus.com,Tachus Fiber,ISP
 tachyon.net.id,Tachyon,ISP
+tafjord.no,Tafjord Connect,ISP
 taifo.com.tw,TAIFO,ISP
 taipeinet.com.tw,TaipeiNet (Peicity Digital Cable Television),ISP
 taiwanmobile.com,Taiwan Mobile,ISP
+take2games.com,Take-Two Interactive,Entertainment
 take2hosting.com,Take 2 Hosting,Web Host
 takeda.com,Takeda,Healthcare
 takethemameal.com,Take Them A Meal,SaaS
+taknet.ir,Taknet,ISP
 takushoku-u.ac.jp,Takushoku University,Education
 tal.de,tal.de,Web Host
 talk-straight.com,Talk Straight,ISP
@@ -7534,18 +8325,23 @@ target.com,Target,Retail
 tarhely.eu,Tárhely.Eu,Web Host
 tarr.hu,Tarr,ISP
 tasfrance.com,ATSAT (Nubevia),ISP
+tasmanet.com.au,TasmaNet,ISP
 tatacommunications.com,Tata Communications,ISP
 tataidc.co.in,Tata Tele Business Services (TTBS),ISP
 tataindicom.com,Tata Teleservices,ISP
+tataplayfiber.com,Tata Play Broadband,ISP
 tatatel.co.in,Tata Teleservices,ISP
 tatatelebusiness.com,Tata Teleservices,ISP
 tatateleservices.com,Tata Teleservices,ISP
 tattelecom.ru,Tattelecom,ISP
+tavola.com.br,Tavola Conectividade,ISP
+taylortel.org,Taylor Telephone Cooperative,ISP
 tbaytel.net,TBayTel,ISP
 tbc.net.tw,TBC,ISP
 tbntelecom.com.br,TBN Telecom,ISP
 tbonet.net.br,Infix Telecom,ISP
 tbs.co.jp,Tokyo Broadcasting System,Government Media
+tcc-technology.com,TCC Technology,Web Host
 tcell.tj,Tcell,ISP
 tcftelecom.com.br,TCF Telecom,ISP
 tchile.com,Tchile,Web Host
@@ -7561,11 +8357,13 @@ tcs.com,TATA Consultancy Services,SaaS
 tct.net,TCT,ISP
 tctwest.net,TCT,ISP
 tcu.edu,Texas Christian University,Education
+td.com,TD Bank,Finance
 tdcgroup.com,TDC,ISP
 tdf.fr,TDF,ISP
 tds.net,TDS,ISP
 tdstelecom.com,TDS Telecom,ISP
 te.eg,Telecom Egypt,ISP
+team-cymru.org,Team Cymru,Email Security
 team.blue,team.blue,Web Host
 teamglac.com,TeamGLAC,Healthcare
 teammidwest.com,MEC Midwest Energy and Communications,ISP
@@ -7574,25 +8372,34 @@ tec.mx,Tecnológico de Monterrey,Education
 tech.gov.sg,Government Technology Agency Singapore,Government
 tech.ru,TECH.RU,Web Host
 tech4hosting.com,Tech 4 Hosting,Web Host
+techcom.cz,TechCom Czech,ISP
 techdata.com,Tech Data,Logistics
 teche.net,Uniti,MSP
+techiemedia.net,Techie Media,Web Host
 techmahindra.com,Tech Mahindra,MSP
+techminds.ca,TechMinds Canada,ISP
 technological.ro,Technological Romania,ISP
 technolutions.com,Technolutions,SaaS
 technolutions.net,Technolutions,SaaS
 technozone.com.ph,Technozone Corporation,Construction
+tecnalia.com,Tecnalia,Science
+tecnocratica.net,Tecnocratica,Web Host
 tecwave.com.br,Tecwave Telecom,ISP
 tedata.net,Telecom Egypt,ISP
 tedforbes.com,Ted Forbes,Photography
 tees.ne.jp,Toyohashi Cable Network,ISP
 tegna.com,TEGNA (Nexstar),Government Media
+teklinks.com,TekLinks,MSP
+teknotel.com,Teknotel,Web Host
 teksavvy.com,TekSavvy,ISP
 tel.net.ba,HT Eronet,ISP
 tel.ru,TEL Suntel,ISP
 telbo.net,TELBO,ISP
+telcel.com,Telcel,ISP
 telcocom.com.ar,Telcocom,ISP
 telcomaster.com,TelcoMaster,ISP
 telconet.ec,Telconet,ISP
+telcoproservices.cz,Telco Pro Services,ISP
 tele-ag.de,TELE AG,ISP
 tele.net,VOLhighspeed,ISP
 tele2.com,Tele2,ISP
@@ -7621,6 +8428,7 @@ telecom.na,Telecom Namibia,ISP
 telecom.net.ar,Telecom Argentina,ISP
 telecom.tm,Turkmentelecom,ISP
 telecomarmenia.am,Telecom Armenia (Team),ISP
+telecomclm.net,Telecom Castilla La Mancha,ISP
 telecomitalia.com,TIM,ISP
 telecomitalia.it,TIM,ISP
 telecomitalia.sm,TIM San Marino,ISP
@@ -7635,6 +8443,7 @@ telefonica.com.ec,Telefonica Ecuador (Otecel),ISP
 telefonica.com.pe,Telefónica Perú,ISP
 telefonica.de,Telefónica Germany,ISP
 telefonicachile.cl,Telefónica Chile,ISP
+telegram.org,Telegram Messenger,Social Media
 telehouse.bg,Telehouse Bulgaria,Web Host
 telehouse.net,Telehouse,Web Host
 telekabel.com.mk,Telekabel,ISP
@@ -7647,21 +8456,27 @@ telekom.mk,Makedonski Telekom,ISP
 telekom.rs,MTS,ISP
 telekom.si,Telekom Slovenije,ISP
 telekom.sk,Slovak Telekom,ISP
+telekomunikacijuvartai.lt,Cgates (Telekomunikaciju vartai),ISP
 telemach.ba,Telemach,ISP
 telemach.hr,Telemach,ISP
 telemach.si,Telemach,ISP
 telemaxx.de,TelemaxX,Web Host
+telemidia.net.br,Telemidia,ISP
+telemovil.net,Telemovil El Salvador,ISP
 telenet-ops.be,Telenet BV,ISP
 telenet.be,Telenet,ISP
 telenet.lv,Telenet Latvia,ISP
+telenettv.ru,Telenet Russia,ISP
 telenor.com.pk,Telenor Pakistan,ISP
 telenor.dk,Telenor,ISP
 telenor.no,Telenor,ISP
 telenor.se,Telenor,ISP
 telenord.com.do,Telenord,ISP
+teleos.ru,Teleos-1,ISP
 telepac.pt,SAPO,Email Provider
 telepacific.net,TPx Communications,ISP
 telepermit.co.nz,Spark NZ,ISP
+telepoint.bg,Telepoint,Web Host
 telered.com.ar,Telered,ISP
 telering.at,Magenta,ISP
 telesat.com,Telesat,ISP
@@ -7674,6 +8489,7 @@ telesur.sr,Telesur,ISP
 teletu.it,Vodafone,ISP
 televiaducto.com.do,Televiaducto,ISP
 telfy.com,Telfy,ISP
+telgo.com.br,Telgo,ISP
 telia.dk,Norlys,ISP
 telia.ee,Telia,ISP
 telia.fi,Telia,ISP
@@ -7684,6 +8500,7 @@ teliacompany.com,Telia,ISP
 teliacygate.se,Telia Cygate,MSP
 teligraph.com.sg,Teligraph,MSP
 telin.net,Telkom Indonesia,ISP
+telin.sg,Telin Singapore (Telkom Indonesia),ISP
 telium.com.br,Telium Networks,ISP
 telium.net.br,Telium,ISP
 telkea.com,Telkea,ISP
@@ -7692,14 +8509,18 @@ telkom.co.za,Telkom South Africa,ISP
 telkomadsl.co.za,Telkom,ISP
 telkomsa.net,Telkom,ISP
 telkomsel.com,Telkomsel,ISP
+telkos.net,Telkos Kosovo,ISP
 tellas.gr,Nova Telecommunications,ISP
 telma.mg,Yas,ISP
 telmax.com,telMAX,ISP
 telmex.com,Telmex,ISP
 telmex.net.ar,Telmex Argentina,ISP
+telnaptelecom.pl,Telnap Telecom,ISP
 telnetworldwide.com,Telnet Worldwide,ISP
 telnyx.com,Telnyx,SaaS
+telpin.com.ar,Telpin Pinamar,ISP
 telpol.net.pl,Telpol,ISP
+telset.ee,Telset Estonia,ISP
 telstra.com.au,Telstra,ISP
 telstra.net,Telstra,ISP
 telstrainternational.com,Telstra Global,ISP
@@ -7722,6 +8543,7 @@ tennessee.edu,University of Tennessee,Education
 teol.net,mtel,ISP
 tera-byte.com,Tera-Byte,Web Host
 teracom.dk,Cibicom,ISP
+teracom.se,Teracom Sweden,ISP
 terago.ca,TeraGo,ISP
 teraline-telecom.net,Teraline Telecom,ISP
 teraline.kz,Teraline Telecom,ISP
@@ -7738,6 +8560,7 @@ terrecablate.it,Terrecablate,ISP
 tesatelecom.com,Tesa Telecom,ISP
 tesla.com,Tesla,Automotive
 tet.lv,Tet,ISP
+teuto.net,teuto.net,IaaS
 tevapharm.com,Teva Pharmaceuticals,Healthcare
 tevisat.net,Tevisat,ISP
 texas.gov,The Government of Texas,Government
@@ -7750,6 +8573,7 @@ thcservers.com,THCServers,Web Host
 the.hosting,THE.Hosting,Web Host
 theaccessgroup.com,The Access Group,SaaS
 thebunker.net,The Bunker (Cyberfort),Web Host
+thecable.net,The Cable St. Kitts,ISP
 thecamels.org,Thecamels,Web Host
 thechristhospital.com,The Christ Hospital,Healthcare
 thecloud.net,Sky WiFi (The Cloud),ISP
@@ -7757,11 +8581,15 @@ thegameshowcompany.ca,The Game Show Company,Entertainment
 thegigabit.com,Gigabit Hosting,Web Host
 thegirlandthefig.com,the girl & the fig,Food
 theglobalresearchnetwork.com,Global Healthcare Research,Healthcare
+thehost.ua,TheHost Ukraine,Web Host
 thehostgroup.com,The Host Group,Web Host
 themercury.com,The Mercury,News
+therocksnet.com,Rocks Computer Services,ISP
+thesolarsystems.net,Joint Power Technology,Web Host
 thibodaux.com,Thibodaux Hospitals,Healthcare
 thinkbignets.com,IQ Fiber (ThinkBig Networks),ISP
 thinkhuge.net,Think Huge,Web Host
+thinkon.com,ThinkOn,IaaS
 thomsonreuters.com,Thomson Reuters,SaaS
 three.co.uk,Three,ISP
 three.com.hk,3 Hong Kong (Hutchison),ISP
@@ -7781,6 +8609,7 @@ tidewater.net,Tidewater Telecom,ISP
 tie.cl,Telefónica Internet Empresas S.A.,ISP
 tier.net,Tier.Net,Web Host
 tierpoint.com,TierPoint,Web Host
+tierra.net,TierraNet,Web Host
 tierzero.com,Tierzero,ISP
 tieto.com,Tietoevry,Consulting
 tietoevry.com,Tietoevry,Consulting
@@ -7798,6 +8627,7 @@ tigobusiness.com.ni,Tigo,ISP
 tigostar.cr,Tigo,ISP
 tii-usa.com,Technology International,Consulting
 tikona.in,Tikona,ISP
+tilaa.com,Tilaa,Web Host
 tim.com.br,TIM Brasil,ISP
 tim.it,TIM,ISP
 time.com.my,TIME,ISP
@@ -7828,6 +8658,8 @@ tjbtn.net,Tianjin Broadcasting TV Network,ISP
 tkchopin.pl,Chopin Telewizja Kablowa,ISP
 tkk.net.pl,Telewizja Kablowa Koszalin,ISP
 tkreal.ru,The Real Group,Logistics
+tkrjasek.cz,Valachnet (TKR Jasek),ISP
+tkrz-business.de,TKRZ Business,ISP
 tktelekom.pl,TK Telecom,ISP
 tlapnet.cz,Tlapnet,ISP
 tm.com.my,TM,ISP
@@ -7853,6 +8685,7 @@ tnm.co.mw,TNM,ISP
 tnnet.fi,TNNet,MSP
 tnsi.com,TNS Transaction Network Services,SaaS
 tnsplus.kz,TNS-Plus,ISP
+tnstate.edu,Tennessee State University,Education
 tntsupport.net,TNT Support,MSP
 toast.net,TOAST.net,ISP
 today.com.kh,Today Internet,ISP
@@ -7867,7 +8700,10 @@ tokai-com.co.jp,TOKAI Communications,ISP
 tokala-mobile.com,Tokala Communications,ISP
 tombigbee.org,Tombigbee Communications,ISP
 tombigbeefiber.com,Tombigbee Fiber,ISP
+tomica.ru,Tomika Tomsk,ISP
 tomsknet.ru,Rostelecom Tomsk,ISP
+toob.co.uk,toob,ISP
+top-ix.org,TOP-IX,ISP
 top-tokyo.co.jp,TOP CORPORATION,Healthcare
 top86.com,Qingdao Cable TV Network Center,ISP
 topauctions24-7.com,TopAuctions24-7,Retail
@@ -7883,6 +8719,7 @@ tornadovps.com,Tornado VPS,Web Host
 toronto.ca,City of Toronto,Government
 toronto.edu,University of Toronto,Education
 torontomu.ca,Toronto Metropolitan University,Education
+toshima.co.jp,Toshima Cable Network,ISP
 tosis.co.jp,Tosoh Information Systems,MSP
 tosoh.co.jp,Tosoh,Industrial
 totalplay.com.mx,Totalplay,ISP
@@ -7897,6 +8734,7 @@ toya.com.pl,Toya,ISP
 toyo.ac.jp,Toyo University,Education
 toyotasystems.com,Toyota Systems,Automotive
 tp.edu.sg,Temasek Polytechnic,Education
+tpg.com.au,TPG,ISP
 tpgi.com.au,TPG,ISP
 tpgtelecom.com.au,TPG,ISP
 tpnet.pl,Orange,ISP
@@ -7910,7 +8748,9 @@ tradeindia.com,TradeIndia,SaaS
 trafficforce.lt,TrafficForce,Marketing
 trafficmanager.net,Microsoft Azure,Technology
 trainhealthonline.com,TrainHealthOnline,Education
+trakiacable.net,Trakia Kabel,ISP
 transact.com.au,TransACT,ISP
+transatel.com,Transatel (NTT),ISP
 transip.nl,TransIP,Web Host
 transmail.net,Zoho,SaaS
 transocean.com,Transocean,Industrial
@@ -7925,12 +8765,14 @@ transworld-home.com,Transworld Home Pakistan,ISP
 travelers.com,Travelers,Finance
 tre.se,Tre,ISP
 treasury.gov,U.S. Department of the Treasury,Government
+trend.inc,Trend Capital,SaaS
 trendmicro.com,Trend Micro,Email Security
 trendmicro.com.sg,Trend Micro,Email Security
 trendmicro.eu,Trend Micro,Email Security
 trentu.ca,Trent University,Education
 trgovinadijelova.hr,Trgovina dijelova,Automotive
 tri-c.edu,Cuyahoga Community College,Education
+tri-cogo.com,Tri-CoGo,ISP
 tri.go.ke,Tourism Research Institute,Science
 tri.ph,Sky Cable Philippines (TRI),ISP
 triadefibra.com,Tríade Fibra,ISP
@@ -7956,6 +8798,7 @@ true.th,TRUE,ISP
 truecorp.co.th,True Corporation,ISP
 truefullstaq.com,TrueServer,Web Host
 truehost.cloud,Truehost Cloud,Web Host
+trueidc.com,True IDC Thailand,Web Host
 trueinternet.co.th,TRUE,ISP
 truemail.co.th,True Internet,ISP
 truespeed.com,TrueSpeed Communications,ISP
@@ -7964,6 +8807,7 @@ truman.edu,Trueman State University,Education
 truphone.com,Truphone,ISP
 trusted-network.de,Trusted Network,Web Host
 trustifi.com,Trustifi,Email Security
+truvista.biz,Plant TiftNet (Truvista),ISP
 truvista.net,Truvista,ISP
 trytek.ru,Trytek,ISP
 tsimages.net,TSImages,SaaS
@@ -7999,6 +8843,7 @@ turbobsb.com.br,Turbo BSB,ISP
 turbonetgoncalves.com.br,Turbonet Telecom,ISP
 turbonett.com.br,Turbonett,ISP
 turbosp.com.br,Turbo SP,ISP
+turingidc.com,Turing Group,Web Host
 turk.net,TurkNet,ISP
 turkcell.com.tr,Turkcell,ISP
 turksat.com.tr,Türksat,ISP
@@ -8007,6 +8852,7 @@ turktelekomint.com,Turk Telekom International,ISP
 turkticaret.net,Turkticaret.Net,Web Host
 turner.com,Warner Bros Discovery,Entertainment
 turnkeyinternet.net,Hivelocity (TurnKey Internet),Web Host
+turontelecom.uz,Turon Telecom Uzbekistan,ISP
 tus.ac.jp,Tokyo University of Science,Education
 tusass.gl,Tusass Greenland,ISP
 tusd1.org,Tucson Unified School District,Education
@@ -8019,14 +8865,19 @@ tva.gov,Tennessee Valley Authority,Utilities
 tvactelecom.com.br,TVAC Telecom,ISP
 tvcabo.ao,TV Cabo,ISP
 tvcabo.mz,TVCabo Mozambique,ISP
+tvcassis.com.br,TVC de Assis (Cabonnet),ISP
+tvepa.com,Tallahatchie Valley Internet (TVEPA),ISP
+tvhost.ru,Sky@Net (TVHost),ISP
 tvk.pl,TVK Telka,ISP
 tvk.wroc.pl,TVK Telka,ISP
+tvoe.tv,TKT (Tvoe.tv),ISP
 tvpublica.com.ar,TVP,ISP
 tvsatrm.ro,TVSat Romania,ISP
 tvymas.co,TV&MÁS,ISP
 tw1.com,Transworld Associates Pakistan,ISP
 twilio.com,Twilio,SaaS
 twinlakes.net,Twin Lakes Communications,ISP
+twinvalley.com,Twin Valley Communications,ISP
 twitter.com,X (Twitter),Social Media
 twl-kom.de,TWL-KOM,ISP
 twlakes.net,Twin Lakes Communications,ISP
@@ -8083,6 +8934,7 @@ uc.cl,Pontificia Universidad Catolica de Chile,Education
 uc.edu,University of Cincinnati,Education
 uc.edu.ve,Universidad de Carabobo,Education
 ucalgary.ca,University of Calgary,Education
+ucanet.ru,UCA Networks Moscow,ISP
 ucar.edu,University Corporation for Atmospheric Research,Education
 ucatv.co.jp,Utsunomiya Cable TV,ISP
 uccs.edu,University of Colorado Colorado Springs,Education
@@ -8113,31 +8965,40 @@ ucsc.edu,"University of California, Santa Cruz",Education
 ucsd.edu,University of California San Diego,Education
 ucsf.edu,"University of California, San Francisco",Education
 uct.ac.za,University of Cape Town,Education
+ucv.co.jp,UCV Ueda Cable Vision,ISP
 ucv.ve,Universidad Central de Venezuela,Education
+ucy.ac.cy,University of Cyprus,Education
 udag.de,United Domains,Web Host
 udayton.edu,University of Dayton,Education
 udc.hk,Hong Kong Communications,Web Host
 udel.edu,University of Delaware,Education
 udg.mx,Universidad de Guadalajara,Education
 udlap.mx,Universidad de las Americas Puebla,Education
+udm.ru,UDM Izhevsk,ISP
 udomain.hk,UDomain,Web Host
+udusok.edu.ng,Usmanu Danfodiyo University,Education
 uel.br,Universidade Estadual de Londrina,Education
 uen.org,Utah Education Network,Education
 uepg.br,Universidade Estadual de Ponta Grossa,Education
 ufanet.ru,Ufanet,ISP
 ufba.br,Universidade Federal da Bahia,Education
+uffs.edu.br,UFFS Universidade Federal da Fronteira Sul,Education
 ufinet.com,Ufinet,ISP
 ufl.edu,University of Florida,Education
+ufla.br,UFLA Universidade Federal de Lavras,Education
 ufmg.br,UFMG,Education
 ufone.com,Ufone,ISP
+ufpa.br,Universidade Federal do Para,Education
 ufrgs.br,UFRGS,Education
 ufsc.br,UFSC,Education
 ufscar.br,Universidade Federal de Sao Carlos,Education
 ufuwa.com,Union Fu Wah Digital,Web Host
 ufv.br,Universidade Federal de Vicosa,Education
+ug-tele.com,UG-Telecom Serpukhov,ISP
 ug.edu.gh,University of Ghana,Education
 uga.edu,University of Georgia,Education
 ugmk-telecom.ru,UGMK-Telecom,ISP
+ugto.mx,Universidad de Guanajuato,Education
 uh.edu,University of Houston,Education
 uhc.com,United Healthcare,Healthcare
 uhs.edu.pk,University of Health Sciences,Education
@@ -8165,9 +9026,11 @@ ulakbim.gov.tr,ULAKBIM,Education
 ulalaunch.com,United Launch Alliance,Defense
 ulaval.ca,Universite Laval,Education
 uleth.ca,University of Lethbridge,Education
+ulsan.ac.kr,University of Ulsan,Education
 ultahost.com,UltaHost,Web Host
 ultimate-guitar.com,Ultimate Guitar,Entertainment
 ultimatedomain.hosting,Ultimate Domain Hosting,Web Host
+ultra.one,UltraOne,ISP
 ultralinkce.com.br,Ultralink,ISP
 ultralinkweb.com.br,Ultralink Telecom,ISP
 ultranet.biz,UltraNET,ISP
@@ -8197,6 +9060,7 @@ umn.edu,University of Minnesota,Education
 umniah.com,Umniah,ISP
 umnyeseti.ru,Umnyeseti,ISP
 umt.edu,University of Montana,Education
+umtelecom.com.br,Um Telecom,ISP
 umu.se,Umea University,Education
 unal.edu.co,Universidad Nacional de Colombia,Education
 unam.mx,Universidad Nacional Autónoma de México,Education
@@ -8222,22 +9086,26 @@ uni-halle.de,Martin Luther University Halle-Wittenberg,Education
 uni-klu.ac.at,Universitat Klagenfurt,Education
 uni-koeln.de,University of Cologne,Education
 uni-linz.ac.at,University of Linz,Education
+uni-lj.si,University of Ljubljana,Education
 uni-mainz.de,Johannes Gutenberg University Mainz,Education
 uni.edu,University of Northern Iowa,Education
 uniabita.it,UniAbita,Real Estate
 uniadex.co.jp,UNIADEX,MSP
 uniandes.edu.co,Universidad de los Andes,Education
+unica.cloud,Unica Telecomunicazioni,ISP
 unicaja.es,Unicaja,Finance
 unicajabanco.es,Unicaja,Finance
 unicamp.br,Unicamp,Education
 unicanetworking.com.br,Única Networking,ISP
 unicreditgroup.eu,UniCredit,Finance
 unidata.it,Unidata,ISP
+unifesp.br,Universidade Federal de Sao Paulo,Education
 unifiedlayer.com,UnifiedLayers,Web Host
 unifiedpostgroup.com,Unifiedpost Group,SaaS
 unifique.com.br,Unifique,ISP
 unifique.net,Unifique,ISP
 unijos.edu.ng,University of Jos,Education
+unilag.edu.ng,University of Lagos,Education
 unilinktecnologia.com.br,Unilink Tecnologia,ISP
 unimedjp.com.br,Unimed João Pessoa,SaaS
 unimelb.edu.au,University of Melbourne,Education
@@ -8270,19 +9138,24 @@ uniti.com,Uniti,MSP
 unity-health.org,Unity Health,Healthcare
 unityhealth.org,Unity Health,Healthcare
 univac.com.sg,Univac,Industrial
+univates.br,Univates,Education
 universal-shoji.co.jp,Universal Shoji,Industrial
+universalmusic.com,Universal Music Group,Entertainment
 univie.ac.at,University of Vienna,Education
 uniwisp.co.za,UniWISP,ISP
+unix-solutions.be,Unix-Solutions,Web Host
 unlp.edu.ar,Universidad Nacional de La Plata,Education
 unm.edu,University of New Mexico,Education
 unn.com.bn,Unified National Networks Brunei,ISP
 unn.edu.ng,University of Nigeria Nsukka,Education
 uno.edu,University of New Orleans,Education
+unoesc.edu.br,Unoesc,Education
 unpl.co.in,UN Broadband,ISP
 unr.edu,"University of Nevada, Reno",Education
 unsw.edu.au,University of New South Wales,Education
 unt.edu,University of North Texas,Education
 untd.com,United Online,ISP
+unwiredltd.com,Unwired,ISP
 uoa.gr,National and Kapodistrian University of Athens,Education
 uoc.gr,University of Crete,Education
 uoeh-u.ac.jp,"University of Occupational and Environmental Health, Japan",Education
@@ -8327,6 +9200,7 @@ usb.ve,Universidad Simon Bolivar,Education
 usbank.com,U.S. Bank,Finance
 usc.edu,University of Southern California,Education
 uscomputers.com,U.S. Computer Corporation,MSP
+usd.edu,University of South Dakota,Education
 usda.gov,U.S. Department of Agriculture,Government
 usen.com,USEN,Entertainment
 user.fm,Fastmail,Email Provider
@@ -8419,12 +9293,15 @@ valley-widehealth.org,Wally-Wide Health,Healthcare
 valleyfiber.ca,Valley Fiber,ISP
 valorc3.com,ValorC3 Data Centers,Web Host
 valverde.edu,Val Verde Unified School District,Education
+vandadvira.com,Vandad Vira Hooman,Web Host
 vanderbilt.edu,Vanderbilt University,Education
 vanderbilthealth.com,Vanderbilt Health,Healthcare
 vantagepnt.com,Vantage Point Solutions,ISP
 vanwerthospital.org,Van Wert Health,Healthcare
+varnamoenergi.se,Varnamo Energi,Utilities
 varzeanet.com.br,Varzea Net,ISP
 vassar.edu,Vassar College,Education
+vaultica.com,Vaultica,Web Host
 vautron.de,Vautron Rechenzentrum,Web Host
 vccs.edu,Virginia Community College System,Education
 vck-gmbh.de,Vestische Caritas-Klinike,Healthcare
@@ -8437,6 +9314,7 @@ vdonsk.ru,Microel,ISP
 vdsina.com,VDSina,Web Host
 vdsina.ru,VDSina,Web Host
 vdska.online,VDSka,Web Host
+vea.coop,Valley Electric Association,Utilities
 vectorfibre.co.nz,Vector Fibre,ISP
 vectra.pl,Vectra,ISP
 vectranet.pl,Vectra,ISP
@@ -8446,6 +9324,7 @@ veesp.com,Veesp,Web Host
 veetime.com,VeeTIME,ISP
 veganet.com.tr,Veganet,ISP
 vegans.it,vegan/s,MSP
+vegatele.com,Vegatele (Farlep-Invest),ISP
 vege.net,vege.net,Web Host
 vegvesen.no,Statens Vegvesen,Government
 veiganet.com.br,VEIGANET,ISP
@@ -8456,6 +9335,7 @@ velo.co.id,VELO Networks Indonesia,ISP
 velocitymsc.com,Velocity Managed Solutions,MSP
 velocitynetwork.net,Velocity Network,ISP
 veloxfiber.com.br,Velox,ISP
+veloxserv.co.uk,VeloxServ,Web Host
 velozfibra.com.br,Veloz Fibra,ISP
 ventech.com,C1,MSP
 vera.com.uy,Antel,ISP
@@ -8475,6 +9355,7 @@ verizon.net,Verizon,ISP
 verizonbusiness.com,Verizon Business,ISP
 vermont.gov,Vermont Government,Government
 vermontel.com,VTel Vermont,ISP
+vernet.lv,Vernet (Versija),ISP
 verobroadband.com,Vero Fiber,ISP
 verointernet.com.br,Internet de Verdade,ISP
 versanet.de,1&1 Versatel,ISP
@@ -8486,12 +9367,15 @@ vgohosting.com,HostPapa,Web Host
 vgonline.com,Video Graphics,Web Host
 vgpinternet.net.br,VGP Internet,ISP
 vgregion.se,Västra Götalandsregionen,Government
+vgscom.ru,VGS (Gorset Vladimir),ISP
 viaccess.net,ONE Communications,ISP
+viaeuropa.net,ViaEuropa,ISP
 vialis.net,Vialis,ISP
 vialuxfibra.com.br,VialuxFibra,ISP
 viamartelecom.com.br,Viamar Telecom,ISP
 viananet.net.br,VianaNet,ISP
 vianet.ca,Vianet,ISP
+vianet.com.np,Vianet Communication Nepal,ISP
 vianova.it,Vianova,ISP
 viarezo.fr,ViaRézo (CentraleSupélec),Education
 viasat.com,Viasat,ISP
@@ -8503,6 +9387,7 @@ vibrantwellnessvoyage.com,Vibrant Wellness Voyage,Healthcare
 vicc.co,Venco Imtiaz Contracting Co,Industrial
 victorkaiser.com,Global Transport,Logistics
 vidanet.hu,ViDaNet,ISP
+vidaoptics.com,Vida Optics,ISP
 video-broadcast.at,Video-Broadcast,ISP
 videotron.ca,Videotron,ISP
 videotron.com,Videotron,ISP
@@ -8520,6 +9405,7 @@ villanova.edu,Villanova University,Education
 vinahost.vn,VinaHost,Web Host
 vinakom.com,Vinakom,MSP
 vinedisposal.com,Vine Disposal,Logistics
+vinnitsa.com,Veco Vinnitsa,ISP
 vinu.edu,Vincennes University,Education
 vip.hr,A1,ISP
 vipfibertelecom.com.br,VIP Fiber,ISP
@@ -8546,7 +9432,10 @@ virtual1.com,PXC,ISP
 virtualhosting.hk,UDomain,Web Host
 virtualnetfibra.com.br,Virtual Net Fibra,ISP
 virtualserver.io,Zitcom,Web Host
+virtuaoperator.pl,Virtual Operator (VirtuaOperator),ISP
 virtuaserver.com.br,VirtuaServer,Web Host
+virtuo.host,Virtuo.Host,Web Host
+virtutel.com.au,Virtutel,ISP
 visa.com,Visa,Finance
 visabeira.co.ao,COMATEL,ISP
 visi.com,US Signal,MSP
@@ -8577,6 +9466,7 @@ vm.co.mz,Vodacom Mozambique,ISP
 vmedia.ca,VMedia,ISP
 vmi.edu,Virginia Military Institute,Education
 vnet.sk,VNET Slovakia,ISP
+vnet.su,VNet,ISP
 vng.com.vn,VNG Online,SaaS
 vnnic.vn,VNNIC Vietnam Internet Network,Government
 vnpt.com.vn,VNPT,ISP
@@ -8587,6 +9477,7 @@ vntelecom.com.br,VN Telecom,ISP
 vo.lu,Visual Online Luxembourg,ISP
 voartelecom.com.br,Voar Telecom,ISP
 vocalocity.com,Vonage Business (Vocalocity),SaaS
+vocetelecom.com.br,Voce Telecom,ISP
 vocom.com,Vocom International,ISP
 vocus.co.nz,2degrees,ISP
 vocus.com.au,Vocus,ISP
@@ -8618,18 +9509,24 @@ vodafone.ua,Vodafone,ISP
 vodafonedsl.it,Vodafone Itily,ISP
 vodafoneidea.com,Vi,ISP
 vodien.com,Vodien,Web Host
+voe.ch,VOe Multimedia,ISP
 voicehost.co.uk,VoiceHost,PaaS
+voip.kz,Voip Kazakhstan Network,ISP
 voith.com,Voith,Industrial
+volcano.net,Volcano Communications,ISP
 volcengine.com,Volcengine (ByteDance),IaaS
 volhighspeed.at,VOLhighspeed,ISP
 volia.com,Volia,ISP
 volico.com,Volico Data Centers,Web Host
 volkswagengroupamerica.com,Volkswagen of America,Automotive
 volstate.net,IT Voice,MSP
+voltbb.com,Volt Broadband,ISP
+voluy.com.br,Voluy Telecom,ISP
 volvo.com,Volvo,Manufacturing
 volz.ua,Volz Ukraine,ISP
 vom.com,Valley of the Moon,ISP
 voo.be,VOO,ISP
+voonami.com,Voonami,MSP
 vootelecom.com.br,Voo Telecom,ISP
 vorboss.com,Vorboss,ISP
 vosnet.ru,Home.Net Voskresensk,ISP
@@ -8642,20 +9539,25 @@ voyager.nz,Voyager,ISP
 vpath.co.za,Pathcare Vermaak,Healthcare
 vpls.com,VPLS,MSP
 vpndns.net,Now-DNS,Web Host
+vpsville.ru,Vpsville,Web Host
 vr.fi,VR Group (Finnish Railways),Logistics
 vrmgr.com,Virtual Resort Manager,Real Estate
 vsc.edu,Vermont State Colleges,Education
 vsenet.de,VSE NET,ISP
+vsevnet.ru,Vsevnet,ISP
 vshosting.cz,vshosting,Web Host
 vsp.fi,VSP Vakka-Suomen Puhelin,ISP
 vsu.by,Vitebsk State University,Education
 vt.edu,Virginia Tech,Education
 vtal.com,V.tal,ISP
 vtc.vn,VTC Digicom,Government Media
+vtel.jo,VTEL Jordan,ISP
+vtelecom.ru,Vostoktelecom,ISP
 vtext.com,Verizon SMS,ISP
 vtgus.com,Virtual Technologies Group,MSP
 vtr.com,VTR,ISP
 vtr.net,VTR,ISP
+vts.bf,Virtual Technologies and Solutions Burkina Faso,ISP
 vtt.fi,VTT Technical Research Centre of Finland,Education
 vtx.ch,VTX,ISP
 vtx1.net,VTX1 Communications,ISP
@@ -8673,6 +9575,8 @@ wa-k20.net,Washington K-20 Network,Education
 wa.gov,State of Washington,Government
 wadax-sv.jp,WADAX,Web Host
 wadax.ne.jp,WADAX,Web Host
+wafai.com.sa,WafaiCloud,Web Host
+waicore.com,WAIcore,ISP
 wainet.co.jp,Cable Media WaiWai,ISP
 wakayama-u.ac.jp,Wakayama University,Education
 wal-mart.com,Walmart,Retail
@@ -8683,6 +9587,8 @@ wananchi.com,Wananchi Group,ISP
 wanao.com,Wanao,SaaS
 wancom.net.pk,Wancom Pakistan,ISP
 wansec.com,WANSecurity,Email Security
+wantel.com.br,Wantel,ISP
+waoo.dk,Waoo,ISP
 warian.net,Warian,SaaS
 warwick.ac.uk,University of Warwick,Education
 waseda.jp,Waseda University,Education
@@ -8690,9 +9596,12 @@ washington.edu,University of Washington,Education
 wasip.com,WASIP Ltd.,Healthcare
 watchcomm.net,Watch Communications,ISP
 wateen.com,Wateen,ISP
+watv.co.jp,Watarase Television,ISP
 waugi.cloud,Waugi Cloud,Web Host
 waugi.com,Waugi Cloud,Web Host
 wavebroadband.com,Wave Broadband,ISP
+wavecom.ee,WaveCom Estonia,IaaS
+wavedirect.net,WaveDirect,ISP
 wavemax.com.br,Wavemax Internet,ISP
 wavenet.co.uk,Wavenet,ISP
 wavenetuk.net,Wavenet,MSP
@@ -8717,17 +9626,21 @@ we.bs,LiquidNet,Web Host
 wearecms.com,Charlotte-Mecklenburg Schools,Education
 web-dns1.com,Web Hosting Canada,Web Host
 web-hosting.com,Namecheap,Web Host
+web-telecoms.co.za,Web Telecom Services SA,Web Host
 web.ad.jp,Fujitsu,Technology
 web.africa,Webafrica,ISP
 web.app,Google,PaaS
 web.com.ph,Web.com Philippines,Web Host
 web.de,Web.de,ISP
 web2objects.de,web2objects,Web Host
+weba.ru,WEBA,Web Host
 webadorsite.com,JouwWeb,Web Host
 webair.com,Webair Internet Development,Web Host
 webbingsolutions.com,Webbing,ISP
 webbytelecom.com.br,Webby Internet,ISP
 webd.pl,WEBD.PL,Web Host
+webdiscount.net,Webdiscount,Web Host
+webe.com.my,Unifi (webe Digital),ISP
 webetic.net,Webetic,Web Host
 webex.com,Cisco Webex,SaaS
 webflow.io,Webflow,SaaS
@@ -8766,12 +9679,14 @@ websupport.se,Websuport,Web Host
 websupport.sk,Websupport,Web Host
 websurfer.com.np,Websurfer Nepal,ISP
 webwerks.in,Iron Mountain Data Centers,IaaS
+webworld.ie,WebWorld Ireland,Web Host
 webzi.mx,Webzi,Web Host
 webzilla.com,Webzilla,Web Host
 webzine1.com,Webzine Online,Web Host
 webzineonline.com,Webzine Online,Marketing
 wecenergygroup.com,WEC Energy,Utilities
 weclix.com.br,Weclix,ISP
+weconnect.tech,Connect Managed Services,MSP
 weendeavor.com,Endeavor Communications,ISP
 welcomeitalia.it,Vianova,ISP
 well.com,The WELL,Email Provider
@@ -8792,6 +9707,7 @@ westchestergov.com,County of Westchester,Government
 westcloudvalley.com,Ningxia West Cloud Data,IaaS
 westcoastinternet.com,West Coast Internet (WCI),ISP
 westdc.net,WestHost,Web Host
+westianet.com,Western Iowa Networks,ISP
 westmancom.com,Westman Communications,ISP
 westpac.com.au,Westpac,Finance
 westriv.com,WRT,ISP
@@ -8824,11 +9740,13 @@ whplanet.com,WH Planet Web Hosting,Web Host
 wi-fiber.io,Wi-Fiber,ISP
 wi.gov,The State of Wisconsin,Government
 wia.cz,WIA Telecommunications,ISP
+wicam.com.kh,WiCAM Cambodia,ISP
 wichita.edu,Wichita State University,Education
 wicity.it,WicitY,ISP
 wide.ad.jp,WIDE Project,Science
 widener.edu,Widener University,Education
 wien.gv.at,City of Vienna,Government
+wienenergie.at,Wien Energie,Utilities
 wifeet.com.do,Wifeet,ISP
 wifine.ru,Intercity (Wifine),ISP
 wifinity.co.uk,Wifinity,ISP
@@ -8853,6 +9771,7 @@ williamsbrospharmacy.com,Williams Bros Pharmacy,Healthcare
 willnet.org,WilliNet,ISP
 wilsoncomputer.com,Wilson Computer Support,MSP
 wilsonss.com,Wilson Computer Support,MSP
+wiltel.com.ar,Wiltel,ISP
 wimore.it,WiMore,ISP
 win.be,Win Belgium,ISP
 win.pe,Win Telecom Peru,ISP
@@ -8903,7 +9822,9 @@ wmaker.net,WMaker,ISP
 wmatera.com.br,WMatera Telecom,ISP
 wmservice.com.do,WMService,ISP
 wnet.global,WNET Telecom,ISP
+wnet.net.in,Wan and Lan Internet,ISP
 wnetsystem.com.br,WNET,ISP
+wnt.at,WNT Telecommunication,ISP
 wntellecom.net.br,WN Tellecom,ISP
 wntpr.net,WorldNet Telecommunications,ISP
 wobcom.de,Wobcom Wolfsburg,ISP
@@ -8929,7 +9850,9 @@ worksattelecom.net.br,Worksat Telecom,ISP
 worksmobile.com,Naver Works,SaaS
 worldbank.org,World Bank Group,Nonprofit
 worldbankgroup.org,World Bank Group,Nonprofit
+worldcall.com.pk,Worldcall Pakistan,ISP
 worldcall.net.pk,WorldCom Telecom,ISP
+worldfirstmunication.com,World First Communication,ISP
 worldgatein.net,WorldGate,ISP
 worldline.com,Worldline,SaaS
 worldlink.com.np,WorldLink Communications,ISP
@@ -8937,7 +9860,9 @@ worldnetpr.com,WorldNet Telecommunications,ISP
 worldphone.in,World Phone India,ISP
 worldstream.com,Worldstream,Web Host
 worria.com,Cloudie,Web Host
+worthingtonenterprises.com,Worthington Enterprises,Manufacturing
 wortmann.de,Wortmann,Manufacturing
+wowperu.pe,WOW Peru,ISP
 wowrack.com,Wowrack,Web Host
 wowway.com,WOW!,ISP
 wp.pl,Wirtualna Polska,Web Host
@@ -8954,11 +9879,13 @@ wstelecom.us,WS Telecom,ISP
 wsu.edu,Washington State University,Education
 wtccommunications.ca,WTC Communications Canada,ISP
 wtccommunications.com,WTC Communications,ISP
+wtctx.com,WesTex Connect (Telstar1),ISP
 wtvk.pl,Winogradzka Telewizja Kablowa,ISP
 wu-wien.ac.at,Vienna University of Economics and Business,Education
 wustl.edu,Washington University in St. Louis,Education
 wvnet.edu,WVNET,Education
 wvu.edu,West Virginia University,Education
+wvusd.k12.ca.us,Walnut Valley Unified School District,Education
 wwu.edu,Western Washington University,Education
 www.nic.in,National Informatics Centre,Government
 wwwowww.co.za,wwwOwww,Marketing
@@ -8973,6 +9900,8 @@ x-com.kz,X-COM,ISP
 x-ion.de,x-ion,Web Host
 x-mailer.de,Power-Netz,Web Host
 x-stream.biz,XSTREAM Italy,ISP
+x2com.nl,X2com,ISP
+x99.cloud,X99 Cloud,Web Host
 xbiz.ne.jp,Xserver,Web Host
 xcelenergy.com,Xcel Energy,Utilities
 xceleratorsoftware.com,Key Software Systems Xcelerator,SaaS
@@ -8984,14 +9913,17 @@ xerox.com,Xerox,Technology
 xfernet.com,Xfernet,Web Host
 xfinity.com,Comcast,ISP
 xg.ar,XG Networks Argentina,ISP
+xiber.net,Xiber,ISP
 xilinx.com,Xilinx,Manufacturing
 xinet.com.mx,Xinet,MSP
 xipline.com,Ritter Communications,ISP
+xittel.net,Xittel,ISP
 xl.co.id,XL Axiata,ISP
 xlshosting.nl,XLS Hosting (Signet),Web Host
 xlsmart.co.id,XL Smart (XL Axiata),ISP
 xmission.com,XMission,SaaS
 xmr3.com,OpenText,SaaS
+xn--80ahgneri.net,Online LLC,ISP
 xn.net,XNNET,Web Host
 xn.qh.cn,China Telecom,ISP
 xneelo.co.za,Xneelo,Web Host
@@ -9012,6 +9944,7 @@ xtglobal.vg,XT Global Networks,ISP
 xtom.com,xTom,IaaS
 xtrim.com.ec,Xtrim,ISP
 xturbo.com.br,Xturbo,ISP
+xxlnet.nl,XXLnet,ISP
 xyzservers.com,XYZ Servers,Web Host
 ya.ru,Yandex,Email Provider
 yadtel.net,Zirrus,ISP
@@ -9103,11 +10036,16 @@ zenlayer.com,Zenlayer,IaaS
 zentrointernet.com,Zentro Internet,ISP
 zeonet.co.in,Zeonet,ISP
 zeop.re,Zeop,ISP
+zessnetworks.com,Zess Networks,ISP
+zet-mobile.com,ZET-Mobile Tajikistan,ISP
 zetaglobal.com,Zeta Global,Marketing
 zetaglobal.net,Zeta Global,Marketing
 zetahosting.net,Zeta Hosting,Web Host
+zetservers.com,ZetServers,Web Host
 zettagrid.com,Zettagrid,Web Host
 zf.com,ZF Friedrichshafen,Automotive
+zgh.cl,Grupo ZGH,Web Host
+zhengxinghk.com,Zhengxing Technology HK,Web Host
 zicom.pl,Zicom Next,ISP
 zid.com,ZiD Internet,ISP
 ziggo.nl,Ziggo,ISP
@@ -9130,6 +10068,7 @@ zoho.com.au,Zoho,SaaS
 zoho.eu,Zoho,SaaS
 zoho.in,Zoho,SaaS
 zohocloud.ca,Zoho,SaaS
+zohocorp.com,Zoho,SaaS
 zohocorporation.com,Zoho,SaaS
 zohomail.com,Zoho,SaaS
 zon.pt,NOS Acores,ISP
@@ -9140,7 +10079,9 @@ zoom.com,Zoom,SaaS
 zoom.us,Zoom,SaaS
 zscaler.com,Zscaler,SaaS
 zsttk.ru,TTK,ISP
+zt.hu,ZNET Telekom,ISP
 ztv.co.jp,ZTV,ISP
+zuerich.ch,City of Zurich,Government
 zumpnet.com.br,Zumpnet,ISP
 zumtobelgroup.com,Zumtobel Group,Manufacturing
 zurich.com,Zurich Insurance,Finance

--- a/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
+++ b/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
@@ -11,6 +11,7 @@
 26.107
 2create.studio
 2g12.com
+345000.ru
 39-pbb.net.pk
 3ax.com.br
 3edgetechnologies.com
@@ -54,6 +55,7 @@ abv-10.top
 abv-28.top
 ac.ja
 acbinfo.net.br
+accelerit.co.za
 accessblackmen.com
 accessdomain.com
 accesskenya.com
@@ -145,10 +147,12 @@ alshamil.net.ae
 alsiscad.com
 altecnets.com
 alternativaip.net.br
+altibox.dk
 alttelecom.net.br
 altushost.com
 aluminati.org
 aluminumpipetubing.com
+alyrica.net
 alzewayed.com
 ama.pf
 amaazingcoach.com
@@ -174,6 +178,7 @@ angryturnip.com
 antbd.net
 anteldata.net.uy
 anthc.org
+antik.sk
 antis.edu
 antonaoll.com
 anviklass.org
@@ -217,6 +222,8 @@ as18186.com
 as262543.net.br
 as28220.net
 as328576.net
+as35100.net
+as51129.net
 as55850.net
 as63182.net
 asahachimaru.com
@@ -234,10 +241,12 @@ askartechsolutions.com
 asline.net
 asmecam.it
 asphostserver.org
+astratelekom.com
 atcovvorld.com
 ativanetwork.net.br
 ativatelecom.net.br
 atlanticbb.net
+atlantisnet.bg
 atlantisseafork.com
 atmessage.net
 atozled.com
@@ -272,6 +281,7 @@ b1-market.fit
 b1-wzu.asia
 b8sales.com
 babyaholics.com
+bacloud.com
 bahjs.com
 balaca.com
 balancefundpro.com
@@ -326,6 +336,7 @@ bigloustoys.com
 bigtube.net
 bigwhitehouse.net
 biiinoit.com
+bik.nu
 bikeodyssee.com
 billetweb.fr
 biocorp.com
@@ -343,6 +354,7 @@ blackpointcyber.com
 blackwaterregion.com
 blguss.com
 blmpb.com
+blnwx.com
 blockchainlaw.info
 blogwisefinance.com
 blondewigs.shop
@@ -351,6 +363,7 @@ bloomingdales.com
 blt.ne.jp
 blueberrytelecom.com
 bluecast.ae
+bluegrass.net
 bluenet.ch
 bluepark.co.uk
 blueseasdesigns.com
@@ -530,6 +543,7 @@ cisumrecords.com
 citel.com.mx
 citynet.uz
 cityzoneinfo.com
+civica.com
 ckaik.cn
 clarksvillemotel.com
 claro.com.py
@@ -555,6 +569,7 @@ cloudlogin.co
 cloudpap.com
 cloudplatformpro.com
 cloudsector.net
+cloudsigma.com
 cloudtreno.com
 cloverknollcrafter.com
 cltel.net
@@ -653,6 +668,7 @@ creditpulsehq.com
 cressforda.live
 crestmorn.xyz
 crestridgea.xyz
+criticalcore.nl
 criticalserver8.net
 crnagora.net
 crnetfibra.com.br
@@ -666,6 +682,7 @@ csii.com.hk
 cspirefiber.net
 ct.co.cr
 ctinets.com
+ctk.ne.jp
 ctla.co.kr
 ctstelecom.net
 cumbalikonakhotel.com
@@ -858,6 +875,7 @@ eaglezip.com
 eancenter.com
 eappscdn.com
 earthcare.com
+easpnet.com
 easternkingspei.com
 easyfiber.net.br
 easylink.com
@@ -886,6 +904,7 @@ ejssweets.com
 electricityforum.info
 electronic-consultants.net
 electroplastcr.com
+elektrons-k.lv
 eletelnet.net.br
 elfin.pl
 elhajam.com
@@ -944,6 +963,7 @@ espeed.com.bn
 esprimo.com
 esvabroadband.net
 eteccinformatica.com.br
+etherway.ru
 etisalcom.net
 etsecureserver.com
 eueco.de
@@ -1013,6 +1033,7 @@ fewo-usedom.net
 fgvtelecom.com.br
 fiberalley.com
 fibercorp.com.ar
+fiberdirekt.se
 fiberlinkpe.net.br
 fiberstate.com
 fibramaxbandalarga.com.br
@@ -1135,6 +1156,7 @@ gigasat.net.br
 gigasoftsystems.com
 gigidea.net
 giize.com
+gilanet.net
 gilnet.com.br
 ginous.eu.com
 ginza-entre.com
@@ -1151,6 +1173,7 @@ globalglennpartners.com
 globall.net.br
 globalmicrodosingshop.com
 globalnetserver.net
+globaltransitsystems.online
 globalvistatech.com
 globetrotgal.info
 globoinfo.net.br
@@ -1343,12 +1366,14 @@ hwclouds-dns.com
 hybridinternet.co
 hypericine.com
 hypernet.co.id
+hypernet.ru
 hypointfarms.com
 i-com.fr
 i-mecca.net
 i4cus.tech
 i4dots.com
 iaasdns.com
+iaclouds.com
 iam.net.ma
 iasys-sg.com
 ib.systems
@@ -1394,6 +1419,7 @@ immenzaces.com
 imobie.com
 impey.shop
 improvation.us
+impuls-perm.ru
 in-addr-arpa
 in-addr.arpa
 in2cable.com
@@ -1436,7 +1462,9 @@ interactivedns.com
 interbat.com
 intercom-47-160.pro
 interdata.vn
+interdigi.info
 interfacenet.ar
+interfacenet.com.ar
 interfacenet.net.br
 interfarma.kz
 interflixtelecom.com.br
@@ -1472,6 +1500,7 @@ iperactive.com.ar
 ipl.red
 ipochaser.com
 ipsj.or.jp
+iq.pl
 iqcarr.us.com
 iranita.com
 irapture.com
@@ -1487,6 +1516,7 @@ ispguatemala.com.gt
 ispservices.us
 iswhatpercent.com
 isx.net.nz
+it-nextstep.com
 itc.net.il
 itcng.net
 ite.bg
@@ -1508,6 +1538,7 @@ ivol.co
 ixian3.net
 izaz.com.br
 jacksonpark.com
+jacksonremc.com
 jacobyfeed.com
 jacquelinej.net
 jaeres.com
@@ -1552,6 +1583,7 @@ justplayer.ne.jp
 jutikka.iki.fi
 jwtdigital.co.uk
 jz.adsl
+k2.cloud
 k2telecom.net.br
 kabsi.at
 kadastr.ru
@@ -1605,6 +1637,7 @@ krillaglass.com
 ksasaudi.net
 ksnet.com.br
 ktr.or.kr
+kujtesa.com
 kula.co.mz
 kulttsolutions.co.in
 kuritzen.net
@@ -1685,6 +1718,7 @@ local.net
 localventures.org
 locovmtools.it.com
 loeberlozano.com
+lofisnet.ru
 logicielsdavos.com
 logis.com.mx
 logotelecom.net.br
@@ -1816,6 +1850,7 @@ meditong.com
 meetunearthed.de
 megalan.bg
 megalinkbandalarga.com.br
+meganet.net
 meganetscm.net.br
 megasrv.de
 megaturbointernet.com.br
@@ -1968,6 +2003,7 @@ neovet-base.ru
 nerdnetwork.us
 net-results.com
 net-rubi.com.br
+netassist.ua
 netbitsfibra.com.br
 netboard.hu
 netbri.com
@@ -1977,6 +2013,7 @@ netcell.inf.br
 netcentertelecom.net.br
 netcom.host
 netcom.psi.br
+netcrew.fi
 netdoor.com
 netfiber.inf.br
 netfibra.com.br
@@ -2014,6 +2051,7 @@ nex-tech.com
 nexa.tr
 nextadvance.com
 nextdoor.com.eg
+nextlevelinternet.com
 nextnetwork.net.br
 nexus.telecom
 nexuserver.net
@@ -2058,6 +2096,7 @@ novast.com
 novuscom.net
 npbnl.net
 nqntv.com.ar
+nque.com
 ns360.net
 nssonline.com
 nstelecablecr.com
@@ -2093,6 +2132,7 @@ odn.ne.jp
 offerofpromovue.site
 offerslatedeals.com
 office365.us
+ogi.wales
 ogicom.net
 ogreserve.com
 okbprogress.ru
@@ -2132,6 +2172,7 @@ optimalhealthtip.com
 optnum.com
 optusnet.com.au
 oracleemaildelivery.com
+orange.jo
 orbitel.net.co
 orfsurface.com
 orientalspot.com
@@ -2140,6 +2181,7 @@ orssatto.net.br
 ospepm.cn
 oss-core.com
 oss-core.net
+ostkom.lv
 otccatering.com
 otmprint.com
 ourhosted.com
@@ -2149,6 +2191,7 @@ outsidences.com
 outsource-philippines.com
 ovaapart.com
 ovaltinalization.co
+ovea.com
 overta.ru
 owexxhosting.com
 owgelsgroup.com
@@ -2248,6 +2291,7 @@ portalqueops.net.br
 ports.net
 posolstvostilya.com
 postdirect.net
+postmail.com.cn
 postzaus-home.life
 potia.net
 pottingcompounds.com
@@ -2303,6 +2347,7 @@ quasarstate.store
 quatthonggiotico.com
 quenato.shop
 quest-on-demand.com
+questzones.ca
 quickbuddyicons.com
 quicksrv.de
 qxyxab44njd.com
@@ -2403,12 +2448,14 @@ rscb.org.in
 rsconnection.net.br
 rtat.net
 rtpgiga33.site
+rts.ru
 rubypluspl.us
 rudyguerra.com
 rumahweb.net
 runnin-rebels.com
 rupar.puglia.it
 ruralband.us
+rusanovka-net.kiev.ua
 russel-aitken.co.uk
 rvinternet.net.br
 rvr.in
@@ -2579,6 +2626,7 @@ soes.su
 softdados.net
 softinsightpro.com
 software-computer.de
+sognenett.no
 solarislenses.co.uk
 solixoutreach.com
 sollutium.com
@@ -2605,6 +2653,7 @@ speculations.com
 speednetprov.com.br
 speednetsa.net
 speedtravel.net.br
+speedyline.ru
 spicerackdeli.com
 spiritualtechnologies.io
 spkrl.com
@@ -2643,6 +2692,7 @@ sterling.net
 sterlingescrow.org
 sterlinggroupusa.com
 stillwell.com.hk
+stnet.ad.jp
 stnet.ne.jp
 stock-smtp.top
 stockepictigers.com
@@ -2733,6 +2783,7 @@ telecable.es
 telecet.ru
 telecominternet.net.br
 teledata.mz
+telemontv.com
 telenew.com.br
 telenor.net
 telnet.net.bd
@@ -2777,6 +2828,7 @@ throughputclimb.com
 tiagosilvaprovedores.com.br
 ticdns.com
 ticowebsite.com
+tier4.cloud
 tietoenator.com
 tigo.bo
 tigoune.com.co
@@ -2882,11 +2934,13 @@ ugtelecom.info
 uih.co.th
 uiyum.com
 ujezd.net
+uknoc.co.uk
 ukontrack.com
 ultradesic.com
 ultragate.com
 ultrasrv.de
 uma-jin.net
+umos.ru
 unafiber.net.br
 unaxus.net
 undersilence.net
@@ -2910,6 +2964,7 @@ usablechat.com
 usg-research.eu
 usipp.net
 usskilledserve.com
+utopia.ai
 utopiafiber.com
 utopianhomespa.com
 v-tal.net.br
@@ -2932,6 +2987,7 @@ veenet.africa
 vega-ua.net
 velloznet.com.br
 velocinet.com.br
+velocitytelephone.com
 veloxsp.net.br
 veloxzone.com.br
 veltranoplc.shop
@@ -2952,6 +3008,7 @@ vianetbarras.com.br
 viaparque.net.br
 viaprovedor.com.br
 viartelecom.com.br
+vibrantbb.net
 vibrantwellnesscorp.com
 viggoss.com.au
 viking.com
@@ -3079,6 +3136,7 @@ winde.jp
 winempresas.pe
 wingerslikane.com
 winstonsalemmuseum.com
+wintech.ad.jp
 wiroos.host
 wisdomhard.com
 wisewealthcircle.com
@@ -3106,6 +3164,7 @@ wsr.ac.at
 wszz.torun.pl
 wtcks.net
 wtutelecom.com.br
+wwwmho.com
 wydmedia.com
 wyyerd.us
 wz-kliniken.de


### PR DESCRIPTION
## Summary

Continued the MMDB ASN-domain coverage walk from #747 into the 18k–14k IPv4-weight band. Added **941 new map entries** and 59 new known-unknown entries from the top 1,000 unmapped candidates.

**Coverage delta:**
- ASN-domain coverage by IPv4 weight: **96.0% → 96.5%**
- ASN-domain coverage by domain count: 9.5% → 11.0%
- Map total entries: 9,151 → 10,092

**Composition of additions:**
- ~50 universities and government / state agencies (HMRC, SSA, DHS, DOJ, BART, Pittsburgh, Charlotte, NY courts, Bank of Canada, MTA, gov.si, gov.ru, KAUST, Sharif University, Karolinska Institutet, KTH, etc.)
- ~70 globally-known brands (Nvidia, AMD, BMW, Mastercard, Nasdaq, NetApp, Allianz, Honeywell, JPMorgan, Goldman Sachs, Mitel, Arista, Take-Two, Universal Music, Fox, Nike, Cigna, Aetna, Humana, AbbVie, Mitsubishi Electric, Saint-Gobain, Reliance Industries, Hyundai Autoever, Square Enix, NEXON, Riot Games, HSBC, Standard Chartered, Telegram, RIPE NCC, etc.)
- Long tail of regional ISPs / hosters / MSPs / data center operators classified via MMDB \`as_name\` + homepage corroboration

**known-unknown changes:** 59 added where the two-corroborating-sources bar still wasn't met. The two files remain disjoint per the workflow guardrail.

## Test plan

- [x] \`python sortlists.py\` exits 0 (types valid, alphabetic sort, dedupe)
- [x] CRLF line endings preserved in \`base_reverse_dns_map.csv\`
- [x] No domain appears in both \`base_reverse_dns_map.csv\` and \`known_unknown_base_reverse_dns.txt\` (\`comm -12\` check passes)
- [x] No full-IP entries in either file (privacy rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)