### PR TITLE
Classify reverse DNS map: next 1000 unmapped MMDB ASN domains

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -2,6 +2,7 @@ base_reverse_dns,name,type
 0101host.com,0101HOST,Web Host
 012.net.il,012Mobile (Partner),ISP
 018.co.il,XPhone (XFone 018),ISP
+019mobile.co.il,019Mobile (Telzar),ISP
 02online.de,Telefonica O2 Germany,ISP
 099.net.il,099 Primo Communications,ISP
 1-2-1marketing.com,foreUP,SaaS
@@ -27,12 +28,14 @@ base_reverse_dns,name,type
 123website.nl,One.com,Web Host
 1240.hu,EuroCable Hungary,ISP
 126.com,NetEase,Email Provider
+1310.io,1310,ISP
 15min.lt,15min,News
 163.com,163,Email Provider
 163data.com.cn,China Telecom,ISP
 180medical.com,180 Medical,Healthcare
 189.cn,China Telecom,ISP
 1blu.de,1blu,Web Host
+1city.org,Yalta-Tv KOM,ISP
 1e100.net,Google,Technology
 1gservers.com,1GServers,Web Host
 1scom.com,Millennium Telcom,ISP
@@ -44,6 +47,8 @@ base_reverse_dns,name,type
 23m.com,23M,Web Host
 24shells.net,24 Shells,Web Host
 263.net,263,Email Provider
+263global.com,263 Global Communications,ISP
+2connect.cz,2 Connect,ISP
 2day.kz,2DAY Telecom LLP,ISP
 2degrees.nz,2degrees,ISP
 2iij.net,IIJ,ISP
@@ -56,14 +61,18 @@ base_reverse_dns,name,type
 365datacenters.com,365 Data Centers,Web Host
 3bb.co.th,3BB,ISP
 3bb.in.th,3BB,ISP
+3data.ru,3data,IaaS
 3disystems.com,3Di Systems,SaaS
 3dprintingindustry.com,3D Printing Industry,Industrial
+3ds.com,Dassault Systèmes,SaaS
+3hcloud.com,Newserverlife,IaaS
 3kt.eu,3K Technology,MSP
 3m.com,3M,Manufacturing
 3rivers.net,3 Rivers Communications,ISP
 3s.com.tn,3S Tunisie,MSP
 3s.pl,Play,ISP
 3utilities.com,No-IP,Web Host
+3winfra.com,3W Infra,IaaS
 3xktech.cloud,3xK Tech,Web Host
 3z.net,3z,MSP
 3zden.cloud,3z,MSP
@@ -71,17 +80,21 @@ base_reverse_dns,name,type
 47.pl,AfterMarket.pl,Web Host
 4d-dc.com,Redcentric,Web Host
 4gbhost.com,4GBHost,Web Host
+51idc.com,51IDC,IaaS
 5gnetworks.com.au,5G Networks Australia,MSP
 6dg.co.uk,Six Degrees,MSP
 6ptelecom.com.br,6P Telecom,ISP
 7-dj.com,Fujitsu Systems Applications,MSP
 702com.com,702 Communications,ISP
 7bull.net,7BullNet (MyTek Trading),ISP
+7play.es,7Play,ISP
+7sigma.net,Lake Livingston Communications,ISP
 7stardigitalnetwork.com,Seven Star Digital Network,ISP
 84grams.se,84 Grams,ISP
 8x8.com,8x8,SaaS
 99cloudhosting.com,99CloudHosting,Web Host
 a-hadar.co.il,Hadar Group,Real Estate
+a-n-t.ru,Alpha Net Telecom,ISP
 a1.bg,A1,ISP
 a1.by,A1,ISP
 a1.hr,A1,ISP
@@ -95,6 +108,7 @@ a2hosting.com,A2 Hosting,Web Host
 a2mobile.pl,a2mobile,ISP
 a2telecomfibra.com.br,A2 Telecom Fibra,ISP
 a2webhosting.com,hosting.com,Web Host
+a2z.az,A2Z Technologies,MSP
 a2zcreatorz.ca,A2Z Creatorz,Technology
 aa.com,American Airlines,Travel
 aa.net.uk,Andrews & Arnold,ISP
@@ -113,6 +127,7 @@ abbvie.com,AbbVie,Healthcare
 abc.net.au,ABC,Government Media
 abchk.com,ABCHK,Web Host
 abchk.net,ABCHK,Web Host
+abcrede.com.br,ABCRede,ISP
 abissnet.al,Abissnet,ISP
 ablbrasil.com.br,ABL Brasil,Healthcare
 abn.co.kr,Areum Broadcasting Network,ISP
@@ -120,6 +135,7 @@ abnamro.com,ABN AMRO,Finance
 abnormal-email.com,Abnormal AI,Email Security
 abogados.or.cr,Colegio de Abogados de Costa Rica,Legal
 abs.gov.au,Australian Bureau of Statistics,Government
+absa.co.za,Absa,Finance
 absatellite.com,ABS Satellite,ISP
 abstract.fi,Abstract,Web Host
 abv.bg,ABV Mail,Email Provider
@@ -132,12 +148,14 @@ accelecom.net,Accelecom,ISP
 accelia.net,Accelia,SaaS
 accenture.com,Accenture,Consulting
 accesscom.com,HyperSurf (Accesscom),ISP
+accessglobalcommunication.co.za,AccessGlobal Communication,ISP
 accesshaiti.net,Access Haiti,ISP
 accessmedlab.com,Access Medical Labs,Healthcare
 accessnet.com.br,AccessNet,ISP
 accessoneinc.com,Access One,MSP
 accesstel.net,AccessTEL,ISP
 accretive-networks.net,Accretive Technology Group,SaaS
+accs.or.jp,Academic Newtown Community Cable,ISP
 acd.net,ACD.net,ISP
 ace-fiber.com,ACE Fiber,ISP
 ace-host.net,Ace-Host,Web Host
@@ -151,6 +169,7 @@ acentek.net,AcenTek,ISP
 aceredc.com,Acer e-Enabling Data Center,Web Host
 acessecomunicacao.com.br,Acesse,ISP
 acessoline.net.br,Alt Telecom,ISP
+acetelecom.hu,ACE Telecom,ISP
 acgov.org,Alameda County Government,Government
 ach.or.jp,Ageo Central General Hospital,Healthcare
 acim-pr.org.br,ACIM,Nonprofit
@@ -165,17 +184,20 @@ acropolis.org,New Acropolis,Education
 act.gov.au,ACT Government,Government
 actcorp.in,ACT Fibernet,ISP
 actionnetwork.org,Action Network,SaaS
+actito.com,ACTITO,Marketing
 active-servers.com,active-servers,Web Host
 active24.cz,Active24,Web Host
 activecampaign.com,ActiveCampaign,Marketing
 activegate-ss.jp,Active! gate SS,Email Security
 activenetwork.it,Active Network Italy,ISP
 activetrail.biz,ActiveTrail,Marketing
+actv.ne.jp,Aomori Cable TV,ISP
 acu.edu,Abilene Christian University,Education
 acuperfectwebsites.com,AcuPerfect Websites,Web Host
 acxiom.com,Acxiom,Marketing
 ada.net.tr,AdaNET,ISP
 adabank.com.tr,Dünya Katılım,Finance
+adacor.com,Adacor Hosting,IaaS
 adairit.com,Adair IT,MSP
 adam.es,Adam EcoTech,Web Host
 adamant.ua,Adamant,ISP
@@ -186,8 +208,10 @@ adaptiv-networks.com,Adaptiv Networks,SaaS
 adc.net.ar,Aguas del Colorado,Utilities
 adcstack.com,ADC Group,Web Host
 additionnetworks.net,CherryRoad Technologies,MSP
+addix.net,ADDIX,ISP
 addsecure.se,AddSecure,SaaS
 adelaide.edu.au,University of Adelaide,Education
+adeodc.dk,Adeo Datacenter,IaaS
 adept.co.za,Adept ICT,ISP
 adient.com,Adient,Manufacturing
 adista.fr,Adista,ISP
@@ -228,6 +252,7 @@ aetna.com,Aetna,Healthcare
 aevengroup.com,Aeven,MSP
 aeza.net,Aeza,Web Host
 aeza.network,Aeza,Web Host
+aeza.ru,Aeza,IaaS
 af-k.de,I-NetPartner GmbH,ISP
 af.mil,U.S. Air Force,Defense
 afes.com,AFES Network Services,ISP
@@ -240,6 +265,7 @@ afp.com,Agence France-Presse,News
 afr-ix.com,AFR-IX Telecom,ISP
 afranet.com,Afranet,ISP
 afrarasa.com,Afra Rasa,ISP
+afribone.com,Afribone Mali,ISP
 africaoncloud.net,Africa on Cloud,IaaS
 africaonline.na,Africa Online Namibia,ISP
 afrihost.com,Afrihost,ISP
@@ -263,16 +289,21 @@ ahn.org,Allegheny Health Network,Healthcare
 ahold.com,Ahold,Retail
 aholddelhaize.com,Ahold Delhaize,Retail
 ahosting.net,Ahosting,Web Host
+ahrefs.com,Ahrefs,Marketing
 ahrt.hu,4iG Telecommunications,ISP
 aichi-colony.jp,Aichi Developmental Disability Center,Healthcare
+aig.com,AIG,Finance
 aigmedical.com,Affiliates in Gastroenterology,Healthcare
 aiinformatics.com,ai informatics,MSP
 aila.org,American Immigration Lawyers Association,Nonprofit
 aims.com.my,AIMS Data Centre Malaysia,Web Host
 ainet.at,Ainet,ISP
+ainetfactory.com,American Information Network,ISP
+ains.com.au,Australia Internet Solutions,ISP
 air-cargo.kiev.ua,Air-Cargo,Logistics
 airadvantage.net,Air Advantage,ISP
 airbus.com,Airbus,Defense
+aircanada.ca,Air Canada,Travel
 aircleaningspecialists.com,"Air Cleaning Specialists, Inc.",Industrial
 aircomusa.com,FaxPipe (Formerly AirCom USA),SaaS
 airdata.ag,AIRDATA,ISP
@@ -285,6 +316,7 @@ airnet.jp,Air Internet Service,ISP
 airnetnetworks.com,Airnet Networks,ISP
 airnewzealand.com,Air New Zealand,Travel
 airport.kr,Incheon International Airport,Travel
+airspeed.ie,Airspeed Communications,ISP
 airstreamcomm.net,Airstream Communications,ISP
 airtekinternet.com,Airtek Solutions,ISP
 airtel.cd,Airtel,ISP
@@ -339,6 +371,7 @@ albany.edu,University at Albany SUNY,Education
 albatros.uz,Albatros Health Care,Healthcare
 alberta.ca,Government of Alberta,Government
 albertahealthservices.ca,Alberta Health Services,Healthcare
+alcans.com.br,Alcans,ISP
 alcansservicos.com.br,Alcans Telecom,ISP
 alcanstelecom.com.br,Alcans Telecom,ISP
 alcom.ax,Alcom Aland,ISP
@@ -378,6 +411,7 @@ allianzsna.com,SNA Insurance,Finance
 alliedtelecom.net,Allied Telecom,ISP
 alligacom.com,TrueCommerce,SaaS
 allinahealth.org,Allina Health,Healthcare
+allnodes.com,Allnodes,SaaS
 allocommunications.com,ALLO,ISP
 allpointsbroadband.com,All Points Broadband,ISP
 allpointsfibre.uk,AllPoints Fibre,ISP
@@ -392,16 +426,20 @@ almatel.ru,Almatel,ISP
 almatv.kz,AlmaTV,ISP
 almeidaparente.eti.br,Almeida Parente,ISP
 almobile.com,AL Mobile,SaaS
+alootelecom.com.br,Aloo Telecom,ISP
 alorica.com,Alorica,Staffing
 alpha-mail.net,Otsuka Corporation,MSP
 alpha-prm.jp,Otsuka Corporation,MSP
 alphacron.de,AlphaCron Datensysteme,Web Host
 alphalink.fr,Alphalink,ISP
+alphavps.com,AlphaVPS,IaaS
 alsatis.com,Alsatis,ISP
 alsatwireless.com,Air Link Rural Broadband,ISP
 alsk.com,Alaska Communications,ISP
 altafiber.com,altafiber,ISP
 altafibra.mx,Altafibra,ISP
+altamahafiber.com,Altamaha Fiber,ISP
+altanredes.com,Altán Redes,ISP
 altarede.com.br,AltaRede,ISP
 altayer.om,Al-Tayer Engineering Services,Construction
 altecom.net,FIBRACAT Telecom,ISP
@@ -434,6 +472,7 @@ ambisys.net,Ambisys,Healthcare
 ambit.com.tw,Ambit Microsystem,Manufacturing
 amd.com,AMD,Manufacturing
 amdintl.com.tw,Kangjian Biomedical Technology,Healthcare
+amdocs.com,Amdocs,SaaS
 america-net.com.br,America-NET,ISP
 america.net,America.net,Web Host
 american.edu,American University,Education
@@ -453,13 +492,16 @@ amis.hr,A1 Croatia (Amis),ISP
 amnet.com.ni,Amnet Telecomunicaciones,ISP
 amobia.com,Amobia,ISP
 ampernet.com.br,Ampernet,ISP
+amplex.net,Amplex,ISP
 amplia.co.tt,AMPLIA,ISP
 amplifyapp.com,Amazon AWS,PaaS
 amplitudo.me,Amplitudo,SaaS
 amres.ac.rs,AMRES,Education
+amt.ru,AMT Telecom,ISP
 amur.ru,Rostelecom Amur,ISP
 an-net.ru,Annet Tver,ISP
 analabs.com.sg,ANALABS,Construction
+analog.com,Analog Devices,Manufacturing
 andorratelecom.ad,Andorra Telecom,ISP
 andrews.edu,Andrews University,Education
 andritz.com,Andritz,Manufacturing
@@ -468,6 +510,7 @@ anexia-it.com,Anexia,Web Host
 anexia.com,Anexia,Web Host
 angelo.edu,Angelo State University,Education
 angolatelecom.com,Angola Telecom,ISP
+anheuser-busch.com,Anheuser-Busch,Food
 anid.com.br,ANID,Nonprofit
 ankara.edu.tr,Ankara University,Education
 anl.gov,Argonne National Laboratory,Government
@@ -482,16 +525,19 @@ antelecom.net,Antelecom,ISP
 antelecom.net.br,AN Telecom,ISP
 anthembroadband.com,Anthem Broadband,ISP
 anti-spam-premium.com,Liquid Web,Web Host
+anticlockwise.com.au,Anticlockwise,MSP
 antietambroadband.com,Antietam Broadband,ISP
 antilles-sante.com,AAS Medical,Healthcare
 antispamcloud.com,N-able,Email Security
 antispameurope.com,Hornetsecurity,Email Security
+anw.at,Alpha NetWork,ISP
 anydigital.sg,AnyDigital,Web Host
 anylogic.com,AnyLogic,SaaS
 anz.com,ANZ Banking Group,Finance
 aoc.gov,Architect of the Capitol,Government
 aofidc.com,Aofei Data International,Web Host
 aoiot.ru,IOT (Skolkovo),IaaS
+aon.com,Aon,Finance
 aopa.org,AOPA,Travel
 aoyama.ac.jp,Aoyama Gakuin University,Education
 ap.org,Associated Press,News
@@ -499,8 +545,10 @@ apa-it.at,APA-Tech,MSP
 apa.at,APA-Tech,MSP
 apaudit.eu,Transparent,Finance
 apexsol.com,Apex Technology,Marketing
+apfutura.net,APfutura Telecom,ISP
 aphp.fr,APHP Paris Hospitals,Healthcare
 aplusgroup.net,A Plus International,Healthcare
+apmoller.com,A.P. Moller - Maersk,Logistics
 apnic.net,APNIC,Nonprofit
 apogee.us,Boldyn,ISP
 apogeehost.com,ApogeeHOST,Web Host
@@ -510,6 +558,7 @@ app-tec.com,Applied Technologies,ISP
 apple.com,Apple,Email Provider
 applefibernet.com,Apple Fibernet,ISP
 applicationx.net,Application X,MSP
+appliedi.net,Applied Innovations,MSP
 appliedmaterials.com,Applied Materials,Manufacturing
 appliwave.com,Eurofiber France (Appliwave),ISP
 appnexus.com,Microsoft Advertising (Xandr),Marketing
@@ -519,15 +568,18 @@ apps-1and1.net,IONOS,Web Host
 appsfruit.com,AppsFruit,Marketing
 appspot.com,Google,PaaS
 aps-inc.co.jp,Arahi Polyslider,Industrial
+aps.edu,Albuquerque Public Schools,Education
 apsfl.in,APSFL Andhra Pradesh State FiberNet,ISP
 aptalaska.com,AP&T,ISP
 aptalaska.net,AP&T,ISP
 aptg.com.tw,APBT,ISP
 aptum.com,Aptum,Web Host
+aptus.co.tz,Aptus Solutions,IaaS
 apxnetprovedor.com.br,Apx Net,ISP
 aql.com,aql,ISP
 aqmd.gov,South Coast AQMD,Government
 aqmhost.net,AqmHost,Web Host
+aqr.com,AQR Capital Management,Finance
 aragon.es,Government of Aragon,Government
 araguaianetmt.com.br,ARAGUAIANET,ISP
 aramcoinc.com,Saudi Aramco,Industrial
@@ -535,7 +587,9 @@ aranetplay.com.br,Aranet Play,ISP
 arapabruzzo.it,ARAP,Industrial
 arax.md,Arax-Impex,ISP
 arbital.ru,Arbital St. Petersburg,ISP
+arbuckleonline.com,Arbuckle Communications,ISP
 archerirm.us,Archer GRC,SaaS
+archimedianet.it,Archimedia,Retail
 archtopfiber.com,Archtop Fiber,ISP
 arcor-ip.net,Vodafone,ISP
 arcusnovus.com,Arcus Novus,Web Host
@@ -572,6 +626,8 @@ artehosting.com.mx,Artehosting,Web Host
 artelecom.pt,AR Telecom,ISP
 arteria-net.com,ARTERIA Networks,ISP
 artfiles.de,Artfiles,Web Host
+arthatel.co.id,Artha Telekomindo,MSP
+artmotion.net,ARTMOTION,ISP
 artnet.pl,Artnet,Web Host
 artx.ru,ArtX,ISP
 aruba.it,Aruba.it,Web Host
@@ -631,6 +687,8 @@ asteria.com,Asteria,SaaS
 astound.com,Astound Broadband,ISP
 astralinfo.co.uk,Astral Informatics,Marketing
 astreaconnect.com,Astrea Communications,ISP
+astuteinternet.com,Astute Internet,ISP
+astutium.com,Astutium,Web Host
 asu-vei.ru,ASU-VEI,Industrial
 asu.edu,Arizona State University,Education
 asvt.ru,ASVT,ISP
@@ -643,6 +701,7 @@ atea.no,Atea Norway,MSP
 ateky.net.br,Ateky Internet,ISP
 atel-rybinsk.ru,AtelRybinsk,ISP
 atel76.ru,Atel Yaroslavl,ISP
+ateltelecom.com.br,Natel Telecom,ISP
 atextelecom.com.br,ATEX Telecom,ISP
 atheer.net.sa,Atheer Net (Jeraisy),ISP
 athenet.net,NTD Networks (Athenet),ISP
@@ -651,9 +710,11 @@ ati.org,ATI Advanced Technology International,Defense
 ati.pe.gov.br,ATI Pernambuco,Government
 ati.tn,Agence Tunisienne d'Internet,Government
 atiinternet.com.br,ATI Internet,ISP
+atkinsrealis.com,AtkinsRéalis,Construction
 atlantech.net,Atlantech Online,ISP
 atlantic.net,Atlantic.Net,Web Host
 atlanticmetro.net,365 Data Centers,Web Host
+atlantisgames.lt,Atlantis Games,Entertainment
 atlas-elektronik.com,Atlas Elektronik,Defense
 atlasnet.com,Atlas Networks,ISP
 atlax.com,ATLAX,Web Host
@@ -663,8 +724,10 @@ atman.pl,Atman,IaaS
 atmc.com,Focus Broadband (ATMC),ISP
 atmc.net,FOCUS Broadband,ISP
 atni.com,ATN International,ISP
+atom.com.mm,Atom Myanmar,ISP
 atom86.net,atom86,ISP
 atomic.ac,Atomic,ISP
+atomicdata.com,Atomic Data,MSP
 atonementonline.com,Our Lady of the Atonement,Religion
 atos.net,Atos,Consulting
 atruvia.de,Atruvia,MSP
@@ -684,6 +747,7 @@ auckland.ac.nz,University of Auckland,Education
 audi.com,Audi,Automotive
 augsburg.edu,Augsburg University,Education
 augusta.edu,Augusta University,Education
+aunalytics.com,Aunalytics,SaaS
 auone-net.jp,KDDI,ISP
 aup.edu.pk,"University of Agriculture, Peshawar",Education
 aura.dk,AURA Fiber,ISP
@@ -694,6 +758,7 @@ auspost.com.au,Australia Post,Logistics
 aussiebb.com.au,Aussie Broadband,ISP
 aussiebroadband.com.au,Aussie Broadband,ISP
 australianjewishnews.com,The Australian Jewish News,News
+australiaonline.net.au,Australia Online,ISP
 aut.ac.nz,Auckland University of Technology,Education
 auth.gr,Aristotle University of Thessaloniki,Education
 autodesk.com,Autodesk,SaaS
@@ -707,10 +772,13 @@ avanta-telecom.ru,Аванта Телеком,ISP
 avantel.ru,Avantel,ISP
 avantiplc.com,Avanti Broadband,ISP
 avantnet.ru,Avant,ISP
+avanza.com.br,Avanza Telecom,ISP
 avatel.es,Avatel,ISP
+avative.net,Avative Fiber,ISP
 avato.com.br,Brasil TecPar,ISP
 avaya.com,Avaya,Technology
 avci.net,Agri-Valley Communications,ISP
+avcsa.com.ar,Atlantica Video Cable,ISP
 avency.de,avency,MSP
 aveniq.ch,Aveniq,MSP
 aventelfrance.com,Aventel,ISP
@@ -740,14 +808,17 @@ axtel.net,Axtel,ISP
 axtelcorp.mx,Axtel,ISP
 ayalaland.com,Ayala Land,Real Estate
 ayalaland.com.ph,Ayala Land,Real Estate
+ayalaport.com,AyalaPort,IaaS
 ayera.com,Ayera,ISP
 ayy.fi,Aalto University Student Union,Education
+azcentral.com,Central Newspapers Technologies,News
 azecom.com.br,Azecom Internet,ISP
 azercell.com,Azercell,ISP
 azeronline.com,Azeronline,ISP
 azertelecom.az,AzerTelecom,ISP
 azintelecom.az,AzInTelecom,ISP
 azmoves.com,Coldwell Banker,Real Estate
+aznet.fr,Aznet,ISP
 azregents.edu,Arizona Board of Regents,Education
 azstarnet.az,Azstarnet (Metronet),ISP
 azteca-comunicaciones.com,Aztec Communications Columbia,ISP
@@ -762,7 +833,9 @@ b2b2c.ca,B2B2C,ISP
 b4rn.org.uk,B4RN,ISP
 babilon-t.com,Babilon-T,ISP
 babson.edu,Babson College,Education
+backboneconnect.co.uk,Backbone Connect,MSP
 backland.net,Backland Communications,MSP
+badenit.de,badenIT,MSP
 badrrayan.com,Badr Rayan Jonoob,ISP
 baesystems.com,BAE Systems,Defense
 bage.dev,BAGE CLOUD,Web Host
@@ -778,19 +851,24 @@ balticum.lt,Balticum TV,ISP
 bambroadband.com,BAM Broadband,ISP
 banchero.org,Bancharo Disability Services,Healthcare
 bancogalicia.com,Banco Galicia,Finance
+bandaancha.cl,Optic Telecomunicaciones,ISP
 bandwidth.co.uk,Bandwidth Technologies,ISP
 bangla.net,ISN Bangla,ISP
+banglalink.net,Banglalink Digital Communications,ISP
 bangmod.cloud,Bangmod Cloud,Web Host
 bank-banque-canada.ca,Bank of Canada,Government
+bank-verlag.de,Bank-Verlag,Finance
 bankofamerica.com,Bank of America,Finance
 banxico.org.mx,Banco de Mexico,Government
 barak-online.net,Netvision,ISP
 barclays.co.uk,Barclays,Finance
 barclayscapital.com,Barclays Investment Bank,Finance
+bard.edu,Bard College,Education
 bardstowncable.net,City of Bardstown Cable,ISP
 baremetal.co.za,Baremetal,ISP
 barings.com,Barings,Finance
 barracuda.com,Barracuda,Email Security
+barryelectric.com,Barry Electric,Utilities
 bart.gov,BART Bay Area Rapid Transit,Government
 barvanet.kz,Barvanet,MSP
 bas.bg,Bulgarian Academy of Sciences,Science
@@ -801,12 +879,15 @@ bashtel.ru,Bashtel,ISP
 basicserver.io,Zitcom,Web Host
 basketnews.lt,BasketNews,Sports
 basmail.jp,TOKI Communications Corporation,ISP
+bassac.fr,Bassac,Construction
+batan.coop,Cooperativa Batan,Utilities
 batelco.com,Batelco,ISP
 bates.edu,Bates College,Education
 battelle.org,Battelle Memorial Institute,Science
 bausch.com,Bausch and Lomb,Healthcare
 baxet.ru,Baxet Holding,Web Host
 baxetgroup.com,Baxet Group,Web Host
+baxter.com,Baxter Healthcare,Healthcare
 bayada.com,BAYADA Home Health Care,Healthcare
 baycix.de,BayCIX,Web Host
 bayer.com,Bayer,Healthcare
@@ -817,22 +898,29 @@ baynet.ne.jp,Tokyo Bay Network,ISP
 bayobab.africa,Bayobab (MTN GlobalConnect),ISP
 bayonette.no,Bayonette (Nexthop),Web Host
 bayoulandcs.com,Bayouland Computer Solutions,MSP
+baza.net,Baza.NET,ISP
 bb-niigata.jp,Niigata Communication Service,ISP
 bb.com.br,Banco do Brasil,Finance
 bbbell.it,BBBell,ISP
 bbc.com,BBC,News
 bbemaildelivery.com,BombBomb,Marketing
+bbft.no,Bredbåndsfylket,ISP
 bbix.net,BBIX,ISP
+bbkhost.com,CyberForest,IaaS
 bbned.nl,Odido,ISP
 bbnetup.com,BBNET UP,ISP
 bbnetup.com.br,BBNET UP,ISP
 bbraun.de,B. Braun Melsungen,Healthcare
+bbsred.com.mx,BBS Red,ISP
 bbt.com.ar,BroadBandTech,ISP
 bbtel.com,BBTEL,ISP
 bbtower.co.jp,BroadBand Tower,Web Host
+bbts.net,Broad Band Telecom Services,ISP
 bc.edu,Boston College,Education
 bc.net,BCNET,Education
 bc9.ne.jp,Kanuma Cable Television,ISP
+bcaa.com,BCAA,Finance
+bcbsal.org,Blue Cross and Blue Shield of Alabama,Healthcare
 bcbsm.com,Blue Cross Blue Shield of Michigan,Healthcare
 bcbsnc.com,Blue Cross Blue Shield of North Carolina,Healthcare
 bcc.co.ug,Blue Crane Communications Uganda,ISP
@@ -841,6 +929,7 @@ bcit.ca,British Columbia Institute of Technology,Education
 bclan.ru,BCLan,ISP
 bcm.edu,Baylor College of Medicine,Education
 bcnetsp.com.br,BC Net,ISP
+bcntele.com,BCN Telecom,ISP
 bcs.org,BCS,Nonprofit
 bcsbeavers.org,Madison-Oneida BOCES,Education
 bcx.co.za,BCX,MSP
@@ -848,12 +937,16 @@ bdcom.com,BDCOM Online,ISP
 bdconnectctg.net,BDconnect,ISP
 bdvco.com,Biodyne,Healthcare
 be.ch,Canton of Bern,Government
+beaconbroadband.com,Beacon Broadband,ISP
+beaming.co.uk,Beaming,ISP
 beanfield.com,Beanfield,ISP
 bearingdepot.com,Bearing Depot & Supply,Retail
 beaumont.org,Corewell Health (Formerly Beaumont),Healthcare
 bec.uk,BE Computing,IaaS
 beccommunications.com,BEC Communications,ISP
 becfiber.com,BEC Fiber,ISP
+bechtel.com,Bechtel,Construction
+bechtle.com,Bechtle Managed Service,MSP
 beckman.com,Beckman Coulter,Healthcare
 bedag.ch,Bedag Informatik,MSP
 bedbathandbeyond.com,Bed Bath & Beyond,Retail
@@ -861,6 +954,7 @@ bedge.com,BEDGE,Web Host
 bee.net.tn,Bee (Smart Solutions Tunisia),ISP
 beecreek.net,Bee Creek Communications,ISP
 beehive.net,Beehive Broadband,ISP
+beeksfinancialcloud.com,Beeks,IaaS
 beeline.kz,Beeline,ISP
 beeline.ru,Beeline,ISP
 beeline.uz,Beeline,ISP
@@ -876,9 +970,11 @@ belcloud.net,Belcloud,Web Host
 bell.ca,Bell Canada,ISP
 bell.net,Bell Canada,ISP
 bell.net.mt,Bellnet Malta,ISP
+belltele.in,"Berlin,Germany",ISP
 belnet.be,BELNET,Education
 belong.com.au,Belong (Telstra),ISP
 beltelecom.by,Beltelecom,ISP
+beltraonet.com.br,Beltrãonet,ISP
 belwave.com,BelWave Communications,ISP
 belwue.de,BelWü,Education
 bendigotelco.com.au,Bendigo Telco,ISP
@@ -901,13 +997,16 @@ bethel.edu,Bethel University,Education
 betterhomeowners.com,InTouch Systems,Marketing
 bevcomm.net,Bevcomm,ISP
 beyond.pl,Beyond.pl,Web Host
+beyondrm.com,Beyond Relationship Marketing,Marketing
 bezeq.co.il,Bezeq,ISP
 bezeqint.net,Bezeq International,ISP
 bfh.ch,Berner Fachhochschule,Education
 bgctv.com.cn,Beijing Gehua CATV,ISP
 bgp.net,BGP Network HK,ISP
+bgpnet.com,BGPNET,IaaS
 bgsu.edu,Bowling Green State University,Education
 bgwan.com,VarnaLan (Geodim),ISP
+bhp.com,BHP,Industrial
 bhtelecom.ba,BH Telecom,ISP
 bia.gov,US Bureau of Indian Affairs,Government
 biaman.pl,BIAMAN Poznan,Education
@@ -918,10 +1017,13 @@ bigcommerce.net,BigCommerce,SaaS
 bigleaf.net,Bigleaf Networks,ISP
 biglobe.co.jp,BIGLOBE,ISP
 biglobe.ne.jp,BIGLOBE,ISP
+bignet.com.br,BCMG Internet,ISP
 bigpond.com,Telstra,ISP
 bigpond.net.au,Telstra,ISP
 bigrivertelephone.com,Big River Telephone,ISP
 bigscoots.com,BigScoots,Web Host
+bigstep.com,Bigstep Cloud,IaaS
+bigtelecom.ru,Big Telecom,ISP
 bilink.com.br,Bilink Telecomunicações,ISP
 bilink.ua,Bilink,ISP
 bilkent.edu.tr,Bilkent University,Education
@@ -958,6 +1060,7 @@ bjarekraft.se,Bjare Kraft,Utilities
 bjc.org,BJC HealthCare,Healthcare
 bkm.uz,Uzbektelekom,ISP
 bkup.com.br,Bkup Telecom,ISP
+blackandco.com,Black Knight,SaaS
 blackberry.com,BlackBerry,SaaS
 blackfoot.net,Blackfoot,ISP
 blackfriarsam.com,Blackfriars Asset Management,Finance
@@ -965,6 +1068,7 @@ blackgate.nl,BlackGATE,Web Host
 blacknight.com,Blacknight Solutions,Web Host
 blacksun.ca,MSP Corp,Web Host
 blanksoft.dev,BlankSoft,MSP
+blastcomm.com,Blast Communications,ISP
 blazenet.biz,BlazeNet,ISP
 blazingseollc.com,Rayobyte (Blazing SEO),SaaS
 blc.fi,BLC Telecom,ISP
@@ -976,6 +1080,8 @@ blinktelecom.com.br,Blink Telecom,ISP
 blitzmediahosting.ca,Blitz Media,Web Host
 blix.com,Blix Solutions,ISP
 blizzard.com,Blizzard Entertainment,Entertainment
+blokowe.pl,Sieci Blokowe S.C,ISP
+bloom.host,AME Hosting,IaaS
 bloomberg.com,Bloomberg,Finance
 blowtech.com.tw,Blowplas Technology,Manufacturing
 bls.gov,U.S. Bureau of Labor Statistics,Government
@@ -992,6 +1098,7 @@ bluetie.com,BlueTie,MSP
 bluevalley.net,Blue Valley,ISP
 bluevps.com,BlueVPS,Web Host
 blueweb.co.kr,BlueWeb,Web Host
+bluewireless.com,Blue Wireless,ISP
 blufibre.ca,BLU Fibre Networks,ISP
 bme.hu,Budapest University of Technology and Economics,Education
 bmhcc.org,Baptist Memorial Health Care,Healthcare
@@ -1013,6 +1120,7 @@ boavistanet.net.br,Boa Vista Net,ISP
 boeing.com,Boeing,Defense
 bof.fi,Bank of Finland,Government
 bofinet.co.bw,Botswana Fibre Networks,ISP
+bogazici.edu.tr,Bogazici University,Education
 bogons.net,Bogons,ISP
 bohc.co.jp,Benefit One Inc.,Retail
 boisestate.edu,Boise State University,Education
@@ -1031,6 +1139,7 @@ bookingtimes.com,BookingTimes,SaaS
 bookmyname.com,BookMyName,Web Host
 boostmobile.com,Boost Mobile,ISP
 boozallen.com,Booz Allen Hamilton,Consulting
+bornfiber.dk,BornFiber Service Provider,ISP
 bosch.com,Bosch,Manufacturing
 bosnet.se,Bosnet Skaraborg,ISP
 boston.gov,City of Boston,Government
@@ -1041,6 +1150,7 @@ bov.com,Bank of Valletta,Finance
 bowdoin.edu,Bowdoin College,Education
 box.ca,Whatbox,Web Host
 boxbroadband.co.uk,Community Fibre (Box Broadband),ISP
+bp.com,BP,Industrial
 bplaced.com,bplaced,Web Host
 bplaced.de,bplaced,Web Host
 bplaced.net,bplaced,Web Host
@@ -1049,6 +1159,7 @@ br.digital,BR Digital Telecom,ISP
 braathe.net,iteam Braathe,MSP
 bracnet.net,BRACNet Limited,ISP
 bradley.edu,Bradley University,Education
+brain.net.pk,Brain Telecommunication,ISP
 brandeis.edu,Brandeis University,Education
 brandenburgtel.com,Brandenburg Telephone,ISP
 branet.com.br,Branet,MSP
@@ -1059,6 +1170,7 @@ brasiltecpar.com.br,Brasil TecPar,ISP
 bravehost.com,Bravenet,Web Host
 bravenet.com,Bravenet,Web Host
 braveriver.com,Vertikal6,MSP
+bravotelecom.com,Bravo Telecom,ISP
 breakthru.net,BreakThru,MSP
 bredband2.com,Broadband2,ISP
 breedbanddelft.nl,Stichting Breedband Delft,ISP
@@ -1086,6 +1198,7 @@ britishairways.com,British Airways,Travel
 briz.ua,BRIZ,ISP
 brking.com.br,Brking,ISP
 brmaster.com.br,BRMaster,ISP
+brmemc.com,Blue Ridge Mountain EMC,Utilities
 broadband.hu,One Hungary,ISP
 broadbandidc.com,BROADBANDIDC,Web Host
 broadbandsolutions.com.au,Broadband Solutions Australia,ISP
@@ -1126,6 +1239,8 @@ btcbahamas.com,BTC Bahamas Telecommunications,ISP
 btcentralplus.com,BT,ISP
 btcl.com.bd,Bangladesh Telecommunications Company,ISP
 btcl.gov.bd,BTCL Bangladesh Telecommunications,ISP
+btcom.kz,BTcom,ISP
+btelbroadband.com,B-Tel,ISP
 btes.net,BTES Bristol Tennessee,Utilities
 btopenworld.com,BT,ISP
 btussel.com,Bug Tussel,ISP
@@ -1144,6 +1259,7 @@ bugtusselwireless.com,Bug Tussel,ISP
 buildingmaterials.com.my,Building Materials,Construction
 buk.edu.ng,Bayero University,Education
 bulloch.net,Bulloch County RTC,ISP
+bullseyetelecom.com,Bullseye Telecom,ISP
 bulsat.com,Bulsatcom,ISP
 bumblebeelinens.com,Bumbletree Linens,Retail
 bumrungrad.com,Bumrungrad International Hospital,Healthcare
@@ -1159,6 +1275,7 @@ burstfire.net,Burstfire Networks,ISP
 busse-computer.de,Busse Computertechnik,MSP
 busse.cloud,Busse Computertechnik,MSP
 buysecure.com,Monmouth Internet,Web Host
+bv.com,Black & Veatch International Company,Construction
 bvconline.com.ar,BVC,ISP
 bvu-optinet.com,BVU OptiNet (Point Broadband),ISP
 bytedance.com,ByteDance,Technology
@@ -1166,14 +1283,18 @@ bytemark.co.uk,Bytemark,Web Host
 byteplus.com,BytePlus,IaaS
 bytes.co.za,Altron Bytes,MSP
 byu.edu,BYU,Education
+byuh.edu,Brigham Young University Hawaii,Education
 byui.edu,Brigham Young University Idaho,Education
 c-able.co.jp,Yamaguchi Cable Vision,ISP
 c-light.net,SC-REN (C-Light),Education
+c3-complete.com,C3 Complete,MSP
 c3.net.pl,C3 NET,ISP
 c3po3090.com.br,Núcleo Brasil Servidores,Web Host
 ca.gov,State of California,Government
+cabase.org.ar,CABASE,ISP
 cable.net.co,Cablenet,ISP
 cablebahamas.com,Cable Bahamas,ISP
+cablecable.net,Cable Cable,ISP
 cablecolor.com.gt,Cable Color,ISP
 cablecolor.hn,Cable Color Honduras,ISP
 cablecom.ch,UPC,ISP
@@ -1197,16 +1318,20 @@ cabonnet.com.br,Cabonnet,ISP
 cabotelecom.com.br,Alares,ISP
 cabq.gov,City of Albuquerque,Government
 cachefly.com,CacheFly,SaaS
+cadence.net.uk,Cadence Networks,ISP
 cairohost.com,Black Host,Web Host
 caiway.nl,Caiway,ISP
 caiweb.net.br,Caiweb,ISP
 cal.net,Cal.net,ISP
 calero.com,Calero,MSP
+calligo.io,Calligo (Canada),MSP
+calloneonline.com,Call One,ISP
 calltower.com,CallTower,SaaS
 calpoly.edu,Cal Poly,Education
 caltech.edu,California Institute of Technology,Education
 calvin.edu,Calvin University,Education
 cam.ac.uk,University of Cambridge,Education
+cambiahealth.com,Cambia Health Solutions,Healthcare
 campaigner.com,Campaigner,Marketing
 camtel.cm,Camtel,ISP
 camtel.com,Cameron Communications,ISP
@@ -1246,6 +1371,7 @@ caribserve.net,Caribserve (New Technologies Group),ISP
 carleton.ca,Carleton University,Education
 carleton.edu,Carlton College,Education
 carnet.hr,CARNET,Education
+carnival.com.bd,Systems Solutions & development Technologies,ISP
 carnivalcorp.com,Carnival Corporation,Travel
 carolinadigitalphone.com,Carolina Digital Phone,ISP
 carrd.co,Carrd,SaaS
@@ -1255,12 +1381,15 @@ carrytel.ca,Carrytel,ISP
 carsforkids.org,Cars For Kids,Nonprofit
 cas.org,Chemical Abstracts Service,Publishing
 casablanca.cz,Casablanca INT,Web Host
+cascable.com,CAS Cable,ISP
+cascadeaccess.com,Cascade Access,ISP
 case.edu,Case Western Reserve University,Education
 casscomm.com,CassComm,ISP
 castrum.com.br,Castrum Internet,ISP
 cat-v.jp,Sendai CATV,ISP
 cat.com,Caterpillar,Industrial
 cat.net.th,National Telecom (Thailand),ISP
+catalysthost.com,Catalyst Host,IaaS
 catawba.edu,Catawba College,Education
 catixs.com,Catixs,ISP
 catnet.jp,Honjo Cable,ISP
@@ -1268,7 +1397,9 @@ catonetworks.com,Cato Networks,SaaS
 catv-ads.jp,advanscope,ISP
 catv296.co.jp,296 Broad Net,ISP
 catvmics.ne.jp,Mics Network,ISP
+catvwink.co.jp,Warabi Cable Vision,ISP
 cau.ac.kr,Chung-Ang University,Education
+cbc.ca,Canadian Broadcasting,News
 cbccom.net,Beijing Tian Wei Xin Tong,ISP
 cbe.ae,CBE,Construction
 cbn.id,CBN Fiber,ISP
@@ -1281,8 +1412,10 @@ cbxnet.de,CBXNET,ISP
 cc9.jp,Cable TV Tochigi (CC9),ISP
 ccac.edu,Community College of Allegheny County,Education
 ccapcable.com,CCAP Cable,ISP
+ccb.com,China Construction Bank,Finance
 ccc-group.com,Canada Colors and Chemicals Limited (CCC),Industrial
 ccc.co.il,Triple C Cloud Computing,Web Host
+ccc.de,Chaos Computer Club,Nonprofit
 cccd.edu,Coast Community College District,Education
 cccoe.k12.ca.us,Contra Costa County Office of Education,Education
 cccomm.net,CC Communications Nevada,ISP
@@ -1311,8 +1444,10 @@ cdw.com,CDW,MSP
 ce-tel.com,CETel (AXESS Networks),ISP
 cea.fr,CEA,Government
 cec-ltd.co.jp,Computer Engineering & Consulting,MSP
+cedarnetworks.com,Cedar Networks,ISP
 cedia.edu.ec,CEDIA Ecuador R&E Network,Education
 cegecom.lu,Cegecom Luxembourg,ISP
+cegedim.fr,Cegedim,SaaS
 cegeka.com,Cegeka,MSP
 cei.gov.cn,China eGovNet Information Center,Government
 celcom.com.my,Celcom Axiata,ISP
@@ -1332,6 +1467,7 @@ centene.com,Centene,Healthcare
 centerasecurity.com,Centera Email Defence,Email Security
 centerasecurity.dk,Centera Email Defence,Email Security
 centersquaredc.com,Centersquare (Csquare),Web Host
+centex.net,Central Texas Telecommunications,ISP
 centralaccess.com,Central Access,ISP
 centralesupelec.fr,CentraleSupélec,Education
 centralinteractiva.com.mx,Central Interactiva,Marketing
@@ -1345,9 +1481,12 @@ centralserver.com.br,Central Server,IaaS
 centraluniversity.org,Central University College,Education
 centrilogic.com,Centrilogic,MSP
 centrin.net.id,Centrin Utama,ISP
+centrixweb.net,Centrix Web Services,Web Host
+century.net.br,Century Telecom,ISP
 centurylink.com,CenturyLink,ISP
 centurylink.com.pe,Cirion,MSP
 centurylink.net,CenturyLink,ISP
+cepanet.com.ar,CEPA,Utilities
 cerberusnetworks.co.uk,Cerberus Networks,ISP
 cerebel.com,CereBel Interactive,Marketing
 cerner.com,Cerner,Healthcare
@@ -1364,6 +1503,7 @@ cetin.cz,CETIN,ISP
 cetin.hu,CETIN Hungary,ISP
 cetin.rs,CETIN,ISP
 cetinbg.bg,CETIN Bulgaria,ISP
+ceys.com.ar,CEyS,Utilities
 ceystel.com.ar,CeySTEL,ISP
 ceznet.cz,ČEZNET,ISP
 cfe.mx,CFE,Utilities
@@ -1394,6 +1534,7 @@ checkpoint.com,Check Point Software,Email Security
 cheetahmail.com,Marigold,SaaS
 cheiljedang.co.kr,CJ CheilJedang,Food
 chello.sk,UPC,ISP
+cheops-technology.ch,Cheops Technology Switzerland,MSSP
 cherryservers.com,Cherry Servers,Web Host
 chesco.net,Chesconet,Education
 chess.no,Telia Norge,ISP
@@ -1418,6 +1559,7 @@ chinaxingye.com,Suzhou Sinye Materials Technology,Industrial
 chinguitel.mr,Chinguitel,ISP
 chl.com,CHL,ISP
 chop.edu,Children's Hospital of Philadelphia,Healthcare
+chosting.solutions,Cloud Hosting Solutions,Web Host
 chosun.ac.kr,Chosun University,Education
 chrobinson.com,C.H. Robinson,Logistics
 chronos.com.tr,Chronos Teknoloji,Technology
@@ -1431,6 +1573,7 @@ chungbuk.ac.kr,Chungbuk National University,Education
 chuo-u.ac.jp,Chuo University,Education
 chupicom.jp,Chupicom,ISP
 churchdev.com,ChurchDev,Web Host
+ciasc.sc.gov.br,Centro de Informatica e Automacao do Estado de SC,Government
 cibc.com,CIBC,Finance
 ciberlynx.com,CiberLynx,Technology
 cica.es,CICA Centro Informatico Cientifico de Andalucia,Science
@@ -1450,12 +1593,14 @@ cirbn.org,CIRBN Central Illinois Regional Broadband Network,ISP
 circana.com,Circana,SaaS
 circit.de,CircIT,MSP
 circleamedical.com,Circle A Medical,Healthcare
+cirex.ru,Telecom-Birzha,MSP
 cirrushosting.com,Cirrus Hosting,Web Host
 cisco.com,Cisco,Technology
 cisp.com,CISP Community ISP,ISP
 citadel.edu,The Citadel,Education
 citec.com.au,CITEC (Queensland Government),Government
 citechco.net,Grameen CyberNet,ISP
+citelia.es,Citelia,ISP
 citenet.net,Citenet Telecom,ISP
 citic.com,CITIC,Conglomerate
 citictel-cpc.com,CITIC Telecom CPC,ISP
@@ -1469,6 +1614,7 @@ citycom-austria.com,Citycom Austria,ISP
 cityemail.com,CityEmail,Email Provider
 cityfibre.com,CityFibre,ISP
 citylink.pro,CityLink Petrozavodsk,ISP
+citynet.at,HALLAG Kommunal,ISP
 citynet.kg,Citynet KG,ISP
 citynet.net,Citynet,ISP
 cityoftacoma.org,City of Tacoma,Government
@@ -1488,6 +1634,7 @@ claranet.com,Claranet,Web Host
 claremont.edu,Claremont University Consortium,Education
 clarix.com,Clarix,MSP
 clarkson.edu,Clarkson University,Education
+clarksvilleconnected.net,Clarksville Connected Utilities,Utilities
 clarksvillede.com,Clarksville Department of Electricity,Utilities
 clarku.edu,Clark University,Education
 claro.com.ar,Claro,ISP
@@ -1500,6 +1647,7 @@ claro.com.pe,Claro,ISP
 claro.net.do,Mail2World,Email Provider
 clarochile.cl,Claro,ISP
 claropr.com,Claro,ISP
+classcom.pl,PHU Classcom,ISP
 classicofficesystems.com,Classic Office Systems,MSP
 claytonindustries.com,Clayton Industries,Industrial
 cldin.eu,Yourhosting,Web Host
@@ -1611,6 +1759,7 @@ code200.global,code200,ISP
 codelco.cl,Codelco,Industrial
 codetel.net.do,codetel.net.do,ISP
 codibee.com,Codibee,SaaS
+coeficiente.mx,Coeficiente Comunicaciones,ISP
 coeficiente.net.mx,Coeficiente,ISP
 coex.co.kr,COEX,Marketing
 coextro.com,Coextro Ontario,ISP
@@ -1623,6 +1772,8 @@ cogentco.com,Cogent,ISP
 cognizant.com,Cognizant,Technology
 coh.org,City of Hope Medical Center,Healthcare
 coj.net,City of Jacksonville,Government
+col-network.com,Colnetwork C.A,ISP
+colba.net,ColbaNet,ISP
 colby.edu,Colby College,Education
 coldwellbankerhomes.com,Coldwell Banker,Real Estate
 coles.com.au,Coles,Retail
@@ -1639,16 +1790,21 @@ colocrossing.com,ColoCrossing,ISP
 cologix.com,Cologix,IaaS
 cologlobal.com,Cologlobal,Web Host
 colorado.edu,University of Colorado Boulder,Education
+coloradocolo.com,Corporate Colocation,IaaS
 colorkrew.com.br,Colorkrew,SaaS
 colos.kz,IFC COLOS,Logistics
+colosolutions.com,Colo Solutions,ISP
 colosseum.com,Colosseum Online,IaaS
 colostate.edu,Colorado State University,Education
+coloup.com,ColoUp,IaaS
 colsecor.com.ar,Colsecor,ISP
 colt.net,Colt,ISP
 columbia.edu,Columbia University,Education
 columbus-networks.hn,Liberty Networks Honduras,ISP
+columbus-telephone.com,Columbus Telephone Company,ISP
 columbus.k12.oh.us,Columbus Public Schools,Education
 columbus.te.ua,MAXNET,ISP
+com4.no,Com4,ISP
 combell.com,Combell,Web Host
 combolivre.net.br,Connection Multimidia,ISP
 comcap.nl,WorldStream LATAM (Comcap),Web Host
@@ -1657,9 +1813,11 @@ comcast.com,Comcast,ISP
 comcast.net,Comcast,ISP
 comcastbusiness.net,Comcast Business,ISP
 comcel.com.co,Claro Colombia,ISP
+comcell.net,COMCELL,ISP
 comclark.com,ComClark,ISP
 comcor.ru,AKADO Telecom,ISP
 comentum.com,Comentum,Technology
+comerica.com,Comerica,Finance
 comeser.it,Comeser,ISP
 comfori.com,Comfori,SaaS
 comfortel.pro,Comfortel,ISP
@@ -1669,8 +1827,10 @@ commerce.gov,US Department of Commerce,Government
 commerzbank.com,Commerzbank,Finance
 commnetbroadband.com,Commnet Broadband,ISP
 commnetwireless.com,Commnet Wireless,ISP
+commonspirit.org,CommonSpirit Health,Healthcare
 commonwealthu.edu,Commonwealth University of Pennsylvania,Education
 comms365.com,Comms365,ISP
+commscope.com,CommScope Technologies,ISP
 communilink.com,CommuniLink,Web Host
 communilink.net,CommuniLink,Web Host
 communitect.com,Solutionreach,SaaS
@@ -1679,7 +1839,9 @@ communitymedical.org,Community Medical Centers,Healthcare
 comnet.bg,Comnet Bulgaria,ISP
 comnet.net.id,Comtronics Systems,MSP
 comnett.com.br,Comnett Provedor de Internet,ISP
+comnica.hu,Comnica,SaaS
 compass.net.nz,Compass NZ,ISP
+complat.ru,Komplat,ISP
 complemar.com,Complemar,Logistics
 completecomputers.cc,Complete Computers,MSP
 compliancearchitects.net,Compliance Aarchitects,Healthcare
@@ -1694,6 +1856,7 @@ computerstlouis.com,Computer St. Louis,MSP
 computronics.com,Computronics,Technology
 comsats.net.pk,COMSATS Internet Services,ISP
 comsol.co.za,Comsol Networks,ISP
+comsouth.net,ComSouth,ISP
 comteco.com.bo,Comteco,ISP
 comtrance.net,comtrance,Web Host
 comune.livorno.it,Città di Livorno,Government
@@ -1727,6 +1890,7 @@ connecta.net,connecta ag,ISP
 connectalagoas.com.br,Connect Alagoas,ISP
 connectctc.com,Consolidated Telephone (CTC),ISP
 connectit.com.au,Connect I.T.,MSP
+connectivia.it,Connectivia,ISP
 connectmax.com.br,Algar Mogi (ConnectMax),ISP
 connectria.com,Connectria,Web Host
 connectrio.com.br,Connect Rio,ISP
@@ -1753,8 +1917,10 @@ contabo.com,Contabo,Web Host
 contaboserver.net,Contabo,Web Host
 contato.net,Contato Internet,ISP
 contegix.com,Contegix,Web Host
+contell.ru,Contell,IaaS
 continent8.com,Continent 8,Web Host
 convention.co.jp,Japan Convention Services,Marketing
+converged.co.uk,Converged Communication Solutions,ISP
 convergeict.com,Converge,ISP
 convergencegroup.co.uk,Convergence Group,ISP
 convergent-interfreight.com,Convergent Interfreight,Logistics
@@ -1771,8 +1937,11 @@ coolwavecom.com,Coolwave Communications,ISP
 cooolbox.bg,Cooolbox,ISP
 coopenet.com.ar,Coopenet,ISP
 cooperatelecom.com.br,Coopera Telecom,ISP
+cooperativenet.com,Cooperative Communications,ISP
 cooptel.qc.ca,Cooptel,ISP
 cooptortu.com.ar,Cooperativa de Tortuguitas,ISP
+coosavalleytech.com,Coosa Valley Technologies,ISP
+coovilros.com,Coovilros,ISP
 copaco.com.py,Copaco,ISP
 copreltelecom.com.br,Coprel Telecom,ISP
 coprosys.cz,Coprosys,ISP
@@ -1803,10 +1972,12 @@ cortland.edu,SUNY Cortland,Education
 cosmonova.net,Cosmonova,ISP
 cosmopolitanlasvegas.com,The Cosmopolitan of Las Vegas,Travel
 costalogistica.com,Costa Logística,Logistics
+costco.com,Costco Wholesale,Manufacturing
 cotas.com,Cotas,ISP
 cotas.com.bo,Cotas,ISP
 cotea.com.ar,COTEA,ISP
 cotecal.com.ar,Cotecal,ISP
+cotel.bo,Cotel,ISP
 cotel.com.ar,Cotel Villa Gesell,ISP
 cotelcam.com.ar,Cotelcam Argentina,ISP
 cotesma.coop,Cotesma San Martin de los Andes,ISP
@@ -1830,6 +2001,7 @@ cprapid.com,cPanel,Web Host
 cpsboe.k12.oh.us,Cincinnati Public Schools,Education
 cpserver.com,A2 Hosting,Web Host
 cpsinet.com,TruBridge,Healthcare
+cpws.com,Columbia Power & Water Systems,Utilities
 cqu.edu.au,Central Queensland University,Education
 cra.cz,České Radiokomunikace,Web Host
 crawkan.net,Craw-Kan Telephone Cooperative,ISP
@@ -1857,6 +2029,7 @@ crowncastle.com,Crown Castle,ISP
 crowncloud.net,CrownCloud,Web Host
 crusoe.ai,Crusoe,IaaS
 crxmgmt.com,The Medicine Shoppe Franchisee,Healthcare
+csaa.com,CSAA Insurance,Finance
 csbnet.se,CSBNET Chalmers Studentbostader,Education
 csc.fi,CSC Finland,Science
 csf.ne.jp,Cable Station Fukuoka (CSF),ISP
@@ -1913,6 +2086,7 @@ cultureamp.com,Culture Amp,SaaS
 cumberlandconnect.org,Cumberland Connect,ISP
 cuny.edu,City University of New York,Education
 curtin.edu.au,Curtin University,Education
+custodiandc.com,CustodianDC,ISP
 customer.speedpartner.de,SpeedPartner,Web Host
 customercontrolpanel.de,netcup,Web Host
 cut.net,Central Utah Telephone,ISP
@@ -1945,13 +2119,16 @@ cyberfolks.pl,cyber_Folks,Web Host
 cyberfolks.ro,cyber_Folks,Web Host
 cyberfuel.com,Cyberfuel.com,Web Host
 cyberia.net.sa,Cyberia,ISP
+cyberinfo.net.br,Cyberinfo,ISP
 cyberlink.ch,Cyberlink,ISP
 cyberlinkasp.com,CyberlinkASP,Web Host
 cyberlynk.net,CyberLynk,MSP
 cybermail.jp,CyberMail,Email Provider
 cybermesa.com,Cyber Mesa,ISP
+cybernetcom.com,Cybernet Communications,IaaS
 cybernextech.co.th,CYBER NEXTECH,Web Host
 cybernextech.com,CYBER NEXTECH,Web Host
+cybersainik.com,Cyber Sainik,MSSP
 cybersmart.co.za,Cybersmart,ISP
 cyberspace.net.ng,Cyberspace Nigeria,ISP
 cybertelecom.com.br,Cyber Telecom,ISP
@@ -1980,7 +2157,9 @@ daakbabu.com,Daak Babu,Email Provider
 dacor.de,suc dacor,ISP
 dada.eu,Register.it (Dada),Web Host
 dadabroadband.com,DaDa Broadband,ISP
+dadepardazimobin.com,Dade Pardazi Mobin,Web Host
 daegu.ac.kr,Daegu University,Education
+daejin.ac.kr,Daejin University,Education
 daemonmail.ner,DaemonMail,Email Provider
 daemonmail.net,TierraNet,Web Host
 dailyinvesthub.com,Daily Invest Hub,Finance
@@ -1995,6 +2174,7 @@ dalnet.tr,DALNET,Web Host
 damamax.jo,Damamax,ISP
 damcogroup.com,Damco Solutions,MSP
 damel.com,Damel Group,Food
+dandemutande.africa,Dandemutande,MSP
 danskkabeltv.dk,DKTV,ISP
 daou.co.kr,Daou Technology,Technology
 daouoffice.com,Dooray,SaaS
@@ -2005,32 +2185,40 @@ dartmouth-hitchcock.org,Dartmouth-Hitchcock,Healthcare
 dartmouth.edu,Dartmouth College,Education
 dartpoints.com,DartPoints,Web Host
 darysoft.com,Dary Web Designs,Web Host
+data-axle.com,Data Axle,Marketing
 data-tronics.com,ArcBest Technologies,Logistics
 data.cr,American Data Networks Costa Rica,ISP
 data102.com,Hivelocity (Data102),Web Host
 data443.com,Data443,Email Security
 databank.com,DataBank,Web Host
 datacamp.co.uk,CDN77,Web Host
+datacanopy.com,Data Canopy Colocation,IaaS
 datacate.com,Datacate,Web Host
 datacenter.eu,Datacenter Luxembourg,Web Host
+datacenterunited.com,DC Star,IaaS
 datacentrum.sk,DataCentrum Slovakia,Government
 datacheap.ru,Datacheap,Web Host
 datacom.com,Datacom,MSP
 datacom.com.au,Datacom,MSP
+datacom.se,Datacom,MSP
 datacorpore.com.br,DataCorpore,Web Host
 datafabrik.de,meerfarbig (datafabrik),Web Host
 dataforest.net,dataforest,Web Host
+datagrid.network,DataGrid Network,IaaS
 datagroup.ua,Datagroup,ISP
 datahouse.ru,DataHouse Citytelecom,Web Host
 datak.ir,Datak,ISP
 dataline.ua,Dataline Ukraine,ISP
 datanat.com,Datanational Corporation,MSP
+datanet.co.uk,Datanet.co.uk,ISP
 datapark.ch,Datapark,ISP
 datapipe.com,Rackspace,Web Host
 dataplace.com,Eurofiber Cloud Infra,IaaS
 dataport.de,Dataport,Government
 datasource.ch,Datasource,Web Host
+dataspace.pl,Dataspace,IaaS
 datatility.com,NSI Hosting (Datatility),Web Host
+datautama.net.id,DATA Utama Dinamika,ISP
 datawagon.com,DataWagon,Web Host
 datawagon.net,DataWagon,Web Host
 dataweb.nl,DataWeb,ISP
@@ -2043,6 +2231,7 @@ datto.com,Datto,MSP
 dattorelay.com,Datto,MSP
 dattoweb.com,Datto,MSP
 dauphintelecom.com,Dauphin Telecom,ISP
+daycohost.com,"Dayco Telecom, C.A",ISP
 daystar.io,Daystar Email Service,Email Provider
 db.com,Deutsche Bank,Finance
 dbcity.com,Waller Creek Communications,ISP
@@ -2087,6 +2276,8 @@ deere.com,John Deere,Agriculture
 deerfieldhosting.net,Deerfield Hosting,Web Host
 default-host.net,INHOSTED LP,Web Host
 degnet.com,DegNet,ISP
+degunino.net,Kom lan,ISP
+dei.gr,ΔΕΗ (Public Power Corporation),Utilities
 deic.dk,DeiC,Education
 delaware.gov,State of Delaware,Government
 delhi.edu,SUNY Delhi,Education
@@ -2142,6 +2333,8 @@ diakovere.de,DIAKOVERE,Healthcare
 dialego.de,Dialego,Marketing
 dialnet.net,Dialnet Colombia,ISP
 dialog.lk,Dialog Axiata,ISP
+dialpad.com,Dialpad,SaaS
+dictu.nl,Ministerie van Economische Zaken,Government
 didichuxing.com,DiDi,Travel
 difesa.it,Ministero della Difesa,Defense
 digestivedaily.com,DigestiveDaily,Healthcare
@@ -2152,9 +2345,11 @@ digicelbroadband.com,Digicel,ISP
 digicelgroup.com,Digicel,ISP
 digicelsr.com,Digicel,ISP
 digicert.com,DigiCert,Email Security
+digicom.al,Digicom Albania,ISP
 digijadoo.net,Jadoo Digital,ISP
 digikabel.hu,One Hungary (Formerly DIGI),ISP
 digimobil.es,DIGI Spain,ISP
+digimobil.it,Digi,ISP
 digital-fortress.com,Digital Fortress,IaaS
 digital808.com,Digital808,Marketing
 digitalairstrike.com,Digital Air Strike,Marketing
@@ -2171,7 +2366,10 @@ digitalpath.net,DigitalPath,ISP
 digitalpolicy.gov.hk,Hong Kong Digital Policy Office,Government
 digitalrealty.com,Digital Realty,Web Host
 digitalredzone.com,Digital Red Zone,Marketing
+digitalskies.com,Digital Skies,ISP
 digitalspace.co.uk,Digital Space,MSP
+digitalspeed.com,DigitalSpeed Communications,ISP
+digitaltv.com.bo,Digital TV CABLE DE EDMUND,ISP
 digitel.com.ve,Digitel,ISP
 digitotal.com.br,Digitotal Networks,ISP
 digiturunc.com,Digiturunc,Web Host
@@ -2195,12 +2393,14 @@ directnic.com,Directnic,Web Host
 directnic.net,Directnic.com,Web Host
 directnode.nl,DirectNode,Web Host
 directv.com,DIRECTV Latin America,Entertainment
+directv.com.co,DIRECTV Colombia,Entertainment
 directwifi.com.br,Direct Internet,ISP
 discoverflow.co,Flow,ISP
 discovergreene.com,"Greene County, New York",Government
 disenosweb.mx,Hive Studio,Web Host
 dishemail.com,DISH,ISP
 disney.com,Disney,Entertainment
+disneyplus.com,Disney+,Entertainment
 distributel.ca,Distributel,ISP
 dito.ph,DITO Telecommunity,ISP
 ditscloud.com,DITSCloud,MSP
@@ -2218,6 +2418,7 @@ dlive.kr,DLIVE,ISP
 dlivry.co,Twilio SendGrid,Marketing
 dlreoil.co.kr,Daelim,Industrial
 dls.net,DLS Internet Services,ISP
+dlx.dk,DLX,IaaS
 dmc.org,Detroit Medical Center,Healthcare
 dmctelecom.com.br,DMC Telecom,ISP
 dmit.com,DMIT Cloud Services,Web Host
@@ -2226,10 +2427,12 @@ dmmhosts.com,DMM Hosts,Web Host
 dmwireless.com,DM Wireless,ISP
 dna.fi,DNA,ISP
 dnchosting.com,Directnic,Web Host
+dnepro.net,Internet Kamyanske,ISP
 dnet.net.id,DNET Indonesia,ISP
 dnetprovider.id,D~NET,ISP
 dnetsurabaya.id,D~NET,ISP
 dnns.net,No-IP Dynamic DNS,Web Host
+dnp.co.jp,Dai Nippon Printing,Print
 dns-net.de,DNS:NET,ISP
 dnsalias.com,DynDNS,Web Host
 dnsalias.net,DynDNS,Web Host
@@ -2267,6 +2470,7 @@ donotspam.de,indevis,MSSP
 donpac.ru,Rostelecom,ISP
 donweb.com,DonWeb (Dattatec),Web Host
 doosan.com,Doosan,Conglomerate
+doratelekom.com.tr,DoraTelekom,ISP
 doruk.net.tr,DorukNet,Web Host
 doshisha.ac.jp,Doshisha University,Education
 dosscloudservices.com,Doss Business Systems,MSP
@@ -2280,6 +2484,7 @@ dotmailer.com,Dotdigital,Marketing
 dotname.co.kr,Dotname Korea,Web Host
 dotroll.com,DotRoll,Web Host
 douzone.com,Douzone Bizon,SaaS
+dowjones.com,Dow Jones,News
 downloaddatarecovery.com,KernelApps,Technology
 doylestowncommunications.com,Doylestown Communications,ISP
 dpsk12.org,Denver Public Schools,Education
@@ -2315,6 +2520,7 @@ dsi.net.br,DSI Defferrari,ISP
 dsidata.sk,DSI DATA Slovakia,ISP
 dslmobil.de,DSLmobil,ISP
 dslon.ws,Dslon Wireless,ISP
+dslx.net,Fibernet,ISP
 dsmc.or.kr,Keimyung University Dongsan Medical Center,Healthcare
 dstl.gov.uk,Defence Science and Technology Laboratory,Defense
 dstny.com,Dstny,SaaS
@@ -2327,11 +2533,14 @@ dtccom.com,DTC Communications,ISP
 dtctelecom.com.br,DTC Telecom,ISP
 dtel.com.br,Dtel Telecom,ISP
 dtel.ru,Dagomys Telecom (Dtel),ISP
+dtestream.com,Data Stream,ISP
 dtln.ru,Data Storage Center,Web Host
 dtmicro.com,DT Micro,Web Host
+dtp.do,Dominican Telecom Prime,ISP
 dtp.net.id,DTPNET,ISP
 dts-security.de,DTS,MSP
 dts.de,DTS,MSP
+dtsanz.com,DTS,ISP
 du.ae,du,ISP
 dubaihealth.ae,Dubai Health,Healthcare
 dubaistdclinic.com,STD Clinic Dubai,Healthcare
@@ -2348,8 +2557,10 @@ duplexcleaning.au,Duplex Cleaning Machines,Manufacturing
 duq.edu,Duquesne University,Education
 durand.com.br,Durand do Brasil,ISP
 dustin.com,Dustin,Retail
+dutil.com,Dalton Utilities,Utilities
 dvcotechnology.com,Cision,Marketing
 dvois.com,D-VoiS,ISP
+dvpl.in,"Vainavi Industies, Internet Service Provider, India",ISP
 dvusd.org,Deer Valley Unified School District,Education
 dwango.co.jp,Dwango,Entertainment
 dwd.de,Deutscher Wetterdienst,Government
@@ -2377,11 +2588,13 @@ dyx-tech.com,DYXnet,ISP
 dyxnet.com,DYXnet,MSP
 dzcrd.net,DZCRD Networks,Web Host
 e-catv.ne.jp,Ehime CATV,ISP
+e-commercepark.com,E-Commerce Park,Retail
 e-i.com,Euro-Information,MSP
 e-kei.pl,Kei,Web Host
 e-know.net,TRAVCHIS (E-Know),Web Host
 e-large.cc,E-Large HK,ISP
 e-mmunity.net,VIPRE,Email Security
+e-net.in,SITI Broadband,ISP
 e-quest.nl,e-Quest,MSP
 e-vergent.com,e-vergent,ISP
 e1b.org,Erie 1 BOCES,Education
@@ -2415,6 +2628,7 @@ easymail.ca,easyMail,Email Provider
 easyname.com,easyname,Web Host
 easyonnet.io,Easy on Net,Web Host
 easyseo.com.my,SEO Services Malaysia,Marketing
+easytvnet.bg,EasyTVNet,ISP
 easyweb.co.za,Easyweb (Xnet),Web Host
 easyweb.com,easyDNS,Web Host
 eatel.com,REV,ISP
@@ -2429,6 +2643,7 @@ ec.com.cn,CIETNET China International Electronic Commerce,SaaS
 ec2software.com,ec² Software Solutions,Healthcare
 echolabs.net,Echo Labs,MSP
 echosp.co.za,Echotel South Africa,ISP
+echoteam.net,Echo Technologies,MSP
 echoworx.net,Echoworx,Email Security
 eci.com,ECI,MSP
 ecm8.com,Campaign Master (UK),Marketing
@@ -2436,6 +2651,7 @@ ecmc.edu,Erie County Medical Center,Healthcare
 ecmwf.int,ECMWF European Centre for Medium-Range Weather Forecasts,Government
 ecn.co.za,ECN South Africa,ISP
 ecn.net.au,ECN Internet,ISP
+ecofon.lt,Ecofon,ISP
 ecohost.la,ecohost Latinoamerica,Web Host
 ecolink.com,Ecolink,Manufacturing
 econocom.es,Econocom Cloud,IaaS
@@ -2469,6 +2685,8 @@ editorx.io,Wix,SaaS
 edmonton.ab.ca,City of Edmonton,Government
 edpnet.be,EDPnet,ISP
 edpnet.net,EDPnet,ISP
+edt.de,Erdenreich Datentechnik,ISP
+edtech.rs,Edge Technology Plus,ISP
 edu.com,InstructionalAssistant,SaaS
 eduneering.com,UL EHS training,SaaS
 edutech.org,EduTech BOCES,Education
@@ -2497,6 +2715,7 @@ ehime-u.ac.jp,Ehime University,Education
 ehostsolution.net,E Host Solution,Web Host
 ehu.eus,University of the Basque Country,Education
 eidsiva.net,Eidsiva,ISP
+eiffage.com,Eiffage,Construction
 eigbox.net,Newfold Digital,Web Host
 einsteinemail.com,Einstein Industries,Web Host
 einsteinmail.com,Einstein Industries,Web Host
@@ -2521,6 +2740,7 @@ elektrafi.com,ElektraFi,ISP
 elementa.com,Elementa,MSP
 elementcritical.com,Element Critical,Web Host
 elementmedia.com,ElementMedia,Web Host
+elevancehealth.com,Elevance Health,Healthcare
 elevartelecom.com.br,Elevar Telecom,ISP
 elevate.uk,Elevate (Telcom Networks),ISP
 elevatedstudios.tech,Elevated Studios,Web Host
@@ -2536,6 +2756,7 @@ elitework.com,EliteWork,SaaS
 elive.net,Elive,Web Host
 elkdata.ee,Elkdata,Web Host
 elkem.com,Elkem,Manufacturing
+ellcom.ru,Elektrosvyaz,ISP
 ellipse.net,Ellipse,MSP
 ello.ch,Ello Communications,ISP
 ellum.net,EllumNet,ISP
@@ -2546,6 +2767,7 @@ elon.edu,Elon University,Education
 elpos.net,ELPOS,ISP
 elte.hu,Eötvös Loránd University,Education
 eltele.no,Serit Eltele,ISP
+eltronik.net.pl,Eltronik,ISP
 email-od.com,SocketLabs,SaaS
 emailarray.com,Emailarray,Email Provider
 emaildodo.com,eMailDodo,Email Provider
@@ -2560,11 +2782,14 @@ embrapa.br,Embrapa Brazilian Agricultural Research Corporation,Government
 embratel.net.br,Embratel,ISP
 embriq.no,Embriq,MSP
 emcali.com.co,EMCALI,Utilities
+emeraldbroadband.com,Emerald Broadband,ISP
 emeraldonion.net,Emerald Onion,Nonprofit
 emeraldonion.org,Emerald Onion,Nonprofit
 emerson.com,Emerson,Manufacturing
 emerytelcom.net,Emery Telcom,ISP
 emexinternet.com.br,Emex Internet,ISP
+emid.co.za,iOCO,MSP
+emily.net,Emily Telephone,ISP
 emirates.net.ae,Etisalat,ISP
 emma-solutions.nl,Emma Solutions (Formerly Wylance),MSP
 emory.edu,Emory University,Education
@@ -2578,6 +2803,7 @@ emsend2.com,ActiveCampaign,Marketing
 emtel.com,Emtel,ISP
 emtel.net.co,EMTEL Colombia,ISP
 enagroup.net,ENA Group,Construction
+enatrel.ni,ENATREL,Utilities
 encrypttitan.net,EncryptTitan,Email Security
 endoffice.com,EndOffice,Web Host
 endurance.com,Newfold Digital,Web Host
@@ -2638,6 +2864,7 @@ epic.com,Epic Systems,Healthcare
 epic.com.cy,Epic Cyprus,ISP
 epic.com.mt,Epic (Formerly Vodafone Malta),ISP
 epichs.org,Epic Health,Healthcare
+epicor.com,Epicor,SaaS
 epicpc.com,Epic Health,Healthcare
 epicura.be,EpiCURA,Healthcare
 epldt.com,ePLDT,IaaS
@@ -2649,6 +2876,7 @@ epsl1.com,Publicis Groupe,Marketing
 epsm-marne.fr,EPSM de la Marne,Healthcare
 eptc.co.sz,Eswatini PTC,ISP
 eqservers.com,EqServers,Web Host
+equifax.com,Equifax,Finance
 equinix.com,Equinix,IaaS
 equinix.de,Equinix Germany,IaaS
 equinor.com,Equinor,Industrial
@@ -2667,7 +2895,10 @@ esavezone.co.kr,SaveZone,Retail
 esboces.org,Eastern Suffolk BOCES,Education
 esc.net.au,EscapeNet,ISP
 esc11.net,Education Service Center Region 11,Education
+esc4.net,Region 4 Education Service Center,Education
+escambia.k12.fl.us,Escambia County School District,Education
 escom.bg,Escom Bulgaria,ISP
+esds.co.in,ESDS Software Solution,IaaS
 esecuredata.com,eSecureData,Web Host
 esited.com,eSited,Web Host
 eskerondemand.com,Esker,SaaS
@@ -2677,6 +2908,9 @@ eso.org,European Southern Observatory,Science
 esolutionsgroup.ca,Govstack (eSolutions Group),Technology
 esosoft.net,EcoSoft,Web Host
 esqsites123.com,ESQ Sites 123,Web Host
+essensys.tech,essensys,SaaS
+essity.com,Essity Hygiene and Health,Healthcare
+estnoc.ee,EstNOC OU,IaaS
 estraspa.it,Estra,Utilities
 estruxture.com,eStruxture Data Centers,IaaS
 esuhsd.org,East Side Union High School District,Education
@@ -2689,6 +2923,7 @@ etcnow.com,ETC,ISP
 etecsa.cu,ETECSA,ISP
 eternet.cc,Eternet,ISP
 etex.net,Etex,ISP
+ethericnetworks.com,Etheric Networks,ISP
 ethernet.edu.et,EthERNet (Ethiopian Education Research Network),Education
 etherni.com,Ethernic,MSP
 ethiotelecom.et,Ethio Telecom,ISP
@@ -2696,6 +2931,7 @@ ethunder-hosting.com,Ethunder Hosting,Web Host
 etik-cloud.com,Infomaniak,IaaS
 etipres.com,ETIPRES,Print
 etisalat.ae,e& (Etisalat),ISP
+etisalat.af,Etisalat Afghan,ISP
 etisalat.com.eg,Etisalat Egypt,ISP
 etius.jp,WebArena,Web Host
 etl.co.ls,Econet Lesotho,ISP
@@ -2705,6 +2941,7 @@ etri.re.kr,ETRI,Government
 etronsol.com,Etron Solutions,MSP
 etsmtl.ca,École de technologie supérieure,Education
 etsu.edu,East Tennessee State University,Education
+ett.ua,Eurotranstelecom,ISP
 eudonet.com,Eudonet,SaaS
 eumetsat.int,EUMETSAT,Government
 eunetworks.com,euNetworks,ISP
@@ -2726,6 +2963,7 @@ eventelecom.com.br,Even Telecom,ISP
 eventsairmail.com,EventsAir,SaaS
 eveo.com.br,EVEO,Web Host
 everest.vn.ua,Everest TV,ISP
+evergy.com,Evergy,Utilities
 evernet.net.co,Evernet,ISP
 eversource.com,Eversource Energy,Utilities
 evertecinc.com,Evertec,Finance
@@ -2737,21 +2975,25 @@ eviden.com,Eviden,Consulting
 eviny.no,Eviny,Utilities
 evms.edu,Eastern Virginia Medical School,Education
 evo-net.it,evonet,ISP
+evobitsit.com,EVOBITS Information Technology,IaaS
 evocative.com,Evocative Data Centers,Web Host
 evolink.com,Evolink,ISP
 evolus-it.com,Evolus IX,ISP
 evolus-ix.com,Evolus IX,ISP
 evolusfibre.com,Evolus IX,ISP
 evolutio.com,Evolutio Cloud Enabler,IaaS
+evolveip.net,Xtium (Formerly Evolveip),MSP
 evonik.de,Evonik,Manufacturing
 evoxt.com,Evoxt,Web Host
 ewe-ip-backbone.de,EWE,ISP
 ewe.com,EWE,ISP
 eweka.nl,Eweka,ISP
+ewii.com,EWII,Utilities
 ewp.live,EasyWP,Web Host
 ewu.edu,Eastern Washington University,Education
 eww.at,eww,Utilities
 exa.net.uk,Exa Networks,ISP
+exabytes.my,Exabytes,Web Host
 exabytes.sg,Exabytes Singapore,Web Host
 exacthosting.com,Exact Hosting,Web Host
 exactt.com,Salesforce Marketing Cloud (Formerly ExactTarget),Marketing
@@ -2768,6 +3010,7 @@ exelera.net,Exelera Telecom,ISP
 exeloncorp.com,Exelon,Utilities
 exepto.ru,Exepto,ISP
 exetel.com.au,Exetel,ISP
+exitovision.com,Exito Vision Cable,ISP
 exlibrisgroup.com,Ex Libris,SaaS
 exonhost.com,ExonHost,Web Host
 exoscale.ch,Exoscale,IaaS
@@ -2784,11 +3027,13 @@ exponential-e.com,Exponential-E,MSP
 expositltd.com,Exposit Ltd.,MSP
 express-scripts.com,Express Scripts,Healthcare
 express.com.ar,Express Telecomunicaciones,ISP
+express.net.ua,Express,ISP
 expressinformatica.art.br,Express Fibra,ISP
 expressotelecom.com,Expresso (Sudatel),ISP
 extendbroadband.com,Extend Broadband,ISP
 extendedcare.com,CarePort,Healthcare
 extra-lan.com.tw,Extra-Lan Technologies,ISP
+extraordinarymanagedservices.com,Extraordinary Managed Services,ISP
 extrasec.de,Extrasec,ISP
 extrememt.com.br,Extreme Provedor de Internet,ISP
 extremeserv.net,extremeserv,Web Host
@@ -2800,16 +3045,20 @@ ezinternetsolutions.com,EZ Internet Solutions,Web Host
 ezorg.nl,E-Zorg,Healthcare
 eztech.com.vn,EZ Technology,Web Host
 ezzi.net,EZZI.net,Web Host
+f-group.ru,FreeNet Group,ISP
+f-i-ts.de,Finanz Informatik Technologie Service,MSP
 f-i.de,Finanz Informatik,MSP
 f-integra.org,Fundacion Integra,Nonprofit
 f2x.nl,F2X Fiber Services,ISP
 f5.com,F5,Technology
+f57.net,Aoxiang Cloud,IaaS
 faa.gov,Federal Aviation Administration,Government
 facebook.com,Meta,Social Media
 faciliti.net.br,Faciliti Telecom,ISP
 fahrenheit88.com,fahrenheit88,Retail
 faiba.co.ke,Jamii Telecommunications,ISP
 fairfax.va.us,"Fairfax County, Virginia",Government
+fairisaac.com,Fair Isaac and Company,SaaS
 fairpoint.com,Fidium Fiber (FairPoint),ISP
 fairview.org,Fairview Health Services,Healthcare
 famu.edu,Florida A and M University,Education
@@ -2835,6 +3084,7 @@ fasternet.com.br,Desktop,ISP
 fastfortechnologies.com,FastForTechnologies,ISP
 fastinternet.inf.br,Fast Web,ISP
 fastlink.lt,Fastlink (Consilium Optimum),ISP
+fastlnk.ru,Fast Link,ISP
 fastly.com,Fastly,SaaS
 fastlylb.net,Fastly,Technology
 fastmail.com,Fastmail,Email Provider
@@ -2879,13 +3129,18 @@ fhptelecom.com.br,FHP Telecom,ISP
 fiber-operator.nl,Fiber Operator,ISP
 fiber.net,Fibernet Utah,Web Host
 fiber.net.id,Fiber Networks Indonesia,ISP
+fiberby.dk,Fiberby,ISP
+fibercast.net,Fibercast,ISP
 fibercop.it,FiberCop,ISP
 fibergreen.es,Fibergreen,ISP
 fibergrid.net,Fiber Grid,ISP
 fiberhost.com,Fiberhost,ISP
 fiberhub.com,FiberHub,ISP
 fiberinternet.com.br,SpeedNet Telecom,ISP
+fiberish.net.pk,Fiberish,ISP
 fiberlight.com,FiberLight,ISP
+fiberlogic.net,Fiber Logic,ISP
+fibernet.com,FiberNet Communications L.C,ISP
 fibernetics.ca,Fibernetics,ISP
 fibernetms.com.br,Fibernet,ISP
 fiberocity.co.uk,Fiberocity,ISP
@@ -2913,6 +3168,7 @@ fidelity.com,Fidelity Investments,Finance
 fidelitycommunications.com,Fidelity Communications,ISP
 fidium.com,Fidium Fiber,ISP
 fidiumfiber.com,Fidium Fiber,ISP
+fidoka.it,Fidoka,ISP
 figma.com,Figma,SaaS
 figma.site,Figma,SaaS
 figueiredoprovedores.com.br,COMNET,ISP
@@ -2921,6 +3177,7 @@ filibe.net,Angelsoft (Filibe),ISP
 finanzaworld.it,FinanzaWorld,Finance
 finanzaworld.net,FinanzaWorld,Finance
 finegroupservers.com,Fast Servers (FineGroup),Web Host
+fintel.com.fj,Fiji International Telecomunications,ISP
 fiocruz.br,Fiocruz Oswaldo Cruz Foundation,Education
 fiord.net,Fiord Networks,ISP
 fiord.ru,NTC FIORD,ISP
@@ -2930,7 +3187,9 @@ fireeyegov.com,FireEye (Government),Email Security
 firelinebroadband.com,Fireline Broadband,ISP
 firenettelecom.com.br,FireNet Telecom,ISP
 firmenich.com,dsm-firmenich,Manufacturing
+first-colo.net,firstcolo,IaaS
 first-server.net,FirstServer,Web Host
+firstcitizens.com,First-Citizens Bank & Trust Company,Finance
 firstcloudsecurity.net,CyberCision,Email Security
 firstcolo.net,firstcolo,Web Host
 firstcomm.com,FirstComm,ISP
@@ -2950,12 +3209,14 @@ fisquare.com,Infince,SaaS
 fit.edu,Florida Institute of Technology,Education
 fittelecom.com.br,FIT Telecom (Vero),ISP
 fiu.edu,Florida International University,Education
+five9.com,Five9,SaaS
 fivenetwork.co.in,Five Network India,ISP
 fixnet.com.tr,FixNet,ISP
 fiz-karlsruhe.de,FIZ Karlsruhe,Science
 fl.gov,State of Florida,Government
 flagman.zp.ua,Flagman Telecom,ISP
 flagtel.com,Flag Telecom,ISP
+flamehosting.net,FlameHosting,Web Host
 flashmaistelecom.com.br,Flash + Telecom,ISP
 flashnete.com.br,Flash Net,ISP
 flashnetprovedor.com.br,Flashnet,ISP
@@ -2991,6 +3252,7 @@ fmu.ac.jp,Fukushima Medical University,Education
 fmv.se,FMV / Forsvarets Materielverk,Defense
 fnal.gov,Fermi National Accelerator Laboratory,Government
 fnb.co.za,First National Bank,Finance
+fnetlink.com,光联世纪 Guanglian Century,ISP
 fnetpe.com.br,FNET,ISP
 fngp.com,Freudenberg-NOK,Manufacturing
 fnj.co.jp,Family Net Japan,ISP
@@ -3002,6 +3264,7 @@ fogel-group.cr,Fogel Group,Industrial
 foliateam.com,Foliateam Group,ISP
 fonabosque.gob.bo,FONABOSQUE,Government
 fonacit.gob.ve,Fonacit,Government
+fonira.at,Fonira Telekom,ISP
 foodtecsolutions.com,FoodTec Solutions,SaaS
 foothills.net,Foothills Communications,ISP
 forcepoint.com,Forcepoint,Email Security
@@ -3024,6 +3287,7 @@ fortimailcloud.com,Fortinet FortiMail Cloud,Email Security
 fortinet.com,Fortinet,Email Security
 fortressitx.com,FortressITX,Web Host
 forwardemail.net,ForwardEmail.net,Email Provider
+forweb.pl,"""FORWEB"" S.C. Monika Bodetko, Tomasz Pawlowski",ISP
 fotbo.com,Fotbo,Web Host
 fourseasonspediatrics.com,Four Seasons Pediatrics,Healthcare
 fox.com,Fox Corporation,Entertainment
@@ -3128,13 +3392,17 @@ galanet.com.ve,Galanet,ISP
 galizanet.com.br,GalizaNET,ISP
 gallerycollection.com,The Gallery Collection,Retail
 galls.com,Galls,Retail
+gals.uz,Gals Telecom,ISP
 gamania.com,Gamania,Entertainment
+game.co.uk,Game UK ASN,Retail
 gamma.co.uk,Gamma,ISP
+gammacom.es,Gamma Operadora de Comunicaciones,ISP
 gammagroup.co,Gamma,ISP
 gamtel.gm,Gamtel Gambia,ISP
 gandi.net,Gandi.net,Web Host
 gannett.com,Gannett (USA Today),News
 gaoland.net,SFR,ISP
+garant.tv,Garant-G,ISP
 garantia.tv,Kolomna-Sviaz TV,ISP
 gardentelecom.com.br,Garden Telecom,ISP
 garena.com,Garena,Entertainment
@@ -3176,6 +3444,7 @@ gctrials.com,GCT,Healthcare
 gcu.edu,Grand Canyon University,Education
 gd.gov.cn,Government of Guangdong Province,Government
 gda.pl,TASK (Gdansk Tech),Education
+gdmissionsystems.com,General Dynamics Mission Systems,Defense
 gdnetfibra.com.br,GD Net Fibra,ISP
 ge.ch,Canton of Geneva,Government
 gearheart.com,Gearheart Communications,ISP
@@ -3189,6 +3458,7 @@ gemnet.mn,Gemnet Mongolia,ISP
 gemzo.ps,Gemzo IT,ISP
 gen2fund.com,Gen II,Finance
 gencat.cat,Generalitat de Catalunya,Government
+gendorf.de,InfraServ Gendorf,Industrial
 gene.com,Genentech,Healthcare
 generacja.pl,GENERACJA.pl Wroclaw,ISP
 generali.de,Generali Deutschland,Finance
@@ -3196,17 +3466,21 @@ generalinformatix.net,General Informatix,Technology
 generalmills.com,General Mills,Food
 geneseo.com,Geneseo Communications,ISP
 geneseo.edu,SUNY Geneseo,Education
+genesys.com,Genesys Telecommunications Laboratories,ISP
 genie-networks.com,Genie Networks,Technology
 genoray.com,GENORAY,Healthcare
 genpact.com,Genpact,MSP
 genstarnetcable.com,Gennstar Network Solutions,ISP
 geo.hosting,GEO.Hosting,Web Host
+geocity.co.in,Geocity Network,ISP
 geolinks.com,GeoLinks,ISP
 georgetown.edu,Georgetown University,Education
 georgia.gov,State of Georgia,Government
 georgiasouthern.edu,Georgia Southern University,Education
 gerberlife.com,Gerber Life Insurance,Finance
 gerrys.net,GIT Gerry's Information Technology,MSP
+gesatel.com,Gesatel,ISP
+gesnet.ru,Gorodskaya Elektronnaya Svyaz,ISP
 getechbrothers.com,Getechbrothers,ISP
 getkeepsafe.com,Keepsafe Software,SaaS
 getordained.org,Universal Life Church,Religion
@@ -3214,6 +3488,7 @@ getresponse.com,GetResponse,Marketing
 getronics.com,Getronics,MSP
 getty.edu,J. Paul Getty Trust,Education
 gettysburg.edu,Gettysburg College,Education
+getunited.com,United Telephone Association,ISP
 getunwired.com,unWired Broadband,ISP
 gevernova.com,GE Vernova,Manufacturing
 gfb.com.mx,BBVA Mexico (Grupo Financiero Bancomer),Finance
@@ -3242,6 +3517,7 @@ gigamaisempresas.com.br,Giga+ Fibra,ISP
 gigared.com.ar,Gigared,ISP
 gigas.com,Gigas Hosting,Web Host
 gigatel.com.ua,Lanet (Gigatel),ISP
+gigatrans.ua,GigaTrans,ISP
 gigenet.com,GigeNET,Web Host
 gigglefiber.com,Giggle Fiber,ISP
 gigstreem.com,Gigstreem,ISP
@@ -3259,6 +3535,7 @@ gitn.com.my,GITN Malaysia,ISP
 glasfaser-ruhr.de,Glasfaser Ruhr,ISP
 glasgow-ky.com,Glasgow EPB,ISP
 glasgowepb.com,Glasgow EPB,ISP
+glattwerk.ch,Glattwerk,Utilities
 glbb.jp,GLBB Japan,ISP
 glcom.net,Great Lakes Comnet,ISP
 glenten.dk,Glenten Odense,ISP
@@ -3268,6 +3545,7 @@ glidegroup.co.uk,Glide,ISP
 glink.inf.br,Glink,Web Host
 gln.net.br,Global Lines,ISP
 global-layer.com,Global Layer,ISP
+global-village.de,Global Village,ISP
 global.fujitsu,Fujitsu,Manufacturing
 global.ntt,NTT,ISP
 globalcombasilicata.it,GlobalCom Basilicata,ISP
@@ -3286,6 +3564,7 @@ globalways.net,Globalways,ISP
 globalxtreme.net,GlobalXtreme Bali,ISP
 globconnex.com,Global Connectivity Solutions,ISP
 globe.com.ph,Globe Telecom,ISP
+globe.de,Globe Development,ISP
 globo.com,Globo,News
 globo.tech,GloboTech,Web Host
 globus-telecom.com,Globus-Telecom,ISP
@@ -3359,6 +3638,7 @@ gov.pf,The Government of French Polynesia,Government
 gov.ru,Russian Government,Government
 gov.si,Slovenia Government Portal,Government
 govdelivery.com,Granicus,SaaS
+government.bg,Government of Bulgaria,Government
 govst.edu,Governors State University,Education
 govstack.com,Govstack (eSolutions Group),Technology
 gpcom.com,Great Plains Communications,ISP
@@ -3371,6 +3651,7 @@ grameenphone.com,Grameenphone,ISP
 granicus.com,Granicus,SaaS
 granitenet.com,Granite Telecommunications,ISP
 graysmark.net,Graysmark Business Systems,MSP
+graysoncollin.com,Cutter Communications,MSP
 greatforti.com,Anpple Tech,Web Host
 greatmail.com,Greatmail,Email Provider
 greatwestlife.com,Canada Life (Great-West Life),Finance
@@ -3384,6 +3665,7 @@ greenecountyny.gov,"Greene County, New York",Government
 greenfloid.com,Green Floid,Web Host
 greengeeks.com,GreenGeeks,Web Host
 greengeeks.net,GreenGeeks,Web Host
+greenhills.net,Green Hills Telephone,ISP
 greenhousedata.com,Lunavi (Greenhouse Data),Web Host
 greenlightnetworks.com,Greenlight Networks,ISP
 greenlighttek.com,Greenlight Tek,MSP
@@ -3398,10 +3680,12 @@ group.bnpparibas,BNP Paribas,Finance
 group.ntt,NTT Group,ISP
 groupe-asten.fr,Groupe Asten,MSP
 groupe-convergence.com,Groupe Convergence,MSP
+groupe-cyllene.com,Groupe Cyllène,MSSP
 groupe-infoclip.com,INFOCLIP,MSP
 groupon.com,Groupon,Retail
 grsolucoestelecom.com.br,GR Soluções Telecom,ISP
 gru.com,Gainesville Regional Utilities,Utilities
+grupocednet.com.br,Grupo Cednet,ISP
 grupocybernet.com.br,Grupo Cybernet,ISP
 grupoice.com,ICE,ISP
 grupoip2.com.br,IP2 Internet,ISP
@@ -3435,6 +3719,7 @@ gtt.net,GTT Communications,ISP
 gturbo.com.br,G Turbo Telecom,ISP
 gtxnet.com.br,GTXNET,ISP
 gu.se,University of Gothenburg,Education
+guamcell.net,GuamCell,ISP
 guardedhost.com,Omnis Network,Web Host
 guj.de,Gruner + Jahr (RTL Deutschland),Publishing
 gulfstreamaircraft.com,Gulfstream Aerospace,Manufacturing
@@ -3454,6 +3739,7 @@ gwnu.ac.kr,Gangneung-Wonju National University,Education
 gwt.net.br,Gateway Telecom,ISP
 gwu.edu,The George Washington University,Education
 h-isac.org,H-ISAC,Healthcare
+h2.nexus,H2NEXUS,IaaS
 h4ahosting.com,H4A Hosting,Web Host
 h4y.us,H4Y Technologies,Web Host
 h5datacenters.com,H5 Data Centers,Web Host
@@ -3474,6 +3760,7 @@ hanami.run,Mailwip (Formerly Hanami),Email Provider
 hanastar.net.id,HSnet,ISP
 handynetworks.com,Summit Hosting (Handy Networks),Web Host
 hankyu-hanshin.co.jp,Hankyu Hanshin,Conglomerate
+hannam.ac.kr,Hannam University,Education
 hanwha.com,Hanwha,Conglomerate
 hanyang.ac.kr,Hanyang University,Education
 hap.be,CHU Ambroise Paré,Healthcare
@@ -3498,10 +3785,14 @@ hawaii.edu,University of Hawaii,Education
 hawaiian.net,Sitestar (Hawaiian),ISP
 hawaiiantel.com,Hawaiian Telcom,ISP
 hawaiidt.com,Xiber Hawaii (Dialogix),ISP
+hawaiiteleport.com,Calian,MSP
 hawetelekom.com,Hawe Telekom,ISP
 hay.net,Hay Communications,ISP
 haynesboone.com,Haynes and Boone,Legal
 hbci.com,Hiawatha Broadband Communications,ISP
+hbs.edu,Harvard Business School,Education
+hcahealthcare.com,Columbia/HCA Healthcare,Healthcare
+hcc.coop,Hamilton County Communications,ISP
 hccl.net,HCCL,MSP
 hccs.edu,Houston Community College,Education
 hcg.gr,Greek Coast Guard,Government
@@ -3511,6 +3802,7 @@ hcltech.com,HCLTech,MSP
 hcltechnologies.com,HCL Technologies,MSP
 hcn.co.kr,Hyundai HCN,ISP
 hcn.gr,HCN Hellenic Cable,ISP
+hcs.net,Hayes Computer Systems,MSP
 hct.ac.ae,Higher Colleges of Technology UAE,Education
 hctc.net,Hill County Telephone Cooperative (HXTC),ISP
 hdems.com,HENNGE Mail Archive,SaaS
@@ -3547,12 +3839,14 @@ henryind.com,Henry Industries,Industrial
 heptanet.com.br,Heptanet,ISP
 herbion.com,Herbion,Healthcare
 herbion.us,Herbion,Healthcare
+herbst.de,Herbst Datentechnik,IaaS
 here.com,HERE Technologies,PaaS
 herefordshire.gov.uk,Herefordshire Council,Government
 hermes-telecom.net,Hermes Telecom Belgium,ISP
 herning.dk,Herning Municipality,Government
 herokuapp.com,Heroku,PaaS
 herotel.com,Herotel,ISP
+herza.id,Herza Digital Indonesia,IaaS
 hessenkom.de,Hessenkom,ISP
 heteml.jp,GMO,Web Host
 hetzner.com,Hetzner,Web Host
@@ -3569,6 +3863,7 @@ hh.nm.cn,China Unicom,ISP
 hhs.gov,U.S. Department of Health & Human Services,Government
 hhsys.org,Huntsville Hospital,Healthcare
 hiab.com,Hiab,Manufacturing
+hicat.ne.jp,Chupicom,ISP
 hickorytech.net,Consolidated Communications,ISP
 highland.net,Highland Connection,ISP
 highlandnet.se,Highlandnet Sweden,ISP
@@ -3590,6 +3885,7 @@ hissm.com,Hiss Media,Marketing
 hit.ac.kr,Daejon Health Sciences College,Education
 hitachi-cloud.com,Hitachi Cloud,IaaS
 hitachi-pt.co.jp,Hitachi,Conglomerate
+hitachi-sunway-is.com,Hitachi Sunway,MSP
 hitc.vn,Hanoi Telecom HCMC,ISP
 hitmedios.com,HT Medios,MSP
 hitrontech.com,Hitron Technologies,Manufacturing
@@ -3616,6 +3912,7 @@ hmcaguas.com,Puerto Rico Telephone Company,ISP
 hmrc.gov.uk,HM Revenue and Customs,Government
 hmu.gr,Hellenic Mediterranean University,Education
 hns.com,Hughes Network Systems,ISP
+hnt.ru,Home Net Telecom,ISP
 hoaspace.com,HOA Space,SaaS
 hofstra.edu,Hofstra University,Education
 hokudai.ac.jp,Hokkaido University,Education
@@ -3663,22 +3960,29 @@ hopone.net,HopOne Internet,Web Host
 hopto.me,No-IP,Web Host
 hopto.org,No-IP,Web Host
 hopus.net,HOPUS,ISP
+horizon-teleports.com,Horizon Teleports,ISP
 horizonscope.com,Horizon Scope Telecom,ISP
 horizonstelecom.com,Horizons Telecom,ISP
 horizontel.com,Horizon Telcom,ISP
 horizontes.net.br,Horizontes Fibra,ISP
 hornetsecurity.com,Hornetsecurity,MSSP
+horyzont.net,Horyzont Technologie Internetowe,ISP
 hosei.ac.jp,Hosei University,Education
+hoseo.ac.kr,Hoseo  University,Education
 hosp.kaizuka.osaka.jp,Kaizuka City Hospital,Healthcare
 hospedagemweb.com.br,Central Server,Web Host
 host-it.co.uk,Host-IT,Web Host
+host-telecom.com,Host-Telecom,ISP
+hostafrica.co.za,Host Africa,Web Host
 hostasaurus.com,Miva (Hostasaurus),SaaS
 hostatom.com,hostatom,Web Host
 hostcenter.co.kr,Hostcenter Korea,Web Host
+hostclick.us,"HOSTCLICK, de DUCA GRACIELA MIRTA",IaaS
 hostcrew.net,HostCrew,Web Host
 hostdent.com,HostNDent,Healthcare
 hostdepot.net,Host Depot,Web Host
 hostdime.com,HostDime,Web Host
+hostdime.com.br,DIMENOC,IaaS
 hostdrive.com,HostDrive,Web Host
 hosted-by-robovps.ru,RoboVPS,Web Host
 hostedemail.com,HostedEmail.com,Email Provider
@@ -3686,6 +3990,8 @@ hostedexchange.asia,Hosted Exchange Asia,Web Host
 hostedpi.com,Mythic Beasts,Web Host
 hostek.com,HOSTEK,Web Host
 hoster.kz,Hoster.KZ,Web Host
+hosterion.ro,HOSTERION,IaaS
+hosteur.com,Hosteur,Web Host
 hosteurope.de,Host Europe,Web Host
 hostgate.ro,Hostgate.ro,Web Host
 hostglobal.plus,HOSTGLOBAL.PLUS,Web Host
@@ -3766,6 +4072,7 @@ howchin.com.my,How Chin Engineering,Industrial
 hp.com,HP,Technology
 hpe.com,Hewlett Packard Enterprise,Technology
 hringdu.is,Hringdu,ISP
+hsbc.co.uk,HSBC Bank,Finance
 hsbc.com.hk,HSBC Hong Kong,Finance
 hse-medianet.de,ENTEGA,ISP
 hsl.org.br,Hospital Sírio-Libanês,Healthcare
@@ -3791,6 +4098,7 @@ hufs.ac.kr,Hankuk University of Foreign Studies,Education
 hugel-inc.com,Hugel,Healthcare
 hugetns.com,Huge TNS,ISP
 hughes.com,Hughes,ISP
+hughes.in,Hughes Communications India Private,ISP
 hughes.net,Hughes Network Systems,ISP
 hughston.com,Hughston Clinic,Healthcare
 hugstelecom.com,Hugs Telecom,ISP
@@ -3828,15 +4136,21 @@ i2bnetworks.com,I2B Networks,Web Host
 i2ts.ne.jp,i2ts,Web Host
 i3d.net,i3D.net,IaaS
 i4i.com,i4i,Technology
+i6c.co.uk,ISIX Communications,IaaS
 iabgteleport.de,IABG Teleport,IaaS
 iadvantage.net,SUNeVision iAdvantage,Web Host
 iaea.org,International Atomic Energy Agency,Government
 iam.ma,Maroc Telecom,ISP
 iasl.com,Internet Access Solutions,ISP
 iastate.edu,Iowa State University,Education
+iaxntelecom.com,IAXN Telecom,ISP
+ibasis.com,iBasis,ISP
+ibh.de,IBH connect,MSP
 ibindley.com,Cardinal Health,Healthcare
+ibits.co.za,IBITS Internet,ISP
 ibm.com,IBM,Technology
 iboss.com,iboss,SaaS
+ibred.es,Red digital de telecomunicaciones de las Islas Baleares,ISP
 ibrowse.com,iBrowse,ISP
 ibw.com.ni,IBW Nicaragua,ISP
 ibx.com,Independence Blue Cross,Healthcare
@@ -3871,6 +4185,7 @@ ictv.jp,Iruma CATV,ISP
 icuk.net,ICUK,Web Host
 ida.org,Institute for Defense Analyses,Defense
 idaho.gov,State of Idaho,Government
+idaq.com,Roebuck,IaaS
 idcf.jp,IDC Frontier,Web Host
 idcloudhost.com,IDCloudHost Indonesia,Web Host
 iddis.com,IDD Enterprises (Fidelity),Finance
@@ -3884,6 +4199,8 @@ identibitsuisse.ch,identibit suisse,Marketing
 identity.digital,Identity Digital (Afilias),Technology
 idig.net,Canadian Web Hosting,Web Host
 idknet.com,Interdnestrcom,ISP
+idkom.de,ID.KOM,MSP
+idline.fr,IDLINE,MSSP
 idm.net.lb,IncoNet IDM,ISP
 idnet.net,IDNet,ISP
 idodns.com,IDO DNS,MSP
@@ -3904,19 +4221,27 @@ iftnet.com.br,IFTNET Telecom,ISP
 ifxnetworks.com,IFX Networks,MSP
 ifxnw.com.ve,IFX Networks,MSP
 iglou.com,IgLou Internet Services,ISP
+ign.com,IGN,News
 ignitedigital.com,Ignite Digital,Marketing
+ignitetelecoms.com,Ignite Telecommunications,ISP
 igpfibra.com.br,IGP Fibra,ISP
+igt.com,IGT,Entertainment
+iguana.cat,Gurbtec Iguana Telecom,ISP
 ihc.com,Intermountain Health,Healthcare
 ihc.host,Iron Hosting Centre,Web Host
 ihk-gfi.de,IHK Gesellschaft fur Informationsverarbeitung,Government
 ihnetworks.com,IHNetworks,Web Host
 ihor-hosting.ru,IHOR Hosting,Web Host
 ihor.online,IHOR Hosting,Web Host
+ihrtelecom.com,Développement Innovations Haut-Richelieu,ISP
 ihs.com,S&P Global (IHS),SaaS
+ihs.com.tr,IHS Kurumsal Teknoloji Hizmetleri,MSP
 ihs.gov,Indian Health Service,Government
 ihug.co.nz,ihug,ISP
+iia.cl,Ingeniería e Informática Asociada (IIA Ltda),ISP
 iiasa.ac.at,IIASA International Institute for Applied Systems Analysis,Science
 iij.ad.jp,Internet Initiative Japan,ISP
+iij.com,IIJ,ISP
 iij4u.or.jp,Internet Initiative Japan,ISP
 iinet.net.au,iiNet,ISP
 iit.edu,Illinois Institute of Technology,Education
@@ -3932,6 +4257,7 @@ iliad.it,Iliad,ISP
 ilight.net,I-Light (Indiana University),Education
 ilimnet.ru,Telnet,ISP
 ilink.net,VDC Powerbase,IaaS
+ilk.net,ILK Internet,ISP
 illinois.edu,University of Illinois,Education
 illinois.net,Illinois Century Network,Education
 illinoisstate.edu,Illinois State University,Education
@@ -3964,6 +4290,7 @@ imsnetworks.com,IMS Networks,ISP
 in.net.pl,INFO-NET grupa ZICOM,ISP
 in2net.com,In2net Network,ISP
 inalan.gr,Inalan,ISP
+inan.cl,Grupo Inan,Web Host
 inasset.it,Retelit (InAsset),ISP
 incapsula.com,Imperva,Email Security
 incheon.ac.kr,University of Incheon,Education
@@ -3973,9 +4300,12 @@ incontact.com,NICE CX,SaaS
 indanet.com.br,Indanet,ISP
 indemed.com,Cardinal Health at-home (Formerly Independence Medical),Healthcare
 indevis.de,indevis,MSSP
+index-education.com,Index Education,SaaS
+indexexchange.com,Index Exchange,Marketing
 indiaaccess.com,IndiaAccess,Web Host
 indiana.edu,Indiana University Bloomington,Education
 indianapolis.in.us,City of Indianapolis,Government
+indigital.net,Indigital Telecom,ISP
 indinet.co.in,Indinet,ISP
 indo.net.id,Indonet,ISP
 indonet.co.id,Indonet,ISP
@@ -3983,7 +4313,9 @@ indonet.id,Indonet,ISP
 indosat.com,IM3,ISP
 indosatooredoo.com,IM3,ISP
 indra.com,Indra,Web Host
+indracompany.com,Indra Sistemas,MSP
 indstate.edu,Indiana State University,Education
+industryinet.com,Industry I-Net,ISP
 indy.gov,City of Indianapolis,Government
 indytel.com,Independence Light & Power Telecommunications,ISP
 inea.pl,INEA,ISP
@@ -3993,6 +4325,7 @@ ines.ro,iNES Group Romania,ISP
 inesc.pt,INESC,Science
 inet.co.th,INET,ISP
 inet.de,INTERNET AG,Web Host
+inet.net.id,Inet Global Indo,ISP
 inet.vn,INET,Web Host
 inetcom.ru,Inetcom,ISP
 inets.ru,ZAO InT,ISP
@@ -4002,6 +4335,7 @@ inexa.com.br,Inexa,ISP
 inexio.net,inexio,ISP
 inext.co.th,INET,ISP
 inf.com,Infosys,MSP
+infinit.us,New Age Consulting Service,MSP
 infinityfiber.com,Infinity Fiber,ISP
 infinityfiber.com.br,Infinity Fibra,ISP
 infinivan.com,InfiniVAN,ISP
@@ -4022,9 +4356,11 @@ infonet-isp.com.br,Infonet Telecom,ISP
 infonetdc.com,Infonet,Web Host
 infopact.nl,Infopact,ISP
 infopasa.com.br,Infopasa,ISP
+infoquest.com,InfoQuest,Web Host
 infor.com,Infor,SaaS
 inforang.com,Inforang,SaaS
 inforcloudsuite.com,Infor,SaaS
+inforent.net,INFORENT,MSP
 informac.com.br,Informac,ISP
 infornetnetwork.net.br,I3 Telecomunicações,ISP
 infoserve.de,InfoServe,MSP
@@ -4049,14 +4385,18 @@ init7.net,Init7,ISP
 inkyphishfence.com,INKY,Email Security
 inl.gov,Idaho National Laboratory,Government
 inmarsat.com,Inmarsat,ISP
+inmart.tv,Inmart,ISP
 inmicsnebula.fi,Telia,ISP
 inmotionhosting.com,InMotion Hosting,Web Host
 innline.am,innline,SaaS
 innline.net,innline,SaaS
 inno.com.ec,Inno,ISP
+innoscale.net,Bird Hosting,Web Host
 innova-red.net,InnovaT,Education
 innova.puglia.it,InnovaPuglia,Government
 innovasur.com,Innovasur,MSP
+innovasur.es,Innovaciones Tecnlogicas del Sur,MSP
+innovatelco.net,Innova Outsourcing,MSP
 innsys.ca,InnSys,ISP
 inoc.com,INOC,MSP
 inovalon.com,inovalon,Healthcare
@@ -4084,17 +4424,21 @@ inteliquent.com,Inteliquent,ISP
 intellicentre.net.au,Macquarie Technology,IaaS
 intellisurvey.com,InteliSurvey,SaaS
 intelsat.com,SES (Formerly Intelsat),ISP
+inteltechdev.ro,Inteli Tech Development,MSP
 intelvision.sc,Intelvision Seychelles,ISP
 inter.com.ve,Inter Telecom,ISP
 inter.edu,Interamerican University of Puerto Rico,Education
 inter.net.il,Internet Gold,ISP
 inter.net.th,Internet Thailand Company Limited,ISP
 intercolnet.com.br,Intercol,ISP
+intercom.it,Intercom,ISP
 intercon.ru,Intercon,ISP
 interconnect.cz,Interconnect,ISP
 interconnect.nl,Interconnect Netherlands,Web Host
 interdeal.co.il,Interdeal,Finance
+interdominios.com,Cloud Builders,IaaS
 interfibras.net.br,Interfibras Telecomunicações,ISP
+interfusion.ie,Vodafone,ISP
 interhost.com,InterHost,Web Host
 interhost.it,Genesys Informatica Srl,MSP
 interior.gov.cl,Chile Ministry of Interior,Government
@@ -4130,8 +4474,11 @@ internexa.com,InterNexa,ISP
 internext.cz,Internext,ISP
 internexus.co.uk,Internexus,ISP
 interphone.com.au,Interphone Australia,ISP
+interpublic.com,Interpublic,Marketing
 interra.ru,Interra,ISP
+intersaar.de,intersaar,ISP
 interserver.net,InterServer,Web Host
+intersil.com,Renesas,Manufacturing
 intertech.net,InterTECH,ISP
 intervel.com.br,Intervel Telecom,ISP
 intervolve.com.au,New Era Technology (Intervolve),MSP
@@ -4146,6 +4493,7 @@ invaluement.com,Invaluement,Email Security
 investinmiddlesex.ca,"Middlesex County, Canada",Government
 investpsp.ca,PSP Investments,Finance
 investpsp.com,PSP Investments,Finance
+invistanet.com.br,Invista Net,ISP
 inwi.ma,Inwi,ISP
 inxserver.de,Inxmail,Marketing
 io-global.com,IO Global Services,ISP
@@ -4159,6 +4507,7 @@ ionblade.com,IonBLADE,Web Host
 ionnetwork.co.id,ION Network (PT Parsaoran Global Datatrans),ISP
 ionos.com,IONOS,Web Host
 ionos.de,IONOS,Web Host
+iovz.net,Iovz Networks,ISP
 iowa.gov,State of Iowa,Government
 ip-135-148-195.us,OVH,Web Host
 ip-146-59-84.eu,OVH,Web Host
@@ -4190,10 +4539,12 @@ ip-home.net,iP-Home,ISP
 ip-kyoto.ad.jp,Advanced Software Technology & Management Research Institute of Kyoto,Education
 ip-max.net,IP-Max,ISP
 ip-projects.de,IP-Projects,Web Host
+ip.ro,IP.RO,ISP
 ip4isp.net,IP4ISP,ISP
 ipacct.com,IPACCT Cable,ISP
 ipandmore.de,ip and more,Web Host
 ipex.cz,IPEX,ISP
+ipglobal.net,IP Global,ISP
 iphmx.com,Cisco Cloud Email Security (CES),Email Security
 iphost.gr,IpHost,Web Host
 iphost.net,IpHost,Web Host
@@ -4202,6 +4553,7 @@ iphouse.net,Sandwich,Web Host
 ipinternational.net,IP Access International,ISP
 ipko.com,IPKO,ISP
 iplan.com.ar,IPlan,ISP
+ipline.fr,Dstny France,SaaS
 ipm.ac.ir,Institute for Research in Fundamental Sciences,Education
 ipm.com,Intelligent Protection Management,Web Host
 ipn.mx,Instituto Politecnico Nacional,Education
@@ -4211,12 +4563,16 @@ ipnext.com.ar,IPNEXT,ISP
 ipng.com.au,Amaze Intelligence (IPNG),ISP
 ipnxnigeria.net,ipNX Nigeria,ISP
 ipost.com,iPost,Marketing
+ipp.fi,Lennu (Ikaalisten-Parkanon Puhelin),ISP
 ippathways.com,IP Pathways,MSP
 iprimus.com.au,iPrimus,ISP
+ipriver.net,IP River,ISP
+iproyal.com,IPRoyal,SaaS
 ipserverone.com,IP ServerOne,Web Host
 ipservice.in.ua,IP Service Ukraine,ISP
 ipstar.com.au,IPSTAR Australia,ISP
 iptel.com.ar,Iptel Argentina,ISP
+iptelecom.asia,Iptelecom Asia,ISP
 iptelecom.it,IP Telecom Italy,ISP
 iptp.com,IPTP Networks,ISP
 ipv.net.pl,Promedia,ISP
@@ -4231,7 +4587,9 @@ iqcomputing.net,IQComputing,Web Host
 iqfiber.com,IQ Fiber,ISP
 iqhive.com,IQ Hive,MSP
 iqon-global.com,IQON Global,Web Host
+iqvia.com,IQVIA,Healthcare
 irbr.ru,ИРБР,Web Host
+ired.net.br,Ired Internet,ISP
 irib.ir,IRIB Islamic Republic of Iran Broadcasting,Government Media
 irinn.in,IRINN India Registry,Nonprofit
 iristel.com,Iristel,ISP
@@ -4239,8 +4597,10 @@ irm.srl,IP.RO (Internet Resources Management),Web Host
 ironmountain.com,Iron Mountain,Technology
 ironwoodcrc.com,Ironwood Cancer & Research Centers,Healthcare
 irpinianetcom.it,Irpinia Net-Com,ISP
+irtc.net,Illinois Rural Telecommunications,ISP
 irtelcom.ru,Irtelcom,ISP
 is.co.ke,Internet Solutions Kenya (NTT),ISP
+is.co.mz,Intra Data Communication,MSP
 is.co.za,Internet Solutions,ISP
 is74.ru,Intersvyaz,ISP
 isc.org,Internet Systems Consortium,Nonprofit
@@ -4250,6 +4610,7 @@ ishantechnologies.com,Ishan Technologies,ISP
 isid.co.jp,Information Services International-Dentsu,MSP
 isiline.it,Isiline,ISP
 isite.de,iWelt,MSP
+isncom.net,ISN Communications,ISP
 isnet.net.tr,Is Net,ISP
 isoceltelecom.com,Isocel,ISP
 isomediainc.com,Isomedia,ISP
@@ -4273,6 +4634,7 @@ isu.net.sa,King Abdul Aziz City for Science and Technology,Science
 isvc.vn,Viet Digital Technology,Web Host
 isync.io,iSync.io,SaaS
 it-grad.ru,IT-GRAD,IaaS
+it-region.ru,IT-Region,ISP
 it-tv.org,IT TV (Information Technologies),ISP
 it7.net,IT7,Web Host
 itafiber.com.br,ITAFIBER,ISP
@@ -4285,11 +4647,13 @@ itaon.net.br,ITAON,ISP
 itb.ac.id,Institut Teknologi Bandung,Education
 itc-web.com,Interstate Telecommunications Cooperative,ISP
 itcen.com,ITCenenTec,ISP
+itcomp.pl,ITCOMP,ISP
 itcsa.net,Informática y Telecomunicaciones,ISP
 itdz-berlin.de,IT-Dienstleistungszentrum Berlin,Government
 ite.net,IT&E Guam,ISP
 itecgroup.co.za,Itec,MSP
 itel.com,iTel Networks,ISP
+itelkom.co,Itelkom,ISP
 itenos.de,ITENOS,MSP
 iteso.mx,ITESO,Education
 itextron.com,Textron,Manufacturing
@@ -4300,23 +4664,27 @@ ithnet.com,ith Kommunikationstechnik,ISP
 ithostline.com,IT HOSTLINE,MSP
 iti-e.co.jp,ITI,Healthcare
 itility.co.uk,Itility,Web Host
+itkm.su,Ivanteevskie Telecom,ISP
 itm8.com,itm8,MSP
 itmedia.co.jp,ITmedia,News
 itnet33.ru,ITNET Kovrov,ISP
 itnorrbotten.se,IT Norrbotten,MSP
 itools.mn,iTools,MSP
 itop.net.br,iTop,ISP
+itp-solutions.de,ITP Solutions,MSP
 itrc.net,Internet Technology Research Consortium,Nonprofit
 itri.org.tw,ITRI,Industrial
 itsa.pl,Intelligent Technologies,ISP
 itsbrasil.net,ITS Telecomunicacoes,ISP
 itscom.jp,its communications,ISP
 itscom.net,iTSCOM,ISP
+itsgroup.com,ITS Integra,MSP
 itsjefen.no,ITsjefen,MSP
 itstechnologygroup.com,ITS Technology Group,ISP
 itstriangle.com,Triangle Communications,ISP
 itu.edu.tr,Istanbul Technical University,Education
 itu.int,International Telecommunication Union,Government
+itvmedia.pl,Timplus,ISP
 itvoice.com,IT Voice,MSP
 iu.edu,Indiana University,Education
 iucc.ac.il,IUCC,Education
@@ -4327,14 +4695,17 @@ iusecom.com.br,Figueiredo e Silva,ISP
 iv.lt,Interneto vizija,Web Host
 iveco.com,Iveco,Manufacturing
 iveloz.net.br,Iveloz Telecom,ISP
+iventmobile.nl,Ivent Mobile,ISP
 iver.com,Iver,MSP
 ivic.gob.ve,IVIC Venezuelan Institute for Scientific Research,Science
 iwashiya-nagai.co.jp,Iwashiya Nagai Co,Healthcare
 iway.ch,iWay,ISP
+iwb.ch,IWB,Utilities
 iwelt.de,iWelt,MSP
 iwhost.com,iWHOST,Web Host
 iwihost.net,Host Telecom,Web Host
 iworx-host.com,iWorx Host,Web Host
+iwv.works,Iconz-Webvisions,Web Host
 ixreach.com,IX Reach,ISP
 izi.com.br,IZI Telecom (ScherrerNet),ISP
 izzi.mx,Izzi Telecom,ISP
@@ -4345,6 +4716,7 @@ jabatus.fr,o2switch,Web Host
 jabbroadband.com,Rise Internet,ISP
 jablonka.cz,Jablonka.cz,Nonprofit
 jackhenry.com,Jack Henry,SaaS
+jackpohle.com,Mount Horeb Telephone,ISP
 jacobs.com,Jacobs Engineering,Construction
 jadecom.or.jp,Japan Association for Development of Community Medicine,Healthcare
 jadeworld.com,Jade Software,SaaS
@@ -4353,6 +4725,7 @@ jaguarcommunications.com,Jaguar Communications,ISP
 jaist.ac.jp,Japan Advanced Institute of Science and Technology,Education
 jal.co.jp,Japan Airlines,Travel
 jalanet.co.id,JALAnet,ISP
+jalawave.net.id,Jalawave Cakrawala,ISP
 jamescitycountyva.gov,"James City County, Virginia",Government
 janis.jp,JANIS,ISP
 japan-wirecable.com,Bell Denki,Industrial
@@ -4368,11 +4741,13 @@ jaxenergy.com,Jackson Energy Authority,Utilities
 jazz.com.pk,Jazz,ISP
 jazztel.com,Jazztel,ISP
 jazztel.es,Jazztel,ISP
+jbntelco.com,JBN telephone Co,ISP
 jbnu.ac.kr,Jeonbuk National University,Education
 jccm.es,Junta de Comunidades de Castilla-La Mancha,Government
 jcntv.co.kr,JCN,ISP
 jcom.co.jp,JCOM,ISP
 jcpenney.com,JCPenney,Retail
+jcs.jo,Jordanian European Internet Services CO,ISP
 jcu.edu.au,James Cook University,Education
 jcv.co.jp,Joetsu Cable Vision,ISP
 jcwifi.com,JC WiFi,ISP
@@ -4399,6 +4774,7 @@ jino.ru,Jino,Web Host
 jinr.ru,Joint Institute for Nuclear Research,Science
 jio.com,Jio,ISP
 jisc.ac.uk,Jisc,Education
+jj.ac.kr,jeonju university,Education
 jjexpress.com.my,JJ Express Services,Logistics
 jknet.com.br,JK Telecom,ISP
 jlab.org,Thomas Jefferson National Accelerator Facility,Education
@@ -4425,6 +4801,7 @@ jotel.co.rs,Jotel Serbia,ISP
 jotelulu.cloud,Jotelulu,Web Host
 jotelulu.com,Jotelulu,Web Host
 jouwweb.site,JouwWeb,Web Host
+joxnet.ru,LLC Real-Net,ISP
 joyent.com,Joyent,IaaS
 jpmchase.com,JPMorgan Chase,Finance
 jpmorgan.com,JPMorgan Chase,Finance
@@ -4439,6 +4816,7 @@ jst.go.jp,Japan Science and Technology Agency,Government
 jsums.edu,Jackson State University,Education
 jtglobal.com,JT,ISP
 jtsa.edu,Jewish Theological Seminary,Education
+jtti.cc,JT Telecom International,ISP
 juce.ca,JUCE Communications,ISP
 juicemagazine.com,Juice Magazine,Publishing
 juliusbaer.com,Julius Baer,Finance
@@ -4497,9 +4875,11 @@ kansas.gov,State of Kansas,Government
 kansas.net,KansasNwt,MSP
 kaopucloud.com,Kaopu Cloud,IaaS
 kappa.net.in,Kappa Internet Services,ISP
+kapper.net,Kapper Network-Communications,ISP
 kari.re.kr,KARI Korea Aerospace Research Institute,Science
 karistelefon.fi,Karis Telefon,ISP
 kartelkomi.ru,Kartel,ISP
+kaspersky.com,Kaspersky Lab Switzerland,MSSP
 kaspr-privacy.io,Kaspr,Marketing
 kasserver.com,all-inkl.com,Web Host
 katch.co.jp,KATCH Network,ISP
@@ -4516,6 +4896,7 @@ kazrena.kz,KazRENA,Education
 kaztranscom.kz,Jusan Mobile,ISP
 kband.no,Hardanger Breiband,ISP
 kbc.com,KBC Group,Finance
+kbcnet.rs,TRUF,ISP
 kbro.com.tw,kbro,ISP
 kbtelecom.net,Koos Broadband Telecom,ISP
 kcc.com,Kimberly-Clark,Manufacturing
@@ -4529,15 +4910,19 @@ kcom.com,KCOM,ISP
 kcs.co.jp,Sakura KCS,MSP
 kct.co.jp,Kurashiki Cable TV,ISP
 kctcs.edu,Kentucky Community and Technical College System,Education
+kcttel.com,Korea Cable Telecom,ISP
 kctvjeju.com,KCTV Jeju,ISP
 kcweb.net,KC Web,ISP
 kddi-webcommunications.co.jp,KDDI Web Communications,Web Host
 kddi.com,KDDI,ISP
 kddi.ne.jp,KIDDI,ISP
+kddia.com,KDDI America,ISP
 kdtidc.com,KDT Korea Data Telecommunication,Web Host
+keepit.com,Keepit,SaaS
 keio.ac.jp,Keio University,Education
 keio.jp,Keio University,Education
 kek.jp,KEK,Education
+kelag.at,Kelag,Utilities
 keliweb.com,Keliweb,Web Host
 kems.net,KEMS,ISP
 kendall.cz,GPS Praha,Healthcare
@@ -4552,11 +4937,13 @@ keralavisionisp.com,Keralavision Broadband,ISP
 kern.org,Kern County Superintendent of Schools,Education
 ketis.ru,KETIS,ISP
 kevag-telekom.de,KEVAG Telekom,ISP
+key-systems.net,Key-Systems,Web Host
 keybank.com,KeyBank,Finance
 keycorpgroup.com,KeyCorp Financial,Finance
 keyinfo.com,Key Information Systems (Converge),MSP
 keymachine.de,Keyweb,Web Host
 keymail.com,KeyMail,Email Provider
+keytele.com,KeyTele,ISP
 keyweb.de,Keyweb,Web Host
 keyyo.com,Keyyo,ISP
 kfglobal.hk,HK Kwaifong Group,Web Host
@@ -4582,6 +4969,7 @@ kinecta.org,Kinecta Federal Credit Union,Finance
 kinetix.net.au,Kinetix Networks,ISP
 kinexmedical.com,Kinex Medical Company,Healthcare
 king-good.com,Jinku Group,Industrial
+king-online.ru,KING-ONLINE,ISP
 king-servers.com,King Servers,Web Host
 king.host,KingHost (LWSA),Web Host
 kingcounty.gov,King County,Government
@@ -4593,12 +4981,15 @@ kinx.net,KINX,ISP
 kio.tech,KIO Networks,Web Host
 kirchmann-hurry.co.za,Kirchmann-Hurry Construction,Construction
 kirkbrothers.com,Kirk Brothers Supercenter,Automotive
+kirkland.com,Kirkland & Ellis,Legal
 kirz.com,KIRZ,ISP
 kist.re.kr,KIST Korea Institute of Science and Technology,Science
+kistem.co.jp,Kistem,MSP
 kit.ac.jp,Kyoto Institute of Technology,Education
 kit.edu,Karlsruhe Institute of Technology,Education
 kitano-hp.or.jp,Kitano Hospital,Healthcare
 kitcarson.com,Kit Carson Electric Cooperative,Utilities
+kiwiinternet.co.nz,The Digital Lab 2007,ISP
 kjm6.de,kajomi MAIL,Email Provider
 kk-takano.co.jp,Takano,Industrial
 kkontech.com,KKONTech Nigeria,ISP
@@ -4610,10 +5001,12 @@ klinikum-esslingen.de,Klinikum Esslingen,Healthcare
 klogixsecurity.com,K logix,MSSP
 kmd.dk,KMD,Consulting
 kmitl.ac.th,King Mongkut's Institute of Technology Ladkrabang,Education
+kmou.ac.kr,Korea Maritime and Ocean University,Education
 kmtn.ru,Kostrom City Telephone Network,ISP
 kmu.ac.jp,Kansai Medical University,Education
 kmu.ac.kr,Keimyung University,Education
 kmv.ru,Post LTD,ISP
+knet-telecom.com,Kurdistan Net,ISP
 knet.ca,K-Net (Keewaytinook Okimakanak),ISP
 knet.kg,Kyrgyztelecom,ISP
 knipp.de,Knipp Medien und Kommunikation,Web Host
@@ -4632,8 +5025,10 @@ koerber.de,Korber,Conglomerate
 koesio.com,Koesio,MSP
 kogakuin.ac.jp,Kogakuin University,Education
 kogite.fr,KoGite,Web Host
+kolpinonet.ru,Kolpinskie Internet-Seti,ISP
 kolsitegroup.com,Kolsite Group,Industrial
 komfort21vek.ru,Comfort XXI Century,ISP
+komitex.net,KOMiTEX,ISP
 kommitt.de,KomMITT-Ratingen,ISP
 komro.net,komro,ISP
 kongkow.com,Kongkow,SaaS
@@ -4642,16 +5037,20 @@ konkuk.ac.kr,Konkuk University,Education
 konnet.com.br,Konnet (Itabirana),ISP
 konstanz.de,City of Konstanz,Government
 konverto.eu,Konverto,MSP
+kookmin.ac.kr,Kookmin University,Education
 koping.net,Kopings Kabel-TV,ISP
 korbank.pl,Korbank,ISP
 kordia.co.nz,Kordia,ISP
 korea.ac.kr,Korea University,Education
 korea.kr,Government of South Korea,Government
+koreatech.ac.kr,Korea University of Technology and Education,Education
 kos.net,Kingston Online Services,ISP
+kosciuskoconnect.com,Kosciusko Connect,ISP
 koscom.co.kr,KOSCOM,Finance
 koshinomiyako.jp,Koshinomiyako Network,ISP
 kosovotelecom.com,Telekomi i Kosoves (Vala),ISP
 kostroma.net,Kostrom City Telephone Network,ISP
+koszalin.pl,City of Koszalin,Government
 koumbit.net,Koumbit.org,MSP
 kovacmed.com,KOVAC-MED,Healthcare
 kpchealth.com,KPC Healthcare,Healthcare
@@ -4666,6 +5065,7 @@ kreativemachinez.tech,Kreative Machinez,Marketing
 kreonet.net,KREONET,Education
 kroger.com,The Kroger Co,Retail
 kronoz.co.jp,kronos,MSP
+krosoft.pl,Krosno Information Center,MSP
 kryptronic.com,Kryptronic,SaaS
 krystal.uk,Krystal Hosting,Web Host
 ks.ac.kr,Kyungsung University,Education
@@ -4691,6 +5091,7 @@ ku.edu.kw,Kuwait University,Education
 kub.org,Knoxville Utilities Board,Utilities
 kumc.edu,University of Kansas Medical Center,Education
 kundenserver.de,domainfactory GmbH,Web Host
+kunsan.ac.kr,Kunsan National University (KNU),Education
 kursktelecom.ru,Kursktelecom,ISP
 kusunoki-hp.com,Kusunoki Hospital,Healthcare
 kutztown.edu,Kutztown University,Education
@@ -4727,6 +5128,8 @@ lakelandnetworks.com,Lakeland Networks,ISP
 lakeregionfiber.com,Lake Region Technology,ISP
 lakotanetwork.com,CRST Telephone Authority (Lakota Network),ISP
 lamar.edu,Lamar University,Education
+lambdalabs.com,Lambda,IaaS
+lampert.at,Kabel-TV Lampert,ISP
 lamrc.com,Lam Research,Manufacturing
 lan.ua,LocalNet Obolon (Aslanua),ISP
 lancastergeneralhealth.org,Penn Medicine Lancaster General Health,Healthcare
@@ -4743,6 +5146,7 @@ lanset.com,Lanset America,ISP
 lanta-net.ru,LanTa,ISP
 laotel.com,Lao Telecom,ISP
 laptech.com,LapTech Precision,Manufacturing
+largnet.ca,LARG*net,Education
 larkinhealth.com,Larkin Health System,Healthcare
 larkinhospital.com,Larkin Health System,Healthcare
 larrycomputerguy.com,Larry The Computer Guy,MSP
@@ -4758,16 +5162,19 @@ latisys.net,Latisys,Web Host
 latitude.sh,Latitude.sh,IaaS
 latrobe.edu.au,La Trobe University,Education
 latvenergo.lv,Latvenergo,Utilities
+launtel.net.au,Launtel,ISP
 laurentian.ca,Laurentian University,Education
 lauruslabs.com,Lasarus Labs,Healthcare
 lausd.net,Los Angeles Unified School District,Education
 lawtendo.com,Lawtendo,Legal
 layerhost.com,LayerHost,Web Host
+layershift.com,Layershift,IaaS
 layerstack.com,LayerStack,Web Host
 lazernet.com.br,Lazernet,ISP
 lb.go.gov.br,Government of Goias State Brasil,Government
 lbl.gov,Lawrence Berkeley National Laboratory,Government
 lblesd.k12.or.us,Linn Benton Lincoln Education Service District,Education
+lbusd.k12.ca.us,Long Beach Unified School District,Education
 lchost.co.uk,LCHost,Web Host
 lcmh.com,Lake Charles Memorial Health System,Healthcare
 lcrcom.es,Aire Networks (LCR),ISP
@@ -4775,6 +5182,7 @@ lcube-server.de,LCube,Web Host
 lcv.jp,LCV,ISP
 lcv.ne.jp,LCV Corporation,ISP
 ldexconnect.co.uk,Iomart LDeX (LDexConnect),Web Host
+ldp.net.id,Lintas Data Prima,ISP
 lds.online,Luganskie Domashnie Seti,ISP
 ldw.com,Last Day of Work,Entertainment
 leaderdrug.com,Cardinal Health,Healthcare
@@ -4789,6 +5197,7 @@ learn.k12.ct.us,LEARN Connecticut,Education
 learningstream.com,Learning Stream,SaaS
 leaseweb.ca,Leaseweb,Web Host
 leaseweb.com,Leaseweb,Web Host
+lee.net,Lee Enterprises,News
 leeschools.net,Lee County Schools Florida,Education
 leftor.ba,Leftor,Web Host
 leftor.com,Leftor,Web Host
@@ -4801,6 +5210,7 @@ leon.pl,Leon Polish ISP,ISP
 leonardocompany.com,Leonardo,Defense
 leonet.de,LEONET,ISP
 leonet.it,Var Group (Leonet),MSP
+leonix.fr,Leonix Telecom,ISP
 lepida.net,Lepida,ISP
 lestetelecom.com.br,Leste,ISP
 letaba.net,Letaba Networks,ISP
@@ -4812,6 +5222,7 @@ level3.net,Lumen,ISP
 lewtelnet.de,LEW TelNet,ISP
 lexi.net,Lexicom,MSP
 lexicom.ca,Lexicom,MSP
+lexisnexis.com,ChoicePoint,Government
 lf.net,LF.net Stuttgart,ISP
 lgatelecom.net,LGA Telecom,MSP
 lgcns.com,LG CNS,Technology
@@ -4828,6 +5239,7 @@ liberated.ca,Liberated Networks,Web Host
 liberatednetworks.com,Liberated Networks,Web Host
 liberation.fr,Liberation,News
 liberty.co.za,Liberty Holdings South Africa,Finance
+libertycommunications.com,Liberty Communications,ISP
 libertycr.com,Liberty,ISP
 libertyglobal.com,Liberty Global,ISP
 libertyhospital.org,Liberty Hospital,Healthcare
@@ -4837,6 +5249,7 @@ libertynetworks.com,Liberty Networks,ISP
 libertypr.com,Liberty,ISP
 libraesva.com,Libraesva,Email Security
 library.on.ca,Ontario Libraries,Nonprofit
+lict.com.ly,LICT,MSP
 lidernetfibra.com.br,Lidernet,ISP
 lidero.net,Lidero Network,ISP
 lietpark.com,Lietpark Communications,ISP
@@ -4847,14 +5260,17 @@ ligataxi.com,LiguaTaxi,SaaS
 liggatelecom.com.br,Ligga Telecom,ISP
 lightbound.com,LightBound,ISP
 lightedge.com,LightEdge,MSP
+lightnet.ie,Lighthouse Networks,ISP
 lightningbroadband.com.au,Lightning Broadband,ISP
 lightningfibre.co.uk,Lightning Fibre,ISP
 lightnode.com,LightNode,Web Host
 lightower.net,Lightower Fiber Networks,ISP
 lightpathfiber.com,Lightpath,ISP
+lightspar.com,LightSpar,ISP
 lightwire.co.nz,Lightwire NZ,ISP
 lightwyse.com,Lumos,ISP
 ligmais.com.br,Lig+Telecom,ISP
+ligtel.com,Ligtel Communications,ISP
 liguriadigitale.it,Liguria Digitale,MSP
 likuid.com,Likuid,Web Host
 lilly.com,Eli Lilly,Healthcare
@@ -4877,11 +5293,14 @@ linkbermuda.com,Link Bermuda,ISP
 linkbrasil.net.br,Link Brasil,ISP
 linkedin.com,LinkedIn,Social Media
 linkfire.com.br,Linkfire Telecom,ISP
+linkfull.com.br,Linkfull,ISP
 linknetms.com.br,Link Net Telecom,ISP
+linknortetel.com.br,NORTETEL,ISP
 linknortetelecom.com.br,Link Norte,ISP
 linksecured.net,LinkSecured (Sudjam),Web Host
 linksul.com.br,LinkSul,ISP
 linkt.fr,Linkt,ISP
+linktelcorp.com,Linktel Telecom do Brasil,ISP
 linode.com,Linode,Web Host
 linodeusercontent.com,Linode,Web Host
 linq.net.br,LinQ Telecomunicacoes,ISP
@@ -4918,6 +5337,7 @@ liveoakfiber.com,LiveOak Fiber,ISP
 liveperson.net,LivePerson,SaaS
 liwest.at,LIWEST,ISP
 ljosleidarinn.is,Ljosleidarinn Iceland,ISP
+ljusnet.se,Ljusdal Energi,ISP
 llnl.gov,Lawrence Livermore National Laboratory,Government
 lloydsbanking.com,Lloyds Banking Group,Finance
 lloydsbankinggroup.com,Lloyds Banking Group,Finance
@@ -4930,6 +5350,7 @@ lmu.edu,Loyola Marymount University,Education
 ln.edu.hk,Lingnan University,Education
 lnc.com,Lincoln Financial,Finance
 lncc.br,LNCC Brazilian National Laboratory for Scientific Computing,Science
+loadedge.net,Root Networks,MSP
 loading.es,Loading,Web Host
 loblaw.ca,Loblaw,Retail
 loc.gov,Library of Congress,Government
@@ -4942,6 +5363,7 @@ lodz.pl,Lodz University of Technology,Education
 loftsinc.com,"Lofts, Inc.",Retail
 loga.net.br,Loga,ISP
 logic.ky,Logic Cayman,ISP
+logical.net,Logical Net,MSSP
 logicweb.com,LogicWeb,Web Host
 logika.ro,Logika IT Solutions,MSP
 loginbusiness.com,Login Inc Tucson,ISP
@@ -4949,14 +5371,18 @@ logis.org,LOGIS,Government
 logisticintegrators.com,Logistics Integrators,Logistics
 logix.in,Logix InfoSecurity,MSP
 logosoft.ba,Logosoft,ISP
+loihde.com,Loihde,MSP
 lokalonline.com.br,Lokal Online Telecom,ISP
 lolipop.jp,Lolipop,Web Host
 lomalindahealth.org,Loma Linda University Health,Healthcare
+loncomillatv.cl,TV Cable Loncomilla,ISP
 lonconnect.co.uk,LonConnect,ISP
 london.on.ca,St. Joseph's Health Care London,Healthcare
+lonestarcell.com,MTN Liberia,ISP
 longlines.com,Long Lines Broadband,ISP
 loni.org,LONI,Education
 loopia.se,Loopia,Web Host
+lorettotel.com,Loretto Communication Services,ISP
 losnettos.net,Los Nettos,Education
 lotteinnovate.com,Lotte Innovate,MSP
 louhi.fi,Louhi,Web Host
@@ -4969,6 +5395,7 @@ lovelandpulse.com,Pulse Loveland,Utilities
 lovit.ru,Lovitel,ISP
 lowesthosting.com,Lowest Hosting,Web Host
 loyalty.com,LoyaltyOne,SaaS
+loyno.edu,Loyola University New Orleans,Education
 loyola.edu,Loyola University Maryland,Education
 lpages.co,Leadpages,Marketing
 lpcgov.org,La Plata County,Government
@@ -4978,6 +5405,7 @@ lponet.fi,LPOnet,ISP
 lpusercontent.com,Leadpages,Marketing
 lrcommunications.com,LR Communications,ISP
 lrnetbandalarga.net.br,L & R Net,ISP
+lrv.lt,LRV,Government
 lrz.de,LRZ,Education
 lsnetworks.net,Lightspeed Networks,ISP
 lss.net.pl,Freshbox,ISP
@@ -4986,6 +5414,7 @@ lstream.org,LifeStream Blood Bank,Nonprofit
 lstrk.net,Listrak,Marketing
 lsu.edu,Louisiana State University,Education
 lsuc.on.ca,Law Society of Ontario,Government
+lsuhsc.edu,LSU Health Sciences Center,Education
 lt-nn.net,Link Telecom NN,ISP
 ltt.ly,Libya Telecom & Technology,ISP
 ltu.se,Luleå University of Technology,Education
@@ -4997,6 +5426,7 @@ luganet.ru,Luganet,ISP
 lugtel.com,Lugansk Telephone Company,ISP
 lukoil-inform.ru,Lukoil-Inform,Industrial
 lumen.com,Lumen,ISP
+lumiglobal.com,Lumi Global,SaaS
 luminabroadband.com,Lumina Broadband,ISP
 luminatebroadband.com,Luminate Fiber,ISP
 lumison.net,Pulsant,Web Host
@@ -5005,20 +5435,26 @@ lumosfiber.com,Lumos,ISP
 lumosnetworks.com,Lumos,ISP
 lunarnaut.com,Lunarnaut,Web Host
 lusfiber.net,LUS Fiber,ISP
+luxnetwork.eu,LUXNETWORK,ISP
 luxoft.com,Luxoft,Consulting
 luxsci.com,LuxSci,Email Security
 luz.edu.ve,Universidad del Zulia,Education
+lvrtc.lv,LVRTC,Government
 lwlcom.net,LWLcom,ISP
 lws-hosting.com,LWS,Web Host
+lws.fr,LWS,Web Host
 lwsd.org,Lake Washington School District,Education
 lxcluster.at,LXCluster,Web Host
 lycatel.com,Lyca Group,ISP
 lycorp.co.jp,LY Corporation,SaaS
+lynchesriver.com,Lynches River Communications,Utilities
 lyntia.com,Lyntia,ISP
 lynxoft.ru,LynXoft,Marketing
 lyse.no,Lyse,ISP
 lytehosting.com,Lyte Hosting,Web Host
 m-net.de,M-net,ISP
+m-real.net,M-Real NET,ISP
+m-soft.cz,"M-SOFT, spol. s r.o",ISP
 m1.com.sg,M1,ISP
 m1net.com.sg,M1,ISP
 m247.ro,M247,IaaS
@@ -5027,6 +5463,7 @@ m2dtelecom.com.br,M2D Telecom,ISP
 m3comva.com,M3COM,ISP
 m4w.at,M4W Kreativ,Marketing
 m9network.com,Volico Data Centers,Web Host
+ma.edu,Westfield State University,Education
 mable.jp,San-in Cable Vision,ISP
 macalester.edu,Macalester College,Education
 machanet.com.br,Grupo Nordeste Telecom,ISP
@@ -5039,6 +5476,7 @@ macstadium.com,MacStadium,Web Host
 mada.ps,Mada,ISP
 maddock.net,Maddock Films,Entertainment
 madgenius.com,Madgenius,Web Host
+madisontelco.com,Madison Telephone Company,ISP
 maersk.com,Maersk,Logistics
 maestroit.com,Maestro IT Services,MSP
 maffin.ad.jp,"MAFF (Japan Ministry of Agriculture, Forestry and Fisheries)",Government
@@ -5049,6 +5487,7 @@ magentosite.cloud,Adobe Magento,SaaS
 magnetplus.ie,Magnet Plus,ISP
 magnite.com,Magnite,Marketing
 magnoliarental.com,Magnolia Rental,Retail
+magrathea-telecom.co.uk,Magrathea Telecommunications,ISP
 magticom.ge,Magticom,ISP
 mahaska.org,Mahaska Communication Group MCG,ISP
 mahidol.ac.th,Mahidol University,Education
@@ -5089,6 +5528,7 @@ mailspamprotection.com,SiteGround,Web Host
 mailwip.com,Mailwip,Email Provider
 maine.edu,University of Maine System,Education
 mainone.net,MainOne,ISP
+mainstream.eu,Mainstream doo Beograd,IaaS
 maisbandalarga.com,Mais Banda Larga,ISP
 maisinternet.net.br,Mais Internet,ISP
 majorcore.com,MajorCore,Web Host
@@ -5110,6 +5550,7 @@ manitu.de,manitu,Web Host
 manxtelecom.com,Manx Telecom,ISP
 mapheadstart.org,Mississippi Action for Progress,Nonprofit
 mappsoluciones.com,MappS Soluciones,Web Host
+marcant.net,MARCANT,MSP
 marcatel.com,Marcatel,ISP
 maren.ac.mw,MAREN Malawi Research and Education Network,Education
 maricopa.edu,Maricopa Community Colleges,Education
@@ -5126,6 +5567,7 @@ marriott.com,Marriott,Travel
 mars-inc.com,Mars,Food
 marsh.com,Marsh,Finance
 marshall.edu,Marshall University,Education
+marshalltelecom.com,Marshall Telecom,ISP
 marstonstelecoms.com,Marston's Telecoms,ISP
 martinsnet.com.br,Martins.Net,ISP
 marubeni.com,Marubeni,Conglomerate
@@ -5143,6 +5585,7 @@ masorange.es,MásOrange,ISP
 mass.gov,Massachusetts Government,Government
 massey.ac.nz,Massey University,Education
 massgeneralbrigham.org,Mass General Brigham,Healthcare
+massivegrid.com,MASSIVEGRID,IaaS
 massivenetworks.com,Massive Networks,ISP
 massresponse.com,Mass Response,SaaS
 master.cz,MasterDC,Web Host
@@ -5179,6 +5622,7 @@ mayoclinic.com,Mayo Clinic,Healthcare
 mbari.org,Monterey Bay Aquarium Research Institute,Education
 mbcokinawa.net,MBC Okinawa,ISP
 mbonetworks.com,MBO Networks,ISP
+mbusa.com,Mercedes-Benz USA,Automotive
 mc.net,helpdesk365 (McHenryCom),MSP
 mc.net.co,Media Commerce Partners,ISP
 mcat.co.jp,MCAT,ISP
@@ -5202,6 +5646,7 @@ mcmtelecom.com,MCM Business (Megacable Mexico),ISP
 mcnbd.com,Millennium Computer's & Networking,MSP
 mcnc.org,MCNC,Education
 mcntelecom.com,MCN Telecom (Kompaas),ISP
+mcoe.org,Merced County Office of Education,Education
 mcpre.ru,McHost,Web Host
 mcpsmd.org,Montgomery County Public Schools (Maryland),Education
 mcsnet.ca,MCSnet,ISP
@@ -5216,6 +5661,7 @@ mdcc.gob.pe,Municipalidad Distrital de Cerro Colorado,Government
 mdcourts.gov,Maryland Courts,Government
 mdlink.de,MDlink,MSP
 mdlsx.ca,"Middlesex County, Canada",Government
+mdsol.com,Medidata,SaaS
 mdstelecom.com.ve,MDS Telecom,ISP
 mdu.com,MDU Resources,Utilities
 me.com,Apple iCloud,Email Provider
@@ -5229,6 +5675,7 @@ media3.us,Media3,MSP
 mediacenter.hu,MediaCenter Hungary,Web Host
 mediacomcable.com,Mediacom,ISP
 mediacommerce.com.co,Media Commerce Partners,ISP
+mediactivegroup.com,Mediactive Group,MSP
 mediafuze.com,Mediafuze,Marketing
 mediaprint.at,Mediaprint,Publishing
 mediasat.ro,Media Sat Romania,ISP
@@ -5262,6 +5709,7 @@ megacp.com,iWorx Host,Web Host
 megadata.net.id,Megadata ISP,ISP
 megafon.ru,MegaFon,ISP
 megafon.tj,MegaFon,ISP
+megalayer.net,Megalayer,IaaS
 megaline.kg,Maga-Line,ISP
 megalink.com,MegaLink Bolivia,ISP
 megalink.net.ru,Мегалинк,ISP
@@ -5269,6 +5717,7 @@ megalinkinternet.com.br,MegaLink,ISP
 megamailservers.com,MegaMailServers,MSP
 megamailservers.eu,MegaMailServers,MSP
 meganetrj.com.br,Meganet,ISP
+megaport.com,Megaport,IaaS
 megared.net.mx,Megared,ISP
 megaspace.de,Megaspace,Web Host
 megatelecom.com.br,SAMM Megatelecom,ISP
@@ -5311,6 +5760,7 @@ messagingengine.com,Fastmail,Email Provider
 mesvr.com,ReadNotify,Email Provider
 meta10.com,META10,IaaS
 metalink.net,MetaLINK Technologies,ISP
+metanet.ch,Metanet,Web Host
 metanet.co.kr,Metanet DT,MSP
 metasolutions.net,META Solutions,Education
 metcal.com.my,Metcal Technologies,Industrial
@@ -5320,14 +5770,17 @@ metpro.co,MetPro,SaaS
 metricsthatmatter.com,Metrics That Matter,SaaS
 metro-set.ru,Metroset Tyumen,ISP
 metro.digital,METRO Digital,Technology
+metrobit.ru,PIN,ISP
 metrocomm.com,Metro Communications,ISP
 metrofibre.co.za,Metrofibre,ISP
 metroflex.com.br,Metroflex,ISP
 metrohealth.org,MetroHealth,Healthcare
 metrolink.it,Metrolink Italy,ISP
 metromax.ru,Metromax,ISP
+metrompls.com,Metro MPLS,ISP
 metronet.com,MetroNet,ISP
 metronetinc.net,Metronet,ISP
+metrooptic.com,Metro Optic,ISP
 metrored.com.mx,Metrored,ISP
 metrored.hn,Metrored Honduras,ISP
 metrored.net.mx,Metrored,ISP
@@ -5346,6 +5799,7 @@ mfa-inc.com,MFA,Industrial
 mfeed.ad.jp,Internet Multifeed (JPNAP),ISP
 mgb.org,Mass General Brigham,Healthcare
 mgconecta.com.br,Conecta,ISP
+mgmresorts.com,MGM Resorts,Travel
 mgnettelecom.com.br,MG NET Telecom,ISP
 mgp.net.br,MGP Telecom,ISP
 mgsm.ru,Aviasales,Travel
@@ -5357,6 +5811,7 @@ mia.net,HostDrive,Web Host
 miami.edu,University of Miami,Education
 miamioh.edu,Miami University,Education
 micaresvc.com,MiCare,Healthcare
+mich.net,Michigan Statewide Educational Network,Education
 michigan.gov,State of Michigan,Government
 microchip.com,Microchip Technology,Manufacturing
 microchip.net.pl,Microchip s.c.,ISP
@@ -5364,13 +5819,17 @@ microfocus-japan.com,Micro Focus,MSP
 microfocus.com,Micro Focus (OpenText),SaaS
 microlinknet.com,Microlink Networks,ISP
 micron.com,Micron Technology,Manufacturing
+micron.net.br,Micron Internet,ISP
 micron21.com,Micron21 Datacentre,Web Host
 micronet.in,MicroNet Gigafiber,ISP
+micropic.com.br,Micropic,ISP
 microscan.co.in,Microscan,ISP
 microscaninternet.com,Microscan,ISP
 microservizi.com,Microservizi,ISP
 microsoft.com,Microsoft,Technology
+micso.it,Micso Information Technology,ISP
 mid-hudson.com,Mid-Hudson Cablevision,ISP
+midatlanticbb.com,MidAtlantic Broadband,ISP
 midcentury.com,Mid Century Communications,ISP
 midcityvet.com,MidCity Veterinary Hospital,Healthcare
 midco.com,Midco,ISP
@@ -5379,7 +5838,9 @@ middlesex.ca,"Middlesex County, Canada",Government
 midi-loisirs.com,Midi Loisirs,Entertainment
 midrivers.com,Mid-Rivers Communications,ISP
 midsouthfiber.com,MidSouth Fiber,ISP
+midwestfibernetworks.com,Midwest Fiber Networks,ISP
 mie-u.ac.jp,Mie University,Education
+miex.at,mieX,ISP
 mifibra.pe,MiFibra Peru,ISP
 migadu.com,Migadu,Email Provider
 migracion.go.cr,Costa Rica Migration,Government
@@ -5398,11 +5859,14 @@ milliken.com,Milliken,Manufacturing
 millipore.com,Millipore,Healthcare
 mills.edu,Mills College (Northeastern Oakland),Education
 milton.ca,Town of Milton,Government
+mimebd.com,Mime,ISP
 mimecast-offshore.com,Mimecast,Email Security
 mimecast.com,Mimecast,Email Security
 mindmoviesmail.com,Mind Movies,SaaS
 minebeamitsumi.com,MinebeaMitsumi,Manufacturing
 mines.edu,Colorado School of Mines,Education
+minet.sk,Minet Slovakia,ISP
+minetinc.net,MiNet,ISP
 minigraphics.net,Mini Graphics,Print
 miniserver.com,Memset,Web Host
 minnstate.edu,Minnesota State Colleges and Universities,Education
@@ -5411,6 +5875,7 @@ mipt.ru,MIPT Moscow Institute of Physics and Technology,Education
 mir9.co.kr,Mir9,Marketing
 mirai.ne.jp,Mirai NET,ISP
 miralogic.ru,MiraLogic,ISP
+miran.ru,Miran,IaaS
 miranda-media.ru,Miranda Media,ISP
 mirohost.net,MiroHost,Web Host
 misaka.io,Misaka Network,IaaS
@@ -5422,6 +5887,7 @@ missouri.gov,State of Missouri,Government
 mistral.co.uk,Nasstar,MSP
 mistral.net,Nasstar,MSP
 mit.edu,MIT,Education
+mitchelltelecom.com,Mitchell Telecom,ISP
 mitec.net,Mitec Solutions,MSP
 mitel.com,Mitel,SaaS
 mitene.co.jp,Mitene Internet,ISP
@@ -5432,6 +5898,7 @@ mittwald.info,Mittwald,Web Host
 mittwaldserver.info,Mittwald,Web Host
 miva.com,Mirva,SaaS
 mivamerchant.net,Mirva,SaaS
+mivitec.de,WIIT,IaaS
 mixvoip.com,Mixvoip,ISP
 miyazaki-catv.ne.jp,Miyazaki Cable Television,ISP
 mizban.com,Mizban,Web Host
@@ -5448,17 +5915,22 @@ mky.com,Mackay Telecommunication,ISP
 mld.id,Media Lintas Data,ISP
 mlec.com,Meriwether Lewis Electric Cooperative,ISP
 mlems.ca,Middlesex-London Paramedic Service,Healthcare
+mlltelecom.com,MLL Telecom,ISP
 mlps.ca,Middlesex-London Paramedic Service,Healthcare
 mls.com.br,MLS Wireless,ISP
 mls.nc,MLS New Caledonia,ISP
 mma.com.br,MMA Fibra,ISP
+mminternet.com,MM Internet,ISP
 mmm.com,3M,Technology
 mmprovedor.com.br,MM Telecom,ISP
 mmrs.jp,Mirai Communication Network Inc.,Web Host
+mncable.net,Sjoberg's,ISP
+mncplay.id,MNC Play,ISP
 mnet.bg,MSAT Cable,ISP
 mni.net,MNI,Marketing
 mnogobyte.ru,MnogoByte,Web Host
 mnsi.net,MNSi Telecom,ISP
+mnu.ac.kr,Mokpo University,Education
 mnzoo.org,Minnesota Zoo,Entertainment
 moack.co.kr,MOACK,Web Host
 mobi.net.lb,Mobi Lebanon (Broadband Plus),ISP
@@ -5474,6 +5946,7 @@ mobinnet.net,Mobinnet,ISP
 mobitel.lk,SLT Mobitel,ISP
 mobtelecom.com.br,Mob Telecom,ISP
 moc.edu,University of Mount Olive,Education
+modee.gov.jo,National Information Technology Center,Government
 modeldrug.com,Model Health Care,Healthcare
 modenesegastone.com,Modenese Gastone,Retail
 modis.com,AKKODiS,Staffing
@@ -5483,6 +5956,7 @@ moe.gov.tw,Ministry of Education Computer Center,Government
 mogilev.by,Mogilev.by,ISP
 mohawkcollege.ca,Mohawk College,Education
 mojohost.com,MojoHost,Web Host
+mokwon.ac.kr,Mokwon University,Education
 molalla.com,Molalla Communications,ISP
 molalla.net,Molalla Communications,ISP
 moldcell.md,Moldcell,ISP
@@ -5491,7 +5965,9 @@ molgroup.hu,MOL Group,Industrial
 momentumtelecom.com,Momentum Telecom,ISP
 monaco-telecom.mc,Monaco Telecom,ISP
 monash.edu,Monash University,Education
+monash.edu.my,Monash University Sunway Campus Malaysia,Education
 monatglobal.com,MONAT Global,Beauty
+mondadori.it,Mondadori,Publishing
 mongodb.com,MongoDB,SaaS
 moniker.com,Moniker,Web Host
 monitorsanywhere.com,Monitors AnyWhere,SaaS
@@ -5503,6 +5979,8 @@ montclair.edu,Montclair State University,Education
 montereybaydesign.com,Monterey Bay Design,Web Host
 montgomerycollege.edu,Montgomery College,Education
 montreal.ca,City of Montreal,Government
+monzoon.net,Monzoon Networks,ISP
+moorecap.com,Moore Capital Management,Finance
 moovik.com.ua,MooVik,Retail
 moph.go.th,Thailand Ministry of Public Health,Government
 morarepublic.co.id,Mora Republic,ISP
@@ -5520,8 +5998,10 @@ mosaictelecom.com,Mosaic Technologies,ISP
 moselletelecom.fr,Moselle Télécom,ISP
 mostobene.com,Mostobene,Healthcare
 motenasu-hosting.biz,NHN Cloud Japan (Motenasu),Web Host
+motive.io,Motive,SaaS
 motivtelecom.ru,Motiv,ISP
 motorola.com,Motorola,Technology
+mottanet.com.br,Mottanet TI - Servicos DE Tecnologia DA Info,ISP
 mounet.com,MouNet,ISP
 mountaintelephone.com,Mountain Telephone,ISP
 mountsinai.org,Mount Sinai,Healthcare
@@ -5531,8 +6011,10 @@ movilnet.com.ve,Movilnet,ISP
 movistar.cl,Moivestar Chlie,ISP
 movistar.com.co,Movistar,ISP
 movistar.com.mx,Movistar,ISP
+movistar.com.ni,Movistar Nicaragua,ISP
 movistar.com.sv,Movistar El Salvador,ISP
 movistar.com.uy,Tigo,ISP
+movistar.cr,Movistar Costa Rica,ISP
 movistar.es,Movistar,ISP
 movitel.co.mz,Movitel,ISP
 mowry.com.br,Mowry (Tascom),ISP
@@ -5548,6 +6030,7 @@ mrhc.org,Magnolia Regional Health Center,Healthcare
 mrhost.biz,MrHost,Web Host
 mrit.gov.pl,Polish Ministry of Development and Technology,Government
 mrse.com.ar,Telefonica de Argentina,ISP
+ms3networks.co.uk,MS3 Networks,ISP
 msctv.ca,Mitchell Seaforth Cable TV,ISP
 msd-consulting.co.za,MSD Consulting,Finance
 mserwis.pl,MSERWIS,Web Host
@@ -5574,11 +6057,14 @@ mtasv.net,Postmark,SaaS
 mtc.com.na,MTC,ISP
 mtccomm.net,MTC Communications,ISP
 mtco.com,MTCO Conxxus,ISP
+mtctel.com,Margaretville Telephone,ISP
 mtdtraining.co.uk,MTD Training Group,SaaS
 mtel.ba,Mtel,ISP
 mtel.me,Mtel,ISP
 mtel.mo,MTel Macau,ISP
+mthnetworks.com,Monkey Tree Hosting,ISP
 mtholyoke.edu,Mount Holyoke College,Education
+mtl.mw,Malawi Telecommunications,ISP
 mtn.ci,MTN,ISP
 mtn.cm,MTNL,ISP
 mtn.co.rw,MTN Rwanda,ISP
@@ -5587,6 +6073,7 @@ mtn.com,MTN,ISP
 mtn.com.gh,MTN,ISP
 mtn.ng,MTN,ISP
 mtn.sd,MTN,ISP
+mtn.zm,MTN Zambia,ISP
 mtncongo.net,MTN Congo,ISP
 mtnet.hr,Magic Net,ISP
 mtnirancell.ir,MTN Irancell,ISP
@@ -5604,6 +6091,7 @@ mtsmail.ca,Bell MTS,ISP
 mtsnet.ru,Mobile TeleSystems PJSC (MTS),ISP
 mtsu.edu,Middle Tennessee State University,Education
 mtsvc.net,GoDaddy,Web Host
+mtt.ru,MTT,ISP
 mtu-net.ru,Mobile TeleSystems,ISP
 mtu.edu,Michigan Technological University,Education
 mtw.ru,MTW Mediasoft,Web Host
@@ -5613,6 +6101,7 @@ multacom.com,MULTACOM,Web Host
 multi.net.pk,Multinet Pakistan,ISP
 multicare.org,MultiCare Health System,Healthcare
 multikom.at,xLINK (Multikom),ISP
+multimedia-bg.net,Multimedia BG,ISP
 multimedia.pl,Multimedia Polska,ISP
 multiplay.pl,Multiplay Poland,ISP
 multipolar.co.id,Multipolar Technology,MSP
@@ -5624,6 +6113,7 @@ mundonetfibra.com.br,Mundo Net Fibra,ISP
 mundopacifico.cl,Mundo Pacifico,ISP
 muni.cz,Masaryk University,Education
 munich-airport.de,Munich Airport,Travel
+murraystate.edu,Murray State University,Education
 musashi-eng.co.jp,Musashi Engineering,Manufacturing
 musc.edu,Medical University of South Carolina,Healthcare
 musfiber.com,Morristown Utilities (MUS Fiber),Utilities
@@ -5632,6 +6122,7 @@ muvnet.com.br,Muvnet Telecom,ISP
 mvd.ru,Ministry of Internal Affairs of Russia,Government
 mvnu.edu,Mount Vernon Nazarene University,Education
 mvps.net,MVPS,Web Host
+mvtvwireless.com,MVTV Wireless,ISP
 mwainternet.com.br,MWA Internet,ISP
 mweb.co.za,MWEB,ISP
 mwprem.net,NTT,ISP
@@ -5648,6 +6139,7 @@ myaisfibre.com,AIS Fibre,ISP
 myanmaposts.net.mm,Myanma Posts and Telecommunications,ISP
 mybluehost.me,Bluehost,Web Host
 mybluepeak.com,Bluepeak,ISP
+mybtc.com,BTC Broadband,ISP
 mycentra.ru,MyCentra,ISP
 myctgs.com,CTG Server,Web Host
 mydataknox.com,MyDataKnox,Web Host
@@ -5711,6 +6203,7 @@ myspreadshop.se,Spreadshop,SaaS
 mytel.com.mm,Mytel Myanmar,ISP
 mytelstar.com,Tel-Star,ISP
 mythic-beasts.com,Mythic Beasts,Web Host
+myvalunet.com,Valu-Net,ISP
 mywhc.ca,Web Hosting Canada,Web Host
 mywkt.net,WK&T West Ky Networks,ISP
 myworkday.com,Workday,SaaS
@@ -5740,6 +6233,7 @@ nano.uz,Nano Telecom,ISP
 nao.ac.jp,National Astronomical Observatory of Japan,Education
 nap.net.tw,Taiwan Network Access Point,ISP
 napinfo.co.id,NAP Info Indonesia,ISP
+naquadria.it,Naquadria,ISP
 naracom.hu,Naracom,ISP
 nasa.gov,NASA,Government
 nasboces.org,Nassau BOCES,Education
@@ -5765,6 +6259,8 @@ naturalwireless.com,Natural Wireless,ISP
 natwestmarkets.com,NatWest Markets,Finance
 nau.edu,Northern Arizona University,Education
 naukanet.ru,Nauka-Svyaz,ISP
+nautile.nc,Nautile,ISP
+nav.co,NAV Communications,IaaS
 navayuga.com,Navayuga,Industrial
 navega.com,Navega Guatemala,ISP
 navegalo.com,Navegalo Costa Rica,ISP
@@ -5781,19 +6277,24 @@ nbcb.cn,Bank of Ningbo,Finance
 nbcuni.com,NBCUniversal,Entertainment
 nbpower.com,New Brunswick Power,Utilities
 nbstelecom.psi.br,NBS Telecom,ISP
+nbtele.com,Noor Al-Bedaya,ISP
 nc.gov,State of North Carolina,Government
 ncbs.res.in,National Centre for Biological Sciences,Education
+nccray.com,Northwest Communications,ISP
 ncell.com.np,Ncell,ISP
 nchc.org.tw,National Center for High-performance Computing,Government
 nckcn.com,NCKCN North Central Kansas Community Network,ISP
+ncn.net,Northwest Communications,ISP
 ncr.com,NCR,Technology
 ncsl.ca,Northern Computer Solutions,MSP
 ncsu.edu,NC State University,Education
 nctc.com,NCTC,ISP
 ncturbi.com.br,NetCom Brasil,ISP
+ncuk.com,NetConnex Broadband,ISP
 ncv.co.jp,Newmedia Corporation,ISP
 nd.edu,University of Notre Dame,Education
 nd.gov,North Dakota Government,Government
+ndchost.com,Network Data Center Host,Web Host
 ndensan.co.jp,Densan,MSP
 nds-g.co.jp,NDS Japan,MSP
 nearlyfreespeech.net,NearlyFreeSpeach.NET,Web Host
@@ -5811,17 +6312,23 @@ need-link-eng.co.jp,Need Link Engineering,Technology
 needles.co.kr,Tae Chang Industrial,Healthcare
 neencloud.it,NEEN,MSP
 negabaritika.ru,Negabaritika,Logistics
+nema.fo,Nema,SaaS
 nemont.com,Nemont,ISP
 neo-fiber.net,NeoFiber Communications,ISP
+neocarrier.com,Neocarrier Communications Sarl,ISP
 neoclan.net,Neoclan Networks,ISP
 neoclan.net.mx,Neoclan Networks,ISP
 neocomisp.com,NeocomISP,ISP
 neocomisp.com.kh,NeocomISP Cambodia,ISP
+neolink.com.br,Neolink,ISP
+neomedia.it,Neomedia,ISP
+neonet.org,NEOnet,Education
 neonova.net,NeoNova,ISP
 neosnetworks.com,Neos Networks,ISP
 neotechprovedor.com.br,NeoTech,ISP
 neotel.co.za,Neotel,ISP
 neotel.mk,Neotel North Macedonia,ISP
+neotelecom.ru,Neotelecom,ISP
 neovia.com.br,Neovia Solutions,ISP
 neovision.de,NEOVISION,Marketing
 nep.net,NEP North-Eastern Pennsylvania Telephone,ISP
@@ -5833,12 +6340,15 @@ nesparc.com,NE SPARC,ISP
 nessus.at,Nessus GmbH,ISP
 nestle.com,Nestle,Food
 net-gate.ro,Net Gate Romania,ISP
+net-minders.com,Netminders Server Hosting,IaaS
 net-rosas.com.br,Net Rosas,ISP
 net-uno.net,Net Uno,ISP
 net.de,net.DE,IaaS
 net.ru,NET.RU Mega ISP,ISP
+net1.ie,Adelphi Net1,ISP
 net11.com.br,Net Onze,ISP
 net4you.com.br,NET4YOU,ISP
+net4you.net,Net4You Internet,ISP
 net92.ru,Sevastopol Telecom,ISP
 netactuate.com,NetActuate,Web Host
 netage.jp,NETAGE,ISP
@@ -5860,6 +6370,7 @@ netcom-kassel.de,Netcom Kassel,ISP
 netcom-r.ru,NetCom-R,ISP
 netcomafrica.com,Netcom Africa,ISP
 netcomet.com.br,Netcomet,ISP
+netconnect.ch,netconnect,ISP
 netcore.co.in,Netcore,Marketing
 netcrawler.ca,Netcrawler,ISP
 netcup.com,netcup,Web Host
@@ -5869,6 +6380,7 @@ netdirekt.com.tr,Netdirekt,Web Host
 netease.com,NetEase,Email Provider
 neterra.net,Neterra,ISP
 netexpand.com.br,NetExpand,ISP
+netfactor.com.tr,Netfactor Telekominikasyon ve Teknoloji Hizmetleri San. ve Tic,MSP
 netfinn.net,netFinn,Web Host
 netflix.com,Netflix,Entertainment
 netforest.ad.jp,Netforest,Web Host
@@ -5881,6 +6393,7 @@ netia.pl,Netia,ISP
 netifox.com,NETIFOX,ISP
 netinnovation.net,Net Innovation,ISP
 netinternet.tr,NetInternet,Web Host
+netiwan.fr,Eurofiber,ISP
 netiz.net.br,Netiz,ISP
 netlify.app,Netlify,PaaS
 netlify.com,Netlify,PaaS
@@ -5894,6 +6407,8 @@ netnam.com,NetNam,ISP
 netnam.vn,NetNam,ISP
 netnar.com.py,Netnar,ISP
 netnerd.com,NetNerd,Web Host
+netnod.se,Netnod,ISP
+netnorth.co.uk,Netnorth,ISP
 netone.ru,NetOne Russia,ISP
 netonline.net,Netonline,ISP
 netowl.jp,スターアカウント,ISP
@@ -5914,6 +6429,7 @@ netrixllc.com,Netrix,MSP
 netroad.ru,Mobile TeleSystems,ISP
 netrouting.com,Netrouting,Web Host
 netsat.in,Netsat Communications,ISP
+netservers.net.uk,Netservers,IaaS
 netservice-jeziorany.pl,Netservice Jeziorany,ISP
 netservices.de,net services,ISP
 netskope.com,Netskope,SaaS
@@ -5952,6 +6468,7 @@ networkplatforms.co.za,Network Platforms ZA,ISP
 networksolutions.com,Network Solutions,Web Host
 networktransit.net,Network Transit,ISP
 networthtelecom.fr,Networth Telecom,ISP
+netwurx.net,Netwurx,ISP
 netzquadrat.de,netzquadrat,Web Host
 neu-medianet.de,fitflat (neu-medianet),ISP
 neu.edu,Northeastern University,Education
@@ -5974,6 +6491,7 @@ newnet.com.br,Newnet,MSP
 newoeste.com.br,New Oeste Telecom,ISP
 newpages.com.my,NEWPAGES,Retail
 newpaltz.edu,SUNY New Paltz,Education
+newrelic.com,New Relic,SaaS
 newroztelecom.com,Newroz Telecom,ISP
 news-gazette.com,News-Gazette,News
 newschool.edu,The New School,Education
@@ -5983,9 +6501,11 @@ newsmanapp.com,NewsMAN,Marketing
 newsunseo.com,NewSunSEO,Marketing
 newtekone.com,NewtekOne,Finance
 newtekwebhosting.com,Intelligent Protection Management,Web Host
+newtel.je,Newtel,ISP
 newworldpresenter.com,New World Presenter,News
 nex-techwireless.com,Nex-Tech Wireless,ISP
 nexcess.net,Nexcess,Web Host
+nexcom.co.id,Nexcom Indonesia,ISP
 nexeon.com,Nexeon,IaaS
 nexg.net,KX NexG,ISP
 nexicom.net,Nexicom,ISP
@@ -6010,6 +6530,8 @@ nextpertise.nl,Nextpertise,ISP
 nexttelecom.net.br,Next Internet,ISP
 nexusds.com,NEXUSDS,ISP
 nexusguard.com,Nexusguard,Email Security
+nexx.net,NEXX,ISP
+nfl.com,National Football League,Sports
 nforce.com,NForce Entertainment,Web Host
 nfshost.com,NearlyFreeSpeech.NET,Web Host
 nftctelecom.com,NFTC North Frontenac Telephone,ISP
@@ -6017,10 +6539,13 @@ nfx.cz,NFX czFree eXchange,ISP
 ngblunetworks.nl,NGBLU Networks,ISP
 ngenix.net,NGENIX,SaaS
 ngloba.com,Ngloba Devices,MSP
+ngn.coop,North Georgia Network,ISP
 ngpweb.com,Bonterra,Marketing
 ngren.edu.ng,NgREN Nigerian Research and Education Network,Education
 nh-serv.co.uk,Nimbus Hosting,Web Host
 nhisac.org,H-ISAC,Healthcare
+nhl.com,National Hockey League,Sports
+nhn-cloud.co.jp,NHN Cloud,IaaS
 nhn-techorus.com,NHN Techorus,MSP
 nhn.no,Norsk Helsenett,Healthcare
 nhncloud.com,NHN Cloud,IaaS
@@ -6049,6 +6574,7 @@ nikhef.nl,Nikhef,Science
 nikkei.co.jp,Nikkei,News
 nimsite.uk,Nimbus Hosting,Web Host
 nine.ch,Nine Internet Solutions,IaaS
+ninestarconnect.com,Hancock Rural Telephone,Utilities
 nineweb.net,Nine Web,Web Host
 niosh.com.my,Malaysian National Institute of Occupational Safety and Health,Government
 nip.io,nip.io,SaaS
@@ -6060,11 +6586,13 @@ nissan.co.jp,Nissan,Automotive
 nist.gov,National Institute of Standards and Technology,Government
 nisz.hu,National Infocommunications Service Company,Government
 nita.gov.gh,NITA National Information Technology Agency Ghana,Government
+nitco.com,Northwestern Indiana Telephone Co,ISP
 nitelusa.com,Comcast,ISP
 nititancommercial.com,Niti Tan Commercial,Industrial
 nitrado.net,Nitrado (marbis),Web Host
 niu.edu,Northern Illinois University,Education
 nixihost.com,NixiHost,Web Host
+nixval.com,NIXVAL Datacenter,IaaS
 nj-ix.net,NJ IX,ISP
 nj.gov,State of New Jersey,Government
 njedge.net,Edge,Nonprofit
@@ -6096,7 +6624,10 @@ nocdirect.com,JaguarPC,Web Host
 nocix.net,Nocix,Web Host
 nocworldwifi.com.br,World Wifi,ISP
 node4.co.uk,Node4,MSP
+nodeone.com.au,Anycast,ISP
 nodesdirect.com,Nodes Direct,Web Host
+nodestop.io,Nodestop,IaaS
+nodex.ru,Resource-M,ISP
 nodosoft.com.ar,Nodosoft,ISP
 noip.me,No-IP,Web Host
 noip.us,No-IP,Web Host
@@ -6106,6 +6637,7 @@ nolegia.net,Nolegia,Web Host
 nomaden.tv,Nomaden TV,Travel
 nomotech.com,Nomotech,ISP
 nomura.com,Nomura,Finance
+nonghyup.com,Nonghyup,Finance
 nonstoponline.com,Starnet,ISP
 noor.net,Noor Group,ISP
 nordic.tel,Nordic Telecom,ISP
@@ -6115,6 +6647,7 @@ nordnet.com,Nordnet,ISP
 nordnet.fr,Nordnet,ISP
 nordsec.com,Nord Security,SaaS
 nordstrom.com,Nordstrom,Retail
+nordu.net,NORDUnet,Education
 noris.de,noris network,Web Host
 norlys.dk,Norlys,ISP
 noroestenet.com,NoroesteNet,ISP
@@ -6150,6 +6683,7 @@ novis.pt,NOS,ISP
 novoserve.com,NovoServe,Web Host
 novotelecom.ru,Novo Telcom,ISP
 novusnow.ca,Novus Entertainment,ISP
+novvacore.com,Novvacore,ISP
 now-dns.net,Now-DNS,Web Host
 now-dns.org,Now-DNS,Web Host
 now.sh,Vercel,PaaS
@@ -6162,12 +6696,14 @@ npl.co.uk,National Physical Laboratory,Education
 npo.nl,NPO Dutch Public Broadcasting,Government Media
 npsin.com,NP Foods Singapore,Food
 nr.no,Norsk Regnesentral,Science
+nrbn.ca,Niagara Regional Broadband Networks,ISP
 nrcki.ru,Kurchatov Institute,Government
 nrconexoes.com.br,NR Conexões,ISP
 nreca.coop,NRECA,Nonprofit
 nri-secure.co.jp,NRI SecureTechnologies,MSP
 nrk.no,NRK,Government Media
 nrtmexico.mx,Corporativo Núcleo Radio Televisión,News
+ns1.com,IBM NS1 Connect,SaaS
 nscorp.com,Norfolk Southern,Logistics
 nsf.gov,National Science Foundation,Government
 nsighttel.com,Nsight,ISP
@@ -6175,6 +6711,7 @@ nsk-kk.com,NSK,Manufacturing
 nsmailserv.com,Netcore,Marketing
 nsnparts.com,NSNParts,Defense
 nstplnet.com,Navkar Supertech,ISP
+nsula.edu,Northwestern State University,Education
 nsupdate.info,nsupdate.info,Web Host
 nsw.gov.au,State of New South Wales,Government
 nt.gov.au,Northern Territory Government,Government
@@ -6196,6 +6733,7 @@ ntt-me.co.jp,NTT-ME,ISP
 ntt.co.jp,NTT,ISP
 ntt.com,NTT Communications,ISP
 ntt.lt,NTT Lithuania,ISP
+ntt.ru,MCNTT,ISP
 nttbizsol.jp,NTT Business Solutions,MSP
 nttdata.com,NTT DATA,Consulting
 nttdocomo.co.jp,NTT DOCMO,ISP
@@ -6206,18 +6744,26 @@ nttsmc.com,NTT SmartConnect,ISP
 ntu.edu.sg,Nanyang Technological University,Education
 ntu.edu.tw,National Taiwan University,Education
 ntua.gr,National Technical University of Athens,Education
+nucdn.co,NuCDN,Web Host
 nucleus.com,Nucleus AI (Fibernetics),SaaS
+nuday.com,Nuday Networks,IaaS
 nuevaamerica.ec,Nueva America,Retail
+nuggetent.com,Nugget Enterprises,IaaS
+numerique.gouv.fr,LA Direction Interministerielle DU Numerique,Government
+nunsys.com,Nunsys,MSP
 nuoz.com,NuOz,ISP
 nuro.jp,NURO Biz,ISP
 nus.edu.sg,National University of Singapore,Education
 nusa.net.id,Nusanet,ISP
 nusanet.id,Nusanet,ISP
 nuskin.com,Nu Skin,Retail
+nustream.com,Nustream Communications,ISP
 nutritionclub.ca,Nutrition Club Canada,Retail
+nuuday.dk,Nuuday,ISP
 nuvancehealth.org,Nuvance Health,Healthcare
 nuvera.net,Nuvera Communications,ISP
 nuveramail.net,Nuvera,Email Provider
+nuvisions.net,Nuvisions,ISP
 nuxt.cloud,Nuxt Cloud (International Hosting Company),Web Host
 nvc.net,Northern Valley Communications,ISP
 nvidia.com,Nvidia,Manufacturing
@@ -6236,9 +6782,11 @@ nychealthandhospitals.org,NYC Health + Hospitals,Healthcare
 nychhc.org,NYC Health + Hospitals,Healthcare
 nycm.com,NYCM Insurance,Finance
 nycourts.gov,New York State Unified Court System,Government
+nyct.net,New York Connect,ISP
 nycu.edu.tw,National Yang Ming Chiao Tung University,Education
 nyi.net,NYI,Web Host
 nyit.edu,New York Tech,Education
+nynex.de,NYNEX satellite OHG,ISP
 nyp.org,NewYork-Presbyterian,Healthcare
 nypd.org,New York City Police Department,Government
 nysed.gov,New York State Education Department,Government
@@ -6269,6 +6817,7 @@ obninsk.com,CentrTelecom Kaluga,ISP
 oboi1.ru,Oboi no1,Retail
 obosnett.no,OBOS Nett,ISP
 ocalafl.gov,Ocala Fiber Network,ISP
+ocbc.com,OCBC Bank (Hong Kong),Finance
 occtoplus.com.br,Occtoplus,SaaS
 ocde.us,Orange County Department of Education,Education
 oce.ne.jp,Osaki Computer Engineering,ISP
@@ -6296,6 +6845,7 @@ oekb.at,Oesterreichische Kontrollbank,Government
 ofnl.co.uk,Open Fibre Networks,ISP
 ogaki-tv.co.jp,Ogaki Cable Television,ISP
 ogero.gov.lb,Ogero,ISP
+ogilvy.com,Ogilvy,Marketing
 ohea.org,Ohio Education Association,Nonprofit
 ohio.edu,Ohio University,Education
 ohio.gov,State of Ohio,Government
@@ -6303,14 +6853,17 @@ ohsu.edu,Oregon Health & Science University,Education
 oja.at,oja.at,ISP
 ojt.kz,ntustik Zharyk Transit,Industrial
 ok.gov,State of Oklahoma,Government
+ok.is,Opin Kerfi,MSP
 okanagan.net,Okanagan.net,Web Host
 okayama-u.ac.jp,Okayama University,Education
 okstate.edu,Oklahoma State University,Education
 okta.com,Okta,SaaS
+oktawave.com,Oktawave,IaaS
 okvirtual.com.br,Ok Virtual,ISP
 ole.net.br,Ole Fibra,ISP
 oleane.fr,Oleane,ISP
 oleanwebhosting.com,Olean Web Hosting,Web Host
+olecomunicacion.net,OLE Comunicacion,ISP
 olemiss.edu,University of Mississippi,Education
 olsztyn.net.pl,University of Warmia and Mazury Olsztyn,Education
 olypen.com,OlyPen,ISP
@@ -6329,6 +6882,7 @@ omnifiber.com,Omni Fiber,ISP
 omninet.co.nz,OmniNet,ISP
 omnis.com,Omnis,Web Host
 omniscient.com,Omniscient Technologies,Technology
+omnispring.com,Omnispring,ISP
 omnistep.com,OmniStep Incorporated,ISP
 omnitel.biz,OmniTel,ISP
 omu.org,Owensboro Municipal Utilities,Utilities
@@ -6381,12 +6935,15 @@ onnet21.com,LG Uplus,ISP
 onnetmais.com.br,OnNet Telecomunicacoes,ISP
 onnettelecom.com.br,OnNet Telecomunicações,ISP
 ono.com,Vodafone Ono,ISP
+onq.com.au,ONQ Communications,ISP
 onrender.com,Render,PaaS
+onshore.com,Onshore,SaaS
 ontario.ca,Government of Ontario,Government
 ontariohealth.ca,Ontario Health,Healthcare
 ontarioshores.ca,Ontario Shores Centre for Mental Health,Healthcare
 ontash.com,Ontash & Ermac,Industrial
 onthenet.com.au,On The Net,ISP
+onurbilisim.com.tr,Onur Bilişim,ISP
 onvif.org,Onvif,Technology
 onx.com,OnX,MSP
 oocl.com,OOCL,Logistics
@@ -6394,6 +6951,7 @@ ooma.com,Ooma,ISP
 oops.net.br,Oops Telecom,ISP
 ooredoo.com.kw,Ooredoo,ISP
 ooredoo.dz,Ooredoo Algeria,ISP
+ooredoo.mv,Ooredoo,ISP
 ooredoo.om,Ooredoo,ISP
 ooredoo.qa,Ooredoo,ISP
 ooredoo.tn,Ooredoo,ISP
@@ -6402,38 +6960,48 @@ opcnet.hu,OPC Networks,ISP
 openair.com,Oracle NetSuite OpenAir,SaaS
 opendns.com,Cisco OpenDNS,Email Security
 openfiber.it,Open Fiber,ISP
+openmetal.io,OpenMetal,IaaS
 opentext.com,OpenText,SaaS
 opentransit.net,Orange,ISP
 openwave.ai,Openwave Messaging,Email Provider
 opera.com,Opera,SaaS
+operational-services.de,Operational Services,MSP
 opiquad.com,Opiquad (Southern Broadband),ISP
 opnet.it,OpNet (WindTre),ISP
 oppd.com,Omaha Public Power District,Utilities
 opt.nc,OPT-NC New Caledonia,ISP
 optage.co.jp,Optage,ISP
+optic-com.eu,OpticCom,ISP
 opticaltel.com,Fibernow (Opticaltel),ISP
 opticomm.com.au,Opticomm,ISP
 optimaitalia.com,Optima Italia,ISP
 optimantra.com,OptiMantra,SaaS
+optimaxbd.net,OptiMax Communication,ISP
 optimum.com,Optimum,ISP
 optimum.net,Optimum,ISP
 optimus.si,Optimus IT d.o.o.,MSP
 optimusmedia.com,Optimus Media,Marketing
 optinet.bg,Optinet (Diana Net),ISP
+options-it.com,Options Technology,Finance
 optipub.com,OptiPub,Publishing
 optisprint.net,5KOM (Optisprint),ISP
 optix.pk,Optix Pakistan,ISP
+optoenlaces.net.mx,Optoenlaces,ISP
 optonline.net,Optimum,ISP
 optus.com.au,Optus,ISP
 optus.net.au,Optus,ISP
+opusinteractive.com,Opus Interactive,IaaS
 oquei.net.br,Oquei Telecom,ISP
 oracle.com,Oracle,Technology
 oraclecloud.com,Oracle Cloud,IaaS
 oraclon.com.br,Oraclon,ISP
+orakom.it,Orakom,ISP
 orange-business.com,Orange Business,ISP
 orange-business.ru,Orange Business,ISP
+orange-sonatel.com,Sonatel,ISP
 orange.be,Orange,ISP
 orange.bf,Orange,ISP
+orange.cd,Orange RDC,ISP
 orange.ci,Orange,ISP
 orange.cm,Orange Cameroun,ISP
 orange.co.bw,Orange Botswana,ISP
@@ -6449,6 +7017,8 @@ orange.pl,Orange,ISP
 orange.ro,Orange,ISP
 orange.sk,Orange,ISP
 orange.tn,Orange,ISP
+orange.tx.us,"Orange County, Texas",Government
+orangebd.online,Orange Communication,ISP
 orangecustomers.net,Orange,ISP
 orangehost.com,OrangeHost,Web Host
 orangemali.com,Orange Mali,ISP
@@ -6460,13 +7030,17 @@ oregon.gov,Oregon Government,Government
 oregonstate.edu,Oregon State University,Education
 ori.net,ORI,ISP
 oricom.ca,Oricom Internet,ISP
+orion.net.id,Orion Cyber Internet,ISP
+orion.on.ca,ORION,Education
 orionnet.ru,Orion Telecom,ISP
 oriontelekom.rs,Orion Telekom,ISP
+orionvm.com,OrionVM Cloud Platform,IaaS
 oristelekom.com,ORIS Telekom,ISP
 orlandodiocese.org,Diocese of Orlando,Nonprofit
 orn.ru,Resurs-Svyaz,ISP
 ornethd.net,Orne THD,ISP
 ornl.gov,Oak Ridge National Laboratory,Government
+orro.group,Orro,MSP
 orthodoxws.com,Orthodox Web Solutions,Web Host
 osaka-sandai.ac.jp,Osaka Sangyo University,Education
 osaka-u.ac.jp,Osaka University,Education
@@ -6484,9 +7058,12 @@ osnetpr.net,Osnet Wireless Puerto Rico,ISP
 osnova.tv,Osnova,ISP
 osogrande.net,Oso Grande Technologies,ISP
 osorio.rs.gov.br,Prefeitura Municipal de Osório,Government
+oss.fi,Oulun Seudun Sähkö,Utilities
+ostnet.pl,OST,ISP
 osu.edu,The Ohio State University,Education
 oswego.edu,SUNY Oswego,Education
 otago.ac.nz,University of Otago,Education
+otaro.co.th,Internet Service Provider,ISP
 otava.com,Otava,MSP
 ote.gr,OTE,ISP
 otelco.net,GoNetSpeed,ISP
@@ -6514,6 +7091,7 @@ ovh.net,OVH,Web Host
 ovh.us,OVH,Web Host
 ovhcloud.com,OVH,Web Host
 ovintiv.com,Ovintiv,Industrial
+ovni.com,Galaxy Communications,ISP
 own.pm,OwnProvider,Web Host
 owncloud-dav-hamburg.de,ownCloud,SaaS
 ownip.net,Now-DNS,Web Host
@@ -6525,19 +7103,24 @@ oxentenet.com,Oxente Net,ISP
 oxfordnetworks.net,FirstLight Fiber,ISP
 oxio.ca,oxio,ISP
 oxsus-vadesecure.net,Scaleway,Web Host
+oxy.com,Occidental Petroleum,Industrial
 oxy.edu,Occidental College,Education
 oxylion.pl,Oxylion,ISP
+oxynet.pl,OXYNET,ISP
 ozarksgo.net,OzarksGo,ISP
 p4net.com.br,P4NET,ISP
 p4net.net.br,P4NET Telecom,ISP
 pa.gov,Commonwealth of Pennsylvania,Government
 pa.net.py,P.A. Networks,ISP
+pacfiber.com,Pembroke Telephone Company,ISP
 pacific.edu,University of the Pacific,Education
 pacific.net.th,Pacific Internet Thailand,ISP
 pacificinternet.com,Pacific Internet,ISP
 pacificored.cl,Pacifico Cable,ISP
 pacificsource.com,PacificSource,Healthcare
+pacificu.edu,Pacific University,Education
 packet.com,Equinix Metal (Packet Host),IaaS
+packet.stream,PacketStream,SaaS
 packetexchange.eu,Packet Exchange,Web Host
 packetfabric.co.jp,PacketFabric Japan,ISP
 packetfabric.com,PacketFabric,ISP
@@ -6552,6 +7135,7 @@ pairvps.com,Pair Networks,Web Host
 pakendikeskus.ee,Pakendikeskus,Manufacturing
 paket78.ru,Пакет Пакетов,Industrial
 palette-up.jp,Palette UP,Web Host
+paloaltonetworks.com,Palo Alto Networks,MSSP
 paltel.ps,Paltel,ISP
 panasonic.com,Panasonic,Technology
 panelserver.biz,panelserver.biz,ISP
@@ -6608,6 +7192,7 @@ pbiaas.com,INOS,Web Host
 pbs.edu.pl,Politechnika Bydgoska,Education
 pbx-change.com,KUDUCOM,ISP
 pca.az,PASHA Capital,Finance
+pcc.edu,Portland Community College,Education
 pcc.in.th,President Chemical,Manufacturing
 pccw.com,PCCW,ISP
 pccwglobal.com,PCCW Global,ISP
@@ -6617,18 +7202,24 @@ pchosp.org,Putnam County Hospital,Healthcare
 pci.com,PCI Pharma Services,Healthcare
 pcinfo.net.br,PC Info Telecom,ISP
 pciservices.com,PCI Pharma Services,Healthcare
+pcisys.net,PCI Fiber,ISP
 pcp.by,Pinsk Central Polyclinic,Healthcare
 pcsb.org,Pinellas County Schools,Education
 pcss.pl,Poznanskie Centrum Superkomputerowo-Sieciowe,Science
+pcu.ac.kr,Paichai University,Education
 pd25.com,Salesforce Marketing Cloud (Formerly Pardot),Marketing
 pdx.edu,Portland State University,Education
+pe3ny.net,Pe3ny Net,ISP
 peacecom.net,Scipio Technologies (Peace Communications),MSP
 peacehealth.org,PeaceHealth,Healthcare
+peaceweb.group,PeaceWeb,ISP
 peakinternet.com,Peak Internet,ISP
 peaknet.net,PeakNet,Industrial
 peapod.com,Peapod,Retail
 pearcebevill.com,"Pearce, Bevill, Leesburg, Moore, P.C.",Finance
+pebblehost.com,PebbleHost,IaaS
 pelephone.co.il,Pelephone,ISP
+pendc.com,PenDC,IaaS
 penguinwebhosting.com,Penguin Webhosting,Web Host
 penki.lt,Penki,ISP
 pennwest.edu,Pennsylvania Western University,Education
@@ -6649,6 +7240,7 @@ perfora.net,IONOS,Web Host
 performive.com,CloudFirst,Web Host
 perftech.si,Perftech Slovenia,MSP
 perimeterwatch.com,PerimeterWatch,MSSP
+pern.edu.pk,PERN (Pakistan Education and Research Network),Education
 personal.com.py,Personal Paraguay,ISP
 peteralan.co.uk,Peter Alan,Real Estate
 petitjeanfiber.com,Petit Jean Fiber,ISP
@@ -6665,6 +7257,7 @@ pg.com,Procter & Gamble,Manufacturing
 pg19.ru,PG-19,ISP
 pgcps.org,Prince George's County Public Schools,Education
 pge.com,PG&E,Utilities
+pgtc.com,Prairie Grove Telephone Co,ISP
 ph.net,PHNet Philippine Network Foundation,Education
 phaselayer.com,Private Layer,Web Host
 phibee-telecom.net,Phibee Telecom,ISP
@@ -6673,13 +7266,17 @@ philasd.org,School District of Philadelphia,Education
 philcom.com,Philcom,ISP
 phmgmt.com,PhMgmt VyprVPN,Web Host
 phoenix-c.or.jp,Phoenix Communications Japan,ISP
+phoenix.gov,City of Phoenix,Government
 phoenixnap.com,phoenixNAP,Web Host
 phonoscope.com,Phonoscope Fiber,ISP
 phpoy.fi,Elmonet (PHP Oy),ISP
 phpwebhosting.com,PHPWebHosting,Web Host
+phsa.ca,Provincial Health Services Authority,Healthcare
 pickup.hu,PickUp Kft,ISP
 piedmonteye.com,Piedmont Eye Center,Healthcare
+pieg.com,Presque Isle Electric & Gas,Utilities
 piercecountywa.gov,"Pierce County, Washington",Government
+piercepepin.com,Pierce Pepin,Utilities
 pif.co.uk,Pinnacle Freight,Logistics
 pilot-ipek.ru,Izhevsk Industrial-Economic College,Education
 pilotfiber.com,Pilot Fiber,ISP
@@ -6689,6 +7286,7 @@ pindc.ru,Pindc Petersburg Internet Network,ISP
 pine-net.com,Pine Telephone,ISP
 pineland.net,Pineland Telephone Cooperative,ISP
 pinellascounty.org,Pinellas County,Government
+pinetel.com,Pine Telephone System,ISP
 pink.co.rs,Mink Media Group,Marketing
 pinnaclecart.com,PinnacleCart,SaaS
 pinpro.by,PinPro,ISP
@@ -6697,18 +7295,22 @@ pioncomm.net,Pioneer Communications Kansas,ISP
 pioneer.co.in,Pioneer Online,ISP
 pioneer.co.th,Pioneer Transportation,Logistics
 pioneer.net,Pioneer Connect,ISP
+pioneerbroadband.net,Pioneer Broadband,ISP
 pip.com.au,PIP Total IT Solutions,Web Host
 pipefy.com,Pipefy Inc,SaaS
+pipehost.net,Pipe Networks,IaaS
 piranha.co.kr,Piranha Systems,Web Host
 pirxnet.pl,PirxNet,ISP
 pishgaman.net,Pishgaman,ISP
 pitchile.cl,PIT Chile,ISP
+pitcolombia.net,PIT Colombia,ISP
 pitt.edu,University of Pittsburgh,Education
 pittsburghpa.gov,City of Pittsburgh,Government
 pius-hospital.de,Pius-Hospital Oldenburg,Healthcare
 pixeledges.com,Pixel Edges Technologies,Marketing
 pj24.ir,Pishgaman Jonoub,ISP
 pknu.ac.kr,Pukyong National University,Education
+plainsinternet.com,Cpuonsite,ISP
 plala.or.jp,Plala,ISP
 planeetta.net,Planeetta,Web Host
 planet-ic.de,Planet IC,IaaS
@@ -6735,6 +7337,8 @@ pldt.com.ph,PLDT Home,ISP
 pldt.net,PLDT,ISP
 pldthome.com,PLDT,ISP
 plesk.page,Plesk,Web Host
+plimtelecom.com.br,PLIM,ISP
+plink.it,Professional Link,ISP
 plinq.nl,PLINQ,ISP
 plis.net.br,Plis Telecom,ISP
 plniconplus.co.id,PLN Icon Plus,MSP
@@ -6755,6 +7359,7 @@ pmcon.net,Premium Connectivity,ISP
 pmt.org,Project Mutual Telephone Cooperative,ISP
 pmweb.com.br,pmweb,Marketing
 pnc.com,PNC Bank,Finance
+pngdataco.com,PNG DataCo,ISP
 pnpt.com,Pinpoint Fiber,ISP
 pobox.com,Pobox,Email Provider
 pocketinet.com,PocketiNet,ISP
@@ -6765,9 +7370,11 @@ podzone.org,DynDNS,Web Host
 pogozone.com,PogoZone,ISP
 poig.ru,POIG (Schelkovo-net),ISP
 point-broadband.com,Point Broadband,ISP
+point.lviv.ua,Pointnet,ISP
 poka.com,Poka Lambro Telecommunications,ISP
 pol-online.com,Bangladesh Online,ISP
 pol.ir,ParsOnline,ISP
+polarcomm.com,Polar Communications,ISP
 polisen.se,Swedish Police,Government
 politiet.no,Norwegian Police,Government
 polk-fl.net,Polk County Public Schools,Education
@@ -6778,6 +7385,7 @@ polyclinique-limoges.fr,Polyclinique de Limoges,Healthcare
 polyesterday.com.mk,Polyesterday,Marketing
 polyesterday.mk,Polyesterday,Marketing
 polyu.edu.hk,Hong Kong Polytechnic University,Education
+poncacityok.gov,Ponca City Utility Authority,Government
 poneytelecom.eu,Pony Telecom,Web Host
 pontenova.com.br,Ponte Nova Online,News
 popp.com,POPP Communications,ISP
@@ -6790,6 +7398,7 @@ porkbun.com,porkbun.com,ISP
 portalcom.inf.br,Portal.com,ISP
 portative.com,Portative Technologies,ISP
 portative.net,Portative Technologies,ISP
+portlandgeneral.com,Portland General Electric Company,Utilities
 portlandk12.org,Portland Public Schools,Education
 portunity.de,Portunity,Web Host
 portusdatacenters.com,Portus Data Centers,Web Host
@@ -6821,9 +7430,12 @@ preciousnetcom.in,Precious Netcom,ISP
 precisehotels.com,Precise Hotels and Resorts,Travel
 predialnet.com.br,Predialnet,ISP
 premierdc.com.tr,PremierDC,Web Host
+premiumchoicebroadband.com,Premium Choice Broadband,ISP
 prempub.com,Premier Publishing,Marketing
 previder.com,Previder,Web Host
+previder.nl,Previder,IaaS
 prgmr.com,Tornado VPS,Web Host
+pride-net.ru,Pride,ISP
 primacom.com,Primacom Indonesia,ISP
 primed-halberstadt.de,Primed Halberstadt,Healthcare
 primenet.in,Primesoftex,Web Host
@@ -6835,6 +7447,7 @@ primustel.ca,Primus,ISP
 princeton.edu,Princeton University,Education
 principal-it.com,Principal IT,MSP
 print.com.br,Printi,Print
+prioritycolo.com,Priority Colo,IaaS
 prismahealth.org,Prisma Health,Healthcare
 prismatelcom.com.br,Prisma Telecom,ISP
 privateemail.com,PrivateEmail.com,Email Provider
@@ -6843,12 +7456,15 @@ privatelabelhosts.com,Private Label Hosts,Web Host
 privatelayer.com,Private Layer,Web Host
 privatesystems.net,PrivateSystems.net,Web Host
 prnewswire.com,PR Newswire,Marketing
+pro-internet.pl,Pro Internet,ISP
 pro-komp.pl,home.pl,Web Host
 pro-m.hu,Pro-M,ISP
 pro01.net,Pro01 (Toyu),Marketing
 proagentwebsites.com,ProAgent Websites,Real Estate
 probe-networks.de,Probe Networks,Web Host
+procempa.com.br,Cia de Proc. de Dado do Município de Porto Alegre,Government
 procergs.rs.gov.br,PROCERGS Rio Grande do Sul,Government
+processtelecom.com.br,Process Solutions Tecnologia DA Informação,ISP
 procopa.dk,Procopa IT,MSP
 prodeb.ba.gov.br,Prodeb Bahia,Government
 prodemge.gov.br,PRODEMGE Minas Gerais,Government
@@ -6858,6 +7474,7 @@ prodesp.sp.gov.br,Prodesp,Government
 prodocom.com.au,Prodocom,SaaS
 produccion.gob.ec,Ecuador Ministry of Production,Government
 proen.co.th,PROEN,Web Host
+profesionalhosting.com,Soluciones web on line,IaaS
 profitserver.ru,Profitserver,Web Host
 progressive.com,Progressive Insurance,Finance
 prohosting.com,ProHosting,Web Host
@@ -6875,6 +7492,8 @@ prosites.com,ProSites,Web Host
 prosodie.com,Odigo,SaaS
 prosodie.es,Prosodie Iberica,MSP
 prospect.pl,Prospect,ISP
+prospeed.net,Prospeed.Net,ISP
+protekweb.com,ProTek Communications,ISP
 proton.ch,Proton,Email Provider
 proton.me,Proton,Email Provider
 protonmail.ch,Proton,Email Provider
@@ -6882,6 +7501,7 @@ provector.pl,Provector,ISP
 provedorfutel.net.br,Futel,ISP
 provedornet.com.br,Provedornet,ISP
 provedornetcenter.com.br,Netcenter,ISP
+provedoronline.com.br,Provedoronline,ISP
 provedorstar.net.br,Star Net,ISP
 provedorsuperconnect.com.br,Super Connect,ISP
 provedortechnet.com.br,Technet Networks,ISP
@@ -6894,9 +7514,12 @@ proxad.net,Free,ISP
 proximus.com,Proximus,ISP
 proximus.lu,Proximus,ISP
 proxxima.net,PROXXIMA,ISP
+prtcnet.com,PRTC,ISP
 prtcnet.org,Peoples Rural Telephone Cooperative,ISP
+prtcom.com,Piedmont Rural Telephone,ISP
 prtcom.ru,Pokrovsky Radiotelefon,ISP
 prtelecom.hu,PR-TELECOM,ISP
+prudential.com,The Prudential Insurance Company of America,Finance
 prudential.com.sg,Prudential Singapore,Finance
 prudentpublishing.com,Prudent Publishing,Retail
 prvepa.com,PearlComm,ISP
@@ -6909,6 +7532,7 @@ psdschools.org,Poudre School District,Education
 pserver.space,Profitserver,Web Host
 pskovline.ru,Pskovline,ISP
 pslightwave.com,PS Lightwave,ISP
+psln.com,Plumas Sierra Telecommunications,ISP
 psn.co.id,Pasifik Satelit Nusantara,ISP
 psnc.pl,Poznan Supercomputing and Networking Center,Science
 pspinc.com,Pacific Software Publishing,Web Host
@@ -6933,6 +7557,7 @@ pucv.cl,Pontificia Universidad Catolica de Valparaiso,Education
 pulkco.com,Pulk & Co,ISP
 pulse.in,Pulse Telesystems,SaaS
 pulsetv.com,Pulse TV,Retail
+pumo.com.tw,PUMO,IaaS
 puntonet.ec,Puntonet,ISP
 purbanigroup.com,Purbani Group,Manufacturing
 purdue.edu,Purdue University,Education
@@ -6942,7 +7567,9 @@ purplecowinternet.com,Purple Cow Internet,ISP
 purtel.com,PURtel,ISP
 pusan.ac.kr,Pusan National University,Education
 pvamu.edu,Prairie View A&M University,Education
+pvschools.net,Paradise Valley Unified School District,Education
 pvt.com,Penasco Valley Telecommunications,ISP
+pw.edu.pl,Politechnika Warszawska,Education
 pwc.com,PwC,Consulting
 pwc.com.au,PwC Australia,Consulting
 pwtinternet.com.br,PWT Internet,ISP
@@ -6967,6 +7594,7 @@ qis.net,Quantum Internet and Telephone,ISP
 qlix.com.br,Qlix,Web Host
 qmul.ac.uk,Queen Mary University of London,Education
 qnsal.cn,Qn-Solar,Manufacturing
+qonnected.nl,Qonnected,ISP
 qq.com,QQ,Email Provider
 qrc.ca,Quality Respiratory Care,Healthcare
 qsoftweb.com,QSoft,Web Host
@@ -6977,6 +7605,7 @@ qtsc.com.vn,Quang Trung Software City,IaaS
 qtsdatacenters.com,QTS,IaaS
 quadax.com,Quadax,Healthcare
 quadranet.com,Quadranet,Web Host
+quadro.net,Quadro Communications Co-Operative,ISP
 qualcomm.com,Qualcomm,Manufacturing
 quality-network.eu,QualityNetwork,ISP
 qualtrics.com,Qualtrics,SaaS
@@ -6986,11 +7615,13 @@ quantum.net.id,Quantum Tera Network,ISP
 quartztelecom.ru,Quartz Telecom,ISP
 quattre.com,Quattre Internet,ISP
 quattrocom.mx,QuattroCom,ISP
+quebecinternet.com,Quebec Internet,ISP
 queensu.ca,Queen's University,Education
 questforum.org,Telecommunications Industry Association,Industrial
 quick.com.br,Quick Internet,ISP
 quickline.ch,Quickline,ISP
 quickline.co.uk,Quickline Communications,ISP
+quicknet.ch,Kabelfernsehen Bodeli,ISP
 quickpacket.com,QuickPacket,Web Host
 quitmancountyms.org,"Quitman County, Mississippi",Government
 quotevalet.com,QuoteValet,SaaS
@@ -7021,6 +7652,7 @@ radiantbd.com,Radiant Communications Bangladesh,ISP
 radiantsolutions.net,Radient Solutions,Web Host
 radio-canada.ca,Radio-Canada (CBC),Government Media
 radiocom.ro,Radiocom Romania,ISP
+radiokable.net,Radiocable Ingenieros,ISP
 radius-net.com,Radius-NET,ISP
 radore.com,Radore,Web Host
 radware.com,Radware,Email Security
@@ -7040,6 +7672,7 @@ rakuten.co.jp,Rakuten Mobile,ISP
 rakuten.com,Rakuten Mobile,ISP
 raleighortho.com,Raleigh Orthopaedic,Healthcare
 rally.ca,Rally Internet,ISP
+rallynet.us,New Florence Telephone Company,ISP
 rambler.ru,Rambler,Email Provider
 rampermail.com.br,Ramper,Marketing
 ramsaysante.fr,Ramsay Santé,Healthcare
@@ -7049,9 +7682,11 @@ range.net,Range Internet,ISP
 ranksitt.net,Ranks ITT,MSP
 rapeedo.net.br,Rapeedo,ISP
 rapid-shield.com,Rapid Shield,Web Host
+rapidbroadband.ie,Rapid Broadband,ISP
 rapidscale.net,RapidScale,Web Host
 rapidsys.com,Rapid Systems,ISP
 raschig.de,Raschig,Manufacturing
+rascom.ru,RASCOM,ISP
 ratiokontakt.de,Ratiokontakt,ISP
 rawbandwidth.com,Raw Bandwidth Communications,ISP
 raycdjr.com,Ray Chrysler Dodge Jeep RAM,Automotive
@@ -7109,6 +7744,7 @@ redetelecom.com.br,Vero (Rede Telecom),ISP
 redetuxnet.com.br,Tuxnet,ISP
 redexpertos.com,RedExpertos,Web Host
 redfoxtelecom.com.br,Redfox Telecom,ISP
+redhat.com,Red Hat,SaaS
 rediff.com,Rediff,News
 rediffmailpro.com,Rediffmail Pro,Email Provider
 redirection.net,Redirectionet,Web Host
@@ -7123,6 +7759,7 @@ reef-guardian.com,Reef Guardian,Education
 reevo.it,ReeVo,MSP
 refinitiv.com,LSEG (Refinitiv),SaaS
 reflected.net,Reflected Networks,Web Host
+reflex.co.za,Reflex Solutions,MSP
 reg.ru,Reg.ru,Web Host
 reg365.net,register365,Web Host
 regentbranding.co.uk,Regent Branding,Marketing
@@ -7134,6 +7771,7 @@ regiondemurcia.es,Region de Murcia,Government
 regione.toscana.it,Regione Toscana,Government
 regions.com,Regions Bank,Finance
 regionstockholm.se,Region Stockholm,Government
+regionuppsala.se,Region Uppsala,Government
 register.it,Register.it,Web Host
 register365.com,register365,Web Host
 register4less.com,Register4Less,Web Host
@@ -7146,10 +7784,12 @@ relaix.net,RelAix Networks,ISP
 relativity.one,RelativityOne,SaaS
 reliablehosting.com,Reliable Hosting,Web Host
 reliablesite.net,ReliableSite,Web Host
+relianceconnects.com,Cascade Access,ISP
 relmax.com,Relmax,Web Host
 relmax.net,Relmax,Web Host
 relod.ru,RELOD,Retail
 relx.com,RELX,SaaS
+relyantcommunications.com,Classic South Communications,ISP
 renal-md.com,Renal-MD,Healthcare
 renater.fr,RENATER,Education
 render.com,Render,PaaS
@@ -7173,6 +7813,7 @@ reyrey.com,Reynolds and Reynolds,SaaS
 reytel.hn,Reytel Honduras,ISP
 rezocean.fr,REZOCEAN,ISP
 rfc.pl,RFC Internet Poland,ISP
+rferl.org,Radio Free Europe/Radio Liberty,News
 rftkabel.de,RFT Kabel,ISP
 rgcommunications.in,RG Communications India,ISP
 rge.com,Rochester Gas and Electric,Utilities
@@ -7203,13 +7844,16 @@ rima-tde.net,"TELEFONICA, S.A.",ISP
 rimex-ltd.com,Rimex,ISP
 rimon.net.il,Internet Rimon,ISP
 ringcentral.com,RingCentral,SaaS
+ringnett.no,Ringnett,ISP
 ringsquared.com,RingSquared,ISP
 ringstad.no,Ringstad Consulting,MSP
 riotel.com.ar,Riotel Rio Tercero,ISP
 riotgames.com,Riot Games,Entertainment
 ripe.net,RIPE NCC,Nonprofit
+ripn.net,RIPN,ISP
 ripplefiber.com,Ripple Fiber,ISP
 risd.org,Richardson Independent School District,Education
+rise.ph,Responsible Internet Sustainability Effort,ISP
 riseinternet.com,Rise Internet,ISP
 risetelecoms.co.za,Rise Telecoms,ISP
 riskonnectclearsight.com,Riskonnect ClearSight,SaaS
@@ -7226,6 +7870,7 @@ rmx.de,Retarus GmbH,SaaS
 rnp.br,RNP,Education
 rnu.tn,Centre de Calcul El Khawarizmi,Education
 roadrunnerwireless.net,Roadrunner Wireless,ISP
+robi.com.bd,"TM International Bangladesh Ltd.Internet service Provider,Gulshan-1,Dhaka-1212",ISP
 robi.com.mk,Telekabel,ISP
 roblox.com,Roblox,Entertainment
 roche.com,Roche,Healthcare
@@ -7233,6 +7878,7 @@ rochester.edu,University of Rochester,Education
 rockcom.co,Rockman Communications,ISP
 rockefeller.edu,The Rockefeller University,Education
 rockenstein.de,Rockenstein,Web Host
+rocketnet.co.za,Directel Communications,ISP
 rocketsoftware.com,Attachmate (Rocket Software),Technology
 rockisland.com,Rock Island Communications,ISP
 rockwellcollins.com,Collins Aerospace,Defense
@@ -7242,6 +7888,7 @@ rogers.com,Rogers,ISP
 rogerscapital.mu,Rogers Capital Mauritius,MSP
 roguevalleyurology.com,Rogue Valley Urology,Healthcare
 roketelkom.co.ug,Roke Telkom Uganda,ISP
+rol.net.mv,Raajjé Online,ISP
 romarg.ro,ROMARG,Web Host
 rootlayer.net,RootLayer LTD.,Web Host
 ropa.de,ropa,Web Host
@@ -7257,6 +7904,7 @@ rotundasoftware.com,Rotunda Software,MSP
 router12.net,Router12 Networks,ISP
 routit.nl,RoutIT,ISP
 rowan.edu,Rowan University,Education
+royalcable.com.ph,RoyalCable Flash,ISP
 royalehosting.net,RoyaleHosting,Web Host
 royalfloraholland.com,Royal FloraHolland,Agriculture
 rpi.edu,Rensselaer Polytechnic Institute,Education
@@ -7266,6 +7914,8 @@ rpworld.co.in,RP World Telecom,ISP
 rqnet.com.br,RqNet,ISP
 rrinternettelecom.com.br,RR Internet Telecom,ISP
 rrtelecomrs.net.br,RR Telecom,ISP
+rrv.net,Halstad Telephone,ISP
+rs.net.ua,TC Radio Systems,ISP
 rsa.com,RSA,Technology
 rsaweb.co.za,RSAWEB,ISP
 rsgsv.net,Intuit Mailchimp,Marketing
@@ -7273,7 +7923,10 @@ rsonet.com.ar,RSONet,ISP
 rssulnet.com.br,RS Sul Net,ISP
 rstp.org.sz,Royal Science and Technology Park,Government
 rt.ru,Rostelecom,ISP
+rtc.email,Reservation Telephone,ISP
+rtccom.com,RTC Communications,ISP
 rtcomm.ru,RTComm,ISP
+rtconline.com,Reserve Long Distance Company,ISP
 rtctel.com,Ringgold Telephone Company,ISP
 rti.org,Research Triangle Institute,Education
 rtinetwork.com.br,RTI Network,ISP
@@ -7284,8 +7937,10 @@ ruelala.com,Rue La La,Retail
 ruhr-uni-bochum.de,Ruhr University Bochum,Education
 runbox.com,Runbox,Email Provider
 runhosting.com,RunHosting,Web Host
+rupkki.sk,RUPKKI,ISP
 ruralroadshealthservices.ca,Alexandra Hospital,Healthcare
 ruraltelephone.com,Nex-Tech (Rural Telephone Service),ISP
+ruralwebtelecom.com.br,RuralWeb,ISP
 rusety.ru,Russet,ISP
 rush.edu,Rush University,Education
 rusonyx.ru,Rysonyx Cloud,Web Host
@@ -7302,6 +7957,7 @@ ryoka.co.jp,Ryoka Denka Kasei,Manufacturing
 rzone.de,Strato AG,Web Host
 s-inform46.ru,Связьинформ (SvyazInform),ISP
 s-net.pl,S-NET,ISP
+s1networks.fi,S1 Networks,ISP
 sa-net.tj,Spitamen Alexander Internet,ISP
 saab.com,Saab,Defense
 saabgroup.com,Saab,Defense
@@ -7357,6 +8013,7 @@ samsungsds.com,Samsung SDS,Technology
 samtel.ru,Samtelecom,ISP
 sana.de,Sana Kliniken Oberfranken,Healthcare
 sanantonio.gov,City of San Antonio,Government
+sanbrunocable.com,San Bruno Cable,ISP
 sandi.net,San Diego Unified School District,Education
 sandia.gov,Sandia National Laboratories,Government
 sandrix.com,Sandrix Technologies,MSP
@@ -7364,10 +8021,12 @@ sandvikenenergi.se,Sandviken Energi,Utilities
 sanet.sk,SANET,Education
 sangchaimeter.com,Sangchai Meter,Industrial
 sangoma.com,Sangoma,SaaS
+sanjoseca.gov,City of San Jose,Government
 sanjuan.edu,San Juan Unified School District,Education
 sanmina.com,Sanmina,Manufacturing
 sanofi.fr,Sanofi,Healthcare
 santa-barbara.ca.us,Santa Barbara County,Government
+santacruz.k12.ca.us,Santa Cruz County Office of Education,Education
 santandergto.com,Santander Global Technology and Operations,Finance
 santehealth.net,Sante Health System,Healthcare
 sanwa.co.jp,Sanwa Supply,Retail
@@ -7387,16 +8046,20 @@ sas.com,SAS Institute,SaaS
 sasag.ch,sasag Kabelkommunikation,ISP
 saskatoon.ca,City of Saskatoon,Government
 sasktel.com,SaskTel,ISP
+satcomm.pk,"Broadband ISP, FTTH and Cable Service Provider",ISP
 satel.net.ua,Satellite (Setilight),ISP
+satellitenetcom.in,Satellite Net Com,ISP
 satfilm.pl,Sat Film,ISP
 satis-tl.ru,Satis,ISP
 satnet.net,Xtrim,ISP
 satorilabs.com,NextGen Healthcare,Healthcare
 satro.sk,SATRO Slovakia,ISP
+satt.cz,SATT,ISP
 sattrakt.com,Sat-Trakt,ISP
 saudi.net.sa,Saudi Telecom Company,ISP
 saunalahti.fi,Elisa,ISP
 savecom.net.tw,SaveCom,ISP
+saveincloud.com,SaveinCloud,Web Host
 saveonhosting.com,Save On Hosting,Web Host
 savezone.co.kr,SaveZone,Retail
 savps.ru,SmartApe,Web Host
@@ -7412,6 +8075,7 @@ sbn.co.th,Super Broadband Network,ISP
 sc.com,Standard Chartered,Finance
 sc.edu,University of South Carolina,Education
 sc.gov,South Carolina Government,Government
+scad.edu,Savannah College of Art and Design,Education
 scaladatacenters.com,Scala Data Centers,Web Host
 scalaxy.com,Scalaxy,IaaS
 scaledsystems.com,SimpleNet,Web Host
@@ -7440,6 +8104,7 @@ scjohnson.com,S.C. Johnson,Manufacturing
 scloud.sg,SCloud Singapore,IaaS
 scn-net.ne.jp,Shonan Cable Network,ISP
 scnet.com.br,SCNet,ISP
+scopesky.com,"ScopeSky for communications, internet and technology services",MSP
 scorm.com,SCORM,SaaS
 scranton.edu,University of Scranton,Education
 screamer.co.za,Screamer Telecoms,ISP
@@ -7456,18 +8121,21 @@ scw.cloud,Scaleway,IaaS
 sddatacenter.com,SD Data Center,Web Host
 sdldelivery.com,Specialty Delivery & Logistics,Logistics
 sdncommunications.com,SDN Communications,ISP
+sds.co.kr,Samjung Data Service,MSP
 sdsc.edu,San Diego Supercomputer Center,Education
 sdsmt.edu,South Dakota Mines,Education
 sdstate.edu,South Dakota State University,Education
 sdv.fr,SdV,Web Host
 seacom.co.za,SEACOM,MSP
 seacom.com,SEACOM,ISP
+seagate.com,Seagate,Manufacturing
 sealbond.co.jp,Nippon Sealbond,Manufacturing
 seanet.com.br,Seanet,ISP
 seaside.ns.ca,Seaside Communications,ISP
 seaspraymta1.com,Cox Communications,ISP
 seaspraymta2.com,Cox Communications,ISP
 seattlechildrens.org,Seattle Children's Hospital,Healthcare
+seattlecolleges.edu,Seattle Community College District,Education
 seciu.edu.uy,SeCIU Uruguay,Education
 secomtrust.net,SECOM Trust Systems,MSP
 secrel.com.br,SecrelNet,ISP
@@ -7539,6 +8207,7 @@ sentara.com,Sentara,Healthcare
 sentex.ca,Sentexx,ISP
 sentex.net,Sentex Communications,ISP
 sentia.com,Sentia,MSP
+sentris.com,Sentris Network,ISP
 seoul.go.kr,Seoul Metropolitan Government,Government
 sepanta.com,Sepanta Communication,ISP
 seqtek.net,SEQTEK,MSP
@@ -7549,6 +8218,7 @@ serpro.gov.br,SERPRO,Government
 serrasultelecom.com.br,Serrasul,ISP
 serv-net.pl,Servcom,ISP
 serv.host,SERV.HOST,Web Host
+serva.net,ServaNet,ISP
 servarica.com,ServaRica,IaaS
 servconfig.com,InMotion Hosting,Web Host
 servcorp.com,Servcorp,SaaS
@@ -7559,8 +8229,10 @@ servebyte.com,Servebyte,Web Host
 servecentric.com,ServeCentric,Web Host
 servehttp.com,No-IP,Web Host
 serveminecraft.net,No-IP,Web Host
+server.net,Servernet Internet,IaaS
 server24.eu,Server24,Web Host
 servercentral.net,Summit,Web Host
+serverchoice.com,ServerChoice,ISP
 servercore.com,Servercore,IaaS
 serverdata.net,GoDaddy,Web Host
 serverel.com,Serverel,Web Host
@@ -7572,6 +8244,7 @@ servermania.com,ServerMania,Web Host
 servername.us,Rad Web Hosting,Web Host
 serverneubox.com.mx,Neubox,Web Host
 serveroffer.net,Serveroffer,Web Host
+serveroid.com,Serveroid,IaaS
 serverpanel.com,Shock Hosting,Web Host
 serverpoint.com,ServerPoint,Web Host
 servers.com,Servers.com,Web Host
@@ -7591,12 +8264,14 @@ servpac.com,Servpac,ISP
 ses-astra.fr,SES Astra,ISP
 ses-stiftung.de,Schwester Euthymia Stiftung,Healthcare
 ses.com,SES (Formerly Intelsat),ISP
+sessiontelecoms.co.za,Session Telecoms(PTY),ISP
 setardsl.aw,SETAR,ISP
 setera.fi,Setera,SaaS
 setitagila.ru,Nizhnetagilskie Computer Networks,ISP
 seven-sky.net,Seven Sky,ISP
 sevennet.net,Goran Net (Sevennet),ISP
 severen.ru,Severen Telecom,ISP
+severtm.ru,Sever Telecom,ISP
 sevstar.net,Lancom,ISP
 sevtelecom.ru,Sevastopol Telecom,ISP
 sewan.be,Sewan Belgium,ISP
@@ -7613,12 +8288,14 @@ sfr.net,SFR,ISP
 sfr.re,SFR,ISP
 sfu.ca,Simon Fraser University,Education
 sfusd.edu,San Francisco Unified School District,Education
+sfv.se,Statens Fastighetsverk,Government
 sfwmd.gov,South Florida Water Management District,Government
 sg.gs,SG.GS,ISP
 sgs.se,Goteborgs Studentbostader (SGS),Education
 sh.cz,SH.cz,Web Host
 sh27.com.br,SunHost,Web Host
 shabakah.com.sa,Shabakah Net,ISP
+shadow.tech,Shadow,SaaS
 shahrad.net,Sefroyek Pardaz,ISP
 shalomnet.com.br,Shalomnet,ISP
 shamrog.com,Shamrog,Web Host
@@ -7633,6 +8310,7 @@ sharktech.net,Sharktech,Web Host
 shastacoe.org,Shasta County Office of Education,Education
 shatel.ir,Shatel,ISP
 shaw.ca,Shaw,ISP
+shawnee.com,Shawnee Communications,ISP
 shawu.edu,Shaw University,Education
 sheffieldpharma.com,Sheffield Pharmaceuticals,Healthcare
 shell.com,Shell,Industrial
@@ -7665,6 +8343,7 @@ shopware.store,Shopware,SaaS
 showakvc.co.jp,"Showa Kasei Kogyo Co., Ltd.",Industrial
 showpad.com,Showpad,Marketing
 shsu.edu,Sam Houston State University,Education
+shtc.net,Sandhill Telephone,ISP
 shtorm.com,Shtorm,ISP
 shtorm.net,Shtorm,ISP
 shudo-u.ac.jp,Hiroshima Shudo University,Education
@@ -7674,6 +8353,7 @@ shyamgroup.org,Shyam Group,Conglomerate
 si.edu,Smithsonian Institution,Education
 siac.com,SIAC,Finance
 siait.si,siaIT,ISP
+sibintek.ru,SIBINTEK,MSP
 sibset-team.ru,Sibirskie Seti,ISP
 sibset.ru,Sibirskie Seti,ISP
 sibyl.com,Sibl Design,MSP
@@ -7692,6 +8372,7 @@ signet.nl,Signet,ISP
 signetbreedband.nl,Signet,ISP
 signium.co.jp,Signium,Consulting
 siho.org,Siho Insurance Services,Finance
+sikkanet.com,Sikka Broadband,ISP
 sikt.no,Sikt (Formerly Uninett),Education
 sileman.net.pl,Sileman,ISP
 sileman.pl,Sileman,ISP
@@ -7716,6 +8397,7 @@ simus.uz,Simus,ISP
 sin.net.cn,Shanghai Information Network,ISP
 sina.com.cn,Sina,Email Provider
 sinal.dk,Norlys,ISP
+sinalbr.com.br,Sinal Br Telecom,ISP
 sinaldoceu.com.br,Sinal do Céu,ISP
 sinectis.com.ar,Sinectis,ISP
 sinergit.com.do,Sinergit,MSP
@@ -7735,6 +8417,7 @@ sipartech.com,Sipartech,ISP
 siriuscom.com,Sirius (CDW),MSP
 siriustec.it,Sirius Technology Italy,ISP
 siriustelecom.uz,Sirius Telecom,ISP
+sistelindo.net.id,Sistelindo Mitralintas,ISP
 sita.aero,SITA,SaaS
 sita.co.za,SITA,Government
 site.rb-hosting.io,Raidboxes,Web Host
@@ -7745,6 +8428,7 @@ sitel.net.pl,Sitel (Livenet),ISP
 sitelbra.com.br,Sitelbra,ISP
 siteprotect.com,SiteMail,Email Provider
 sitios.win,Sitios Win,Web Host
+sits.com,SITS,MSSP
 sitsa.com.ar,SITSA Telecomunicaciones,ISP
 sitsanetworks.net,SiTSA,ISP
 siu.edu,Southern Illinois University Carbondale,Education
@@ -7777,17 +8461,23 @@ skybandalarga.com.br,SKY Servicos de Banda Larga,ISP
 skybest.com,SkyLine SkyBest,ISP
 skybroadband.com,Sky,ISP
 skydsl.eu,skyDSL,ISP
+skydsl.ir,Iran Post,ISP
 skydsl.it,skyDSL,ISP
+skyfiberinternet.com,Sky Fiber Internet,ISP
 skyhighsecurity.com,Skyhigh Security,Email Security
 skyline.od.ua,Skyline Electronics Odesa,ISP
+skylink-data-center.nl,SkyLink Data Center,IaaS
 skymail.com.br,Skymail,Email Provider
 skymesh.net.au,SkyMesh,ISP
 skynet.kg,Skynet Telecom,ISP
 skynet.ru,Skynet,ISP
 skypoint.com,SkyPoint Communications,ISP
 skysdigital.net,SkyDigital,ISP
+skytel.ge,Skytel,ISP
 skytv.co.nz,Sky NZ,Entertainment
+skyware.pl,Skyware,ISP
 skywaywest.com,Skyway West,ISP
+skywire.co.za,Skywire,ISP
 sl-reverse.com,IBM Cloud,PaaS
 slav.dn.ua,Satellite Net Service Slavyansk,ISP
 slb.com,Schlumberger,Industrial
@@ -7801,8 +8491,10 @@ slovanet.sk,Slovanet,ISP
 slt.lk,SLT,ISP
 slu.edu,Saint Louis University,Education
 slv.vic.gov.au,State Library of Victoria,Government
+slvrec.com,San Luis Valley Rural Electric,Utilities
 smart.com.ph,Smart Communications,ISP
 smartape.ru,Smart Ape LLC,Web Host
+smartchoiceus.com,Smart Choice Communications,ISP
 smartcitytelecom.com,MPInet,ISP
 smartcomtelephone.com,SmartCom,ISP
 smartdraw.com,SmartDraw,SaaS
@@ -7839,8 +8531,10 @@ smtp2go.com,SMTP2GO,SaaS
 smu.ac.kr,Sangmyung University,Education
 smu.edu,Southern Methodist University,Education
 snafu.de,snafu,Web Host
+snaju.com,Snaju,Defense
 snapengage.com,SnapEngage,SaaS
 snapfiles.com,SnapFiles,Technology
+snappydsl.net,SnappyDSL,ISP
 snc.edu,St. Norbert College,Education
 sncc.co.kr,SNC Korea,Manufacturing
 snet.com,SNET,ISP
@@ -7850,6 +8544,7 @@ snthostings.com,SnTHostings,Web Host
 snu.ac.kr,Seoul National University,Education
 so-net.ne.jp,So-net,ISP
 so-net.net.tw,So-net,ISP
+so-ups.ru,System Operator of the United Energy System,Utilities
 sobralnet.com.br,Sobralnet,ISP
 socgen.com,Societe Generale,Finance
 socialfive.com,Social5,Marketing
@@ -7858,6 +8553,7 @@ societegenerale.com,Societe Generale,Finance
 socket.net,Socket,ISP
 soco.net,SOCO,ISP
 socoolsolution.com,So Cool Solution,MSP
+soderhamnnara.se,Söderhamn NÄRA,Utilities
 sodetel.net.lb,sodetel,ISP
 soe.com,Daybreak Game Company,Entertainment
 sofreafurnishings.com,Sofrea Furnishings,Retail
@@ -7885,12 +8581,15 @@ solfibraotica.com.br,Sol Internet Fibra Óptica,ISP
 solidtools.com,SolidTools,ISP
 soliton.co.jp,Soliton Systems,SaaS
 solnet.ch,SolNet,ISP
+solnet.net.id,Solnet Indonesia,ISP
 soltia.es,Soltia,Web Host
+solunet.com.ar,Grupo Solunet,ISP
 solutions.com.sa,STC,ISP
 solvinity.com,Solvinity,MSP
 somelec.mr,SOMELEC,Industrial
 somosinternet.co,Somos Internet Colombia,ISP
 somyatrans.com,Somya Translators,Consulting
+sonabusiness.com,Sona Network,ISP
 sonatel.com,Sonatel,ISP
 sonatel.sn,Sonatel,ISP
 sondercloud.com,SonderCloud,Web Host
@@ -7898,6 +8597,7 @@ sonic.com,Sonic,ISP
 sonic.net,Sonic,ISP
 sonichealthcareusa.com,Sonic Healthcare USA,Healthcare
 sonicwall.com,SonicWall,Email Security
+sonitel.ne,SONITEL,ISP
 sony.com,Sony,Entertainment
 sonygs.co.jp,Sony Global Solutions,MSP
 sonynetwork.co.jp,So-net,ISP
@@ -7907,6 +8607,7 @@ sophos.com,Sophos,Email Security
 sorbonne-universite.fr,Sorbonne Université,Education
 soskol.com,Osknoltelecom,ISP
 sosnc.gov,North Carolina Secretary of State,Government
+sota.co.uk,Sotaconnect Network,IaaS
 sougo-group.jp,Camcom Group,SaaS
 soui9.com.br,i9 Telecom,ISP
 soumaster.com.br,Master Internet,ISP
@@ -7921,9 +8622,11 @@ southwestern.edu,Southwestern University,Education
 souuni.com,Uni Telecom,ISP
 soverin.com,Soverin,Email Provider
 soverin.net,Soverin,Email Provider
+soyka.su,CityTelekom,ISP
 sp.edu.sg,Singapore Polytechnic,Education
 sp2-brevo.net,Brevo (Sendinblue),Marketing
 space.net,SpaceNet,MSP
+spacedump.se,SpaceDump IT,MSP
 spacenet.ru,Internet-Cosmos (Spacenet),ISP
 spacenorway.com,Space Norway,ISP
 spaceship.com,Spaceship,Web Host
@@ -7946,6 +8649,7 @@ spartanhost.org,Spartan Host,Web Host
 spb.ru,Smart Telecom,ISP
 spbu.ru,Saint Petersburg State University,Education
 spcmail.jp,SPC Mail S.T.,Email Provider
+spcom.cz,SPCom,ISP
 spd-mgts.ru,MGTS,ISP
 spd.co.il,SPD Hosting,Web Host
 spd.net.tr,SPDNet,Web Host
@@ -7953,6 +8657,7 @@ spectra.co,Shyam Spectra,ISP
 spectranet.com.ng,Spectranet,ISP
 spectranet.in,Spectra,ISP
 spectrum.com,Spectrum,ISP
+spectrum.com.au,Spectrums Core Network,ISP
 spectrum.net,Charter,ISP
 spectrumhealth.org,Corewell Health (Spectrum Health),Healthcare
 speedbone.de,Speedbone,Web Host
@@ -7968,6 +8673,7 @@ speedvirtual.net.br,Speed Virtual,ISP
 speedway.hk,Speedway Travels,Travel
 speedy.com.ar,Movistar (Formerly Speedy),ISP
 speedy.net.pe,Telefonica del Peru,ISP
+speedyquick.net,SpeedyQuick Networks,ISP
 speet.com.br,Speet Telecom,ISP
 speicherzentrum.de,Speicherzentrum,Web Host
 spglobal.com,S&P Global,Finance
@@ -7980,6 +8686,7 @@ spintel.net.au,SpinTel,ISP
 spintheweb.com,Spin The Web,Web Host
 spirit.com.au,Spirit Technology,MSP
 spitfire.co.uk,Spitfire,ISP
+spitwspots.com,SPITwSPOTS,ISP
 spitzer.org,Spitzer Autoworld,Automotive
 splashtop.com,Splashtop,Technology
 splius.lt,Splius,ISP
@@ -7992,6 +8699,7 @@ springfield.ma.us,Springfield Public Schools,Education
 springnet.net,SpringNet,ISP
 sprint-bg.net,Sprint Bulgaria,ISP
 sprint-inet.ru,SPRINTInet (Спринт-инет),ISP
+sprintel.cz,Sprintel,ISP
 sprintinet.ru,SPRINTInet,ISP
 sprious.com,Sprious,Web Host
 sps.net.sa,Gulf Computer Services,ISP
@@ -8020,11 +8728,13 @@ ssnettelecom.net.br,SSNET Telecom,ISP
 sst2u.com,SST2U,Education
 ssuv.uz,"Samarkand Institute of Veterinary Medicine, Animal Husbandry and Biotechnology",Education
 st.nl,Schiphol Telematics,MSP
+st.uz,Sharq Telekom,ISP
 stabletransit.com,Rackspace,Web Host
 stack.net,Stackster,ISP
 stackit.de,STACKIT (Schwarz),IaaS
 stackmail.com,20i,Web Host
 stacksdiscovery.com,Stacks,Web Host
+stacktelecom.ru,Stack Telecom,IaaS
 stadt-koeln.de,City of Cologne,Government
 stadtnetz-bamberg.de,Stadtnetz Bamberg,ISP
 stadtwerke-kapfenberg.at,Stadtwerke Kapfenberg,Utilities
@@ -8047,6 +8757,7 @@ stargatecommunications.com,X-Link Limited,ISP
 starhealthagency.com,Star Home Health,Healthcare
 starhub.com,StarHub,ISP
 starkmans.com,Starkmans Health Care Depot,Healthcare
+starlan.com,Starlan Telecom,ISP
 starlinx.com,StrLinX,MSP
 starman.net.br,Star Man Net,ISP
 starnet.cz,Starnet,ISP
@@ -8057,6 +8768,7 @@ starnettelecom.pl,StarNet Telecom Poland,ISP
 starnetweb.com.br,Starnet,ISP
 starnova.com,Starnova,Web Host
 starry.com,Starry,ISP
+starrydns.com,Starry Network,IaaS
 start.ca,Start Communications,ISP
 starvision.com,StarVision,ISP
 state.ak.us,Alaska Government,Government
@@ -8124,10 +8836,12 @@ stratoserver.net,STRATO,Web Host
 stratosglobal.com,Inmarsat (Stratos Global),ISP
 stratus.com,Stratus Technologies,Technology
 stratusiq.com,StratusIQ,ISP
+stratusnet.com,Stratus Networks,ISP
 streamlit.app,Snowflake,SaaS
 streamlit.io,Snowflake,SaaS
 streamlitapp.com,Snowflake,SaaS
 streamnet.co.uk,Streamline Solutions,MSP
+streamnetworks.co.uk,Stream Networks,ISP
 streamsend.com,Campaigner,Marketing
 strencom.net,DigitalWell (Strencom),ISP
 strongtechnology.net,StrongVPN,Web Host
@@ -8138,6 +8852,7 @@ stthomas.edu,University of St. Thomas,Education
 stu.edu.gh,Sunyani Technical University,Education
 studio4web.com,Studio4Web,Web Host
 stv.ee,STV Estonia,ISP
+stw.at,Stadtwerke Klagenfurt,Utilities
 suanettelecom.com.br,Suanet Telecom,ISP
 subisu.net.np,Subisu Cablenet,ISP
 subnet05.ru,Subnet,ISP
@@ -8146,16 +8861,20 @@ succeed.net,Succeed.net,ISP
 success-hr.com,Success HR,SaaS
 sudatel.sd,Sudatel,ISP
 suddenlink.net,Suddenlink,ISP
+suite224.net,Suite224,ISP
 sulcatel.com.br,Sulcatel,ISP
 sulinternet.net,Sul Internet,ISP
+sulnet.com.br,Sulnet Telecom,ISP
 sulnettelecom.com.br,Sulnet Telecom,ISP
 sulonline.net,Sul Internet,ISP
 sumicity.net.br,Giga+ Fibra,ISP
 summit-broadband.com,Summit Broadband,ISP
+summitcommunications.net,Summit Communications,ISP
 summithealthcare.net,Summit Healthcare,Healthcare
 summithq.com,Summit,Web Host
 sumofiber.com,Sumo Fiber,ISP
 sums.ac.ir,Shiraz University of Medical Sciences,Education
+sunchon.ac.kr,Sunchon National University,Education
 sunet.se,SUNET,Education
 sunfield.ne.jp,Sun Field Internet,ISP
 sungardas.com,11:11 Systems,MSP
@@ -8179,10 +8898,12 @@ supatx.com,SUP ATX,Retail
 super.net.pk,Supernet Pakistan,ISP
 superb.net,CherryRoad (Formerly Superb Internet),Web Host
 supercabotv.com.br,Super Cabo,ISP
+superclouds.net,SuperClouds,IaaS
 superconectados.ar,ARLINK,ISP
 supercp.com,a2 hosting,Web Host
 supereffort.com,Super Effort Technology,Technology
 superhosting.bg,SuperHosting.BG,Web Host
+superitelecom.com.br,Ibituruna TV por assinatura S/C,ISP
 superloop.au,Superloop,ISP
 superloop.com,Superloop,ISP
 supermedia.pl,Supermedia Polska,ISP
@@ -8191,6 +8912,7 @@ supernetes.tv.br,Supernet,ISP
 supernovabih.ba,Supernova,ISP
 superonline.net,Turkcell Superonline,ISP
 supersonic.net.br,Super Sonic Telecom,ISP
+suportinet.com,Ewerton DA Silva Lopes,ISP
 suportinet.com.br,Suportinet,ISP
 supportedns.com,MDD Hosting,Web Host
 supranet.com.br,Supranet,ISP
@@ -8208,10 +8930,13 @@ surfinternet.com,Surf Internet,ISP
 surfplanet.de,Surfplanet Cologne,Web Host
 surry.net,Surry Communications,ISP
 sv-en.ru,Svyaz-Energo,ISP
+sv-tel.ru,Svyazist,ISP
+svalleyec.com,Sequachee Valley Electric,Utilities
 sverigesradio.se,Sveriges Radio,News
 svn-repos.de,LCube,Web Host
 svorka.no,Svorka,ISP
 svsu.edu,Saginaw Valley State University,Education
+svyaznoy.ru,Svyaznoy,Retail
 swan.sk,SWAN,ISP
 swarthmore.edu,Swarthmore College,Education
 swat.coop,Southwest Arkansas Telephone,ISP
@@ -8253,6 +8978,7 @@ synccentric.com,Synccentric,SaaS
 synchronoss.net,Synchronoss,SaaS
 syncontel.net.br,Syncontel Telecomunicações,ISP
 syndeonetwork.com,Syndeo Networks,ISP
+synergyfiber.com,Synergy Broadband,ISP
 synergywholesale.com,Synergy Wholesale,Web Host
 syniverse.com,Syniverse,SaaS
 synlinq.de,Synlinq,Web Host
@@ -8274,6 +9000,8 @@ syseleven.de,SysEleven,IaaS
 sysgroup.com,SysGroup,MSP
 sysnet.ie,VikingCloud,MSP
 systalent.com,Systalent,SaaS
+systemec.nl,Systemec,ISP
+systemlifeline.com,System Lifeline,MSP
 systex.com.tw,Systex,MSP
 sytes.net,No-IP,Web Host
 t-2.net,T-2,ISP
@@ -8291,6 +9019,7 @@ t-online.hu,Magyar Telekom,ISP
 t-pbs.net,Pacnet Business Solutions,ISP
 t-systems.at,T-Systems,MSP
 t-systems.com,T-Systems,MSP
+t-systems.com.sg,T-Systems,MSP
 t-systems.de,T-Systems,MSP
 t1-cloud.ru,T1 Cloud,IaaS
 t2.ru,T2 Mobile,ISP
@@ -8301,6 +9030,7 @@ tachus.com,Tachus Fiber,ISP
 tachyon.net.id,Tachyon,ISP
 tafjord.no,Tafjord Connect,ISP
 taifo.com.tw,TAIFO,ISP
+taiget.ru,Taiget,ISP
 taipeinet.com.tw,TaipeiNet (Peicity Digital Cable Television),ISP
 taiwanmobile.com,Taiwan Mobile,ISP
 take2games.com,Take-Two Interactive,Entertainment
@@ -8323,6 +9053,7 @@ tanomail.com,Tanomail,Retail
 tanzaniaservers.com,Tanzania Servers,Web Host
 target.com,Target,Retail
 tarhely.eu,Tárhely.Eu,Web Host
+tarman.pl,Tarman,ISP
 tarr.hu,Tarr,ISP
 tasfrance.com,ATSAT (Nubevia),ISP
 tasmanet.com.au,TasmaNet,ISP
@@ -8342,10 +9073,14 @@ tbntelecom.com.br,TBN Telecom,ISP
 tbonet.net.br,Infix Telecom,ISP
 tbs.co.jp,Tokyo Broadcasting System,Government Media
 tcc-technology.com,TCC Technology,Web Host
+tcc.on.ca,Tuckersmith Communications Co-Operative,ISP
+tcc.tv.br,Tech Cable do Brasil Sist. de Telec,ISP
 tcell.tj,Tcell,ISP
 tcftelecom.com.br,TCF Telecom,ISP
+tcheturbo.com.br,Tchêturbo,ISP
 tchile.com,Tchile,Web Host
 tci.ir,TCI,ISP
+tcinet.ru,TCI,ISP
 tcmcorp.com,Southland Industries,Construction
 tcmhd.com.br,Sistema Oeste de Servicos,ISP
 tcn-catv.co.jp,Tokyo Cable Network,ISP
@@ -8355,8 +9090,10 @@ tcpnet.com.br,TCPNet,ISP
 tcrholdings.com,TCR Holdings,ISP
 tcs.com,TATA Consultancy Services,SaaS
 tct.net,TCT,ISP
+tctainc.net,Tri-County Telephone,ISP
 tctwest.net,TCT,ISP
 tcu.edu,Texas Christian University,Education
+tcv.bg,TCV,ISP
 td.com,TD Bank,Finance
 tdcgroup.com,TDC,ISP
 tdf.fr,TDF,ISP
@@ -8373,6 +9110,7 @@ tech.gov.sg,Government Technology Agency Singapore,Government
 tech.ru,TECH.RU,Web Host
 tech4hosting.com,Tech 4 Hosting,Web Host
 techcom.cz,TechCom Czech,ISP
+techcrea.fr,Techcrea Solutions,ISP
 techdata.com,Tech Data,Logistics
 teche.net,Uniti,MSP
 techiemedia.net,Techie Media,Web Host
@@ -8384,6 +9122,8 @@ technolutions.net,Technolutions,SaaS
 technozone.com.ph,Technozone Corporation,Construction
 tecnalia.com,Tecnalia,Science
 tecnocratica.net,Tecnocratica,Web Host
+tecnoera.com,Tecnoera,ISP
+tecnoveninternet.com,Tecnoven Services CA,ISP
 tecwave.com.br,Tecwave Telecom,ISP
 tedata.net,Telecom Egypt,ISP
 tedforbes.com,Ted Forbes,Photography
@@ -8394,13 +9134,17 @@ teknotel.com,Teknotel,Web Host
 teksavvy.com,TekSavvy,ISP
 tel.net.ba,HT Eronet,ISP
 tel.ru,TEL Suntel,ISP
+telair.com.au,Telair,ISP
+telalaska.com,TelAlaska,ISP
 telbo.net,TELBO,ISP
 telcel.com,Telcel,ISP
 telcocom.com.ar,Telcocom,ISP
+telcom.net.ua,Telcom,ISP
 telcomaster.com,TelcoMaster,ISP
 telconet.ec,Telconet,ISP
 telcoproservices.cz,Telco Pro Services,ISP
 tele-ag.de,TELE AG,ISP
+tele-plus.ru,Tele-plus,ISP
 tele.net,VOLhighspeed,ISP
 tele2.com,Tele2,ISP
 tele2.kz,Tele2,ISP
@@ -8409,6 +9153,7 @@ telebec.com,Telebec,ISP
 telebecinternet.com,Telebec,ISP
 telebras.com.br,Telebras,ISP
 telecab.com.br,Telecab,ISP
+telecablecentral.com,Telecable Central,ISP
 telecablecr.com,Telecable,ISP
 telecall.com,Telecall,ISP
 telecall.com.br,Telecall,ISP
@@ -8426,6 +9171,7 @@ telecom.li,FL1 (Telecom Liechtenstein),ISP
 telecom.mu,Mauritius Telecom,ISP
 telecom.na,Telecom Namibia,ISP
 telecom.net.ar,Telecom Argentina,ISP
+telecom.ru,Telecom.ru,ISP
 telecom.tm,Turkmentelecom,ISP
 telecomarmenia.am,Telecom Armenia (Team),ISP
 telecomclm.net,Telecom Castilla La Mancha,ISP
@@ -8433,6 +9179,7 @@ telecomitalia.com,TIM,ISP
 telecomitalia.it,TIM,ISP
 telecomitalia.sm,TIM San Marino,ISP
 telecomprovider.com.br,Telecom Provider,ISP
+teledata.co.uk,Teledata UK,IaaS
 teledata.de,TeleData,ISP
 teledataict.com,Teledata Ghana,ISP
 teledyne.com,Teledyne Technologies,Manufacturing
@@ -8446,6 +9193,7 @@ telefonicachile.cl,Telefónica Chile,ISP
 telegram.org,Telegram Messenger,Social Media
 telehouse.bg,Telehouse Bulgaria,Web Host
 telehouse.net,Telehouse,Web Host
+telekabel.bg,Telecabel,ISP
 telekabel.com.mk,Telekabel,ISP
 telekom.at,A1,ISP
 telekom.com,Deutsche Telekom,ISP
@@ -8453,6 +9201,7 @@ telekom.de,Deutsche Telekom,ISP
 telekom.hu,Magyar Telekom,ISP
 telekom.me,Crnogorski Telekom,ISP
 telekom.mk,Makedonski Telekom,ISP
+telekom.ro,Telekom Romania Mobile,ISP
 telekom.rs,MTS,ISP
 telekom.si,Telekom Slovenije,ISP
 telekom.sk,Slovak Telekom,ISP
@@ -8461,7 +9210,9 @@ telemach.ba,Telemach,ISP
 telemach.hr,Telemach,ISP
 telemach.si,Telemach,ISP
 telemaxx.de,TelemaxX,Web Host
+telemgroup.sx,SMITCOMS,ISP
 telemidia.net.br,Telemidia,ISP
+telemor.tl,Viettel Timor Leste,ISP
 telemovil.net,Telemovil El Salvador,ISP
 telenet-ops.be,Telenet BV,ISP
 telenet.be,Telenet,ISP
@@ -8475,6 +9226,8 @@ telenord.com.do,Telenord,ISP
 teleos.ru,Teleos-1,ISP
 telepac.pt,SAPO,Email Provider
 telepacific.net,TPx Communications,ISP
+telepark-passau.de,Telepark Passau,ISP
+teleperformance.com,Teleperformance,SaaS
 telepermit.co.nz,Spark NZ,ISP
 telepoint.bg,Telepoint,Web Host
 telered.com.ar,Telered,ISP
@@ -8483,9 +9236,13 @@ telesat.com,Telesat,ISP
 telesat.hr,Telesat Croatia,ISP
 teleservice.net,Teleservice Skane,ISP
 teleseti.com,Teleseti Plus,ISP
+telesmart.mk,Telesmart Telekom DOO,ISP
+telesom.com,Telesom,ISP
 teleson.net.br,Teleson Telecom,ISP
 telesp.net.br,Telefônica Brasil,ISP
+telespazio.it,Telespazio,ISP
 telesur.sr,Telesur,ISP
+teletek.net.tr,Teletek Bulut Bilisim ve Iletisim Hizmetleri,MSP
 teletu.it,Vodafone,ISP
 televiaducto.com.do,Televiaducto,ISP
 telfy.com,Telfy,ISP
@@ -8516,8 +9273,10 @@ telmax.com,telMAX,ISP
 telmex.com,Telmex,ISP
 telmex.net.ar,Telmex Argentina,ISP
 telnaptelecom.pl,Telnap Telecom,ISP
+telnet.it,TELNET,IaaS
 telnetworldwide.com,Telnet Worldwide,ISP
 telnyx.com,Telnyx,SaaS
+telone.co.zw,TelOne,ISP
 telpin.com.ar,Telpin Pinamar,ISP
 telpol.net.pl,Telpol,ISP
 telset.ee,Telset Estonia,ISP
@@ -8532,6 +9291,7 @@ telus.net,TELUS,ISP
 telvgg.coop,Cooperativa Telefonica V.G.G.,ISP
 telviso.com.ar,TelViso,ISP
 telxius.com,Telxius,ISP
+tely.com.br,Tely,ISP
 tempe.gov,City of Tempe,Government
 temple.edu,Temple University,Education
 templehealth.org,Temple University Health System,Healthcare
@@ -8540,6 +9300,7 @@ tenders.net,Tenders.net,SaaS
 tenet.ac.za,TENET,Education
 tenet.ua,TENET,ISP
 tennessee.edu,University of Tennessee,Education
+tennet.ro,Tennet Telecom,ISP
 teol.net,mtel,ISP
 tera-byte.com,Tera-Byte,Web Host
 teracom.dk,Cibicom,ISP
@@ -8549,6 +9310,7 @@ teraline-telecom.net,Teraline Telecom,ISP
 teraline.kz,Teraline Telecom,ISP
 teralinktelecom.com.br,Teralink,ISP
 teraswitch.com,TeraSwitch Networks,Web Host
+teremki.net.ua,Teremky LAN ISP,ISP
 ternet.or.tz,TERNET Tanzania Education and Research Network,Education
 terra.com,Terra Networks,Web Host
 terra.com.br,Terra Mail,Email Provider
@@ -8560,12 +9322,15 @@ terrecablate.it,Terrecablate,ISP
 tesatelecom.com,Tesa Telecom,ISP
 tesla.com,Tesla,Automotive
 tet.lv,Tet,ISP
+tetrapak.com,Tetra Pak,Manufacturing
 teuto.net,teuto.net,IaaS
 tevapharm.com,Teva Pharmaceuticals,Healthcare
 tevisat.net,Tevisat,ISP
 texas.gov,The Government of Texas,Government
 textowngroup.com,Textown Group,Manufacturing
 tfn.net.tw,Taiwan Fixed Network,ISP
+tftel.com,Tianfeng Communications,ISP
+tgnet.de,true global communications,ISP
 tgtel.com,Thacker-Grigsby Communications,ISP
 thaitoko.com,Thai Toko Engineering,Construction
 thalesgroup.com,Thales,Defense
@@ -8577,6 +9342,7 @@ thecable.net,The Cable St. Kitts,ISP
 thecamels.org,Thecamels,Web Host
 thechristhospital.com,The Christ Hospital,Healthcare
 thecloud.net,Sky WiFi (The Cloud),ISP
+thecomputerhut.co.za,The Computer Hut,MSP
 thegameshowcompany.ca,The Game Show Company,Entertainment
 thegigabit.com,Gigabit Hosting,Web Host
 thegirlandthefig.com,the girl & the fig,Food
@@ -8594,6 +9360,8 @@ thomsonreuters.com,Thomson Reuters,SaaS
 three.co.uk,Three,ISP
 three.com.hk,3 Hong Kong (Hutchison),ISP
 three.ie,Three,ISP
+thrivenetworks.com,Thrive Operations,MSP
+thsprovider.com.br,THS Provider Serviços de Comunicação Multimídia LT,ISP
 thunder.es,Thunder Creativos,Marketing
 thunderbox.io,ThunderBox,Web Host
 thundernet.com.ve,Thundernet,ISP
@@ -8628,8 +9396,10 @@ tigostar.cr,Tigo,ISP
 tii-usa.com,Technology International,Consulting
 tikona.in,Tikona,ISP
 tilaa.com,Tilaa,Web Host
+tiltas.lt,Verslo Tiltas,MSP
 tim.com.br,TIM Brasil,ISP
 tim.it,TIM,ISP
+timbl.co.in,RI Networks,ISP
 time.com.my,TIME,ISP
 timeetc.com,Time Etc,SaaS
 timenet.it,Timenet,ISP
@@ -8649,12 +9419,15 @@ tiscali.it,Tiscali,ISP
 tisco.mx,TISCO Networks,MSP
 tisnet.net.tw,TISNET,ISP
 tisp.com,Datawing (TISP),ISP
+tisparkle.com,Sparkle,ISP
 titan.email,Titan,Email Provider
 titanhq.com,TitanHQ,Email Security
 titech.ac.jp,Institute of Science Tokyo,Education
 tivit.com,Tivit,MSP
 tix.it,Tuscany Internet eXchange,ISP
+tizeti.com,Tizeti,ISP
 tjbtn.net,Tianjin Broadcasting TV Network,ISP
+tk-lindau.de,NetCom BW,ISP
 tkchopin.pl,Chopin Telewizja Kablowa,ISP
 tkk.net.pl,Telewizja Kablowa Koszalin,ISP
 tkreal.ru,The Real Group,Logistics
@@ -8719,6 +9492,7 @@ tornadovps.com,Tornado VPS,Web Host
 toronto.ca,City of Toronto,Government
 toronto.edu,University of Toronto,Education
 torontomu.ca,Toronto Metropolitan University,Education
+torun.pl,City of Toruń,Real Estate
 toshima.co.jp,Toshima Cable Network,ISP
 tosis.co.jp,Tosoh Information Systems,MSP
 tosoh.co.jp,Tosoh,Industrial
@@ -8726,6 +9500,7 @@ totalplay.com.mx,Totalplay,ISP
 totidc.net,TOT,ISP
 toto.co.jp,TOTO,Manufacturing
 totvs.com,Totvs,SaaS
+towardex.com,TowardEX,ISP
 towerstream.com,Towerstream,ISP
 towngastelecom.com,Towngas Telecom,ISP
 townisp.com,Shrewsbury Electric SELCO,Utilities
@@ -8743,10 +9518,12 @@ tps.uz,TPS Telecom,ISP
 tptel.ru,Teleport Telecom,ISP
 tpu.ru,Tomsk Polytechnic University,Education
 tpx.com,TPx Communications,ISP
+trabia.com,Trabia,IaaS
 tradeeasyhk.net,TradeEasyHK,Retail
 tradeindia.com,TradeIndia,SaaS
 trafficforce.lt,TrafficForce,Marketing
 trafficmanager.net,Microsoft Azure,Technology
+trafficmind.com,TMN,MSSP
 trainhealthonline.com,TrainHealthOnline,Education
 trakiacable.net,Trakia Kabel,ISP
 transact.com.au,TransACT,ISP
@@ -8754,15 +9531,19 @@ transatel.com,Transatel (NTT),ISP
 transip.nl,TransIP,Web Host
 transmail.net,Zoho,SaaS
 transocean.com,Transocean,Industrial
+transoceanet.com,Trans Ocean Network,ISP
 transparent.eu,Transparent,Finance
 transparentglobal.com,Transparent,Finance
+transpower.co.nz,Transpower,Utilities
 transsped.com,Trans Sped,SaaS
 transsped.ro,Trans Sped,SaaS
 transtelco.net,Flō Networks,ISP
 transtelecom.net,Trans Telecom,ISP
+transtelecom.ru,TransTelekom,ISP
 transvision.net,Transvision Reseau,ISP
 transworld-home.com,Transworld Home Pakistan,ISP
 travelers.com,Travelers,Finance
+travelport.com,Travelport,SaaS
 tre.se,Tre,ISP
 treasury.gov,U.S. Department of the Treasury,Government
 trend.inc,Trend Capital,SaaS
@@ -8801,10 +9582,12 @@ truehost.cloud,Truehost Cloud,Web Host
 trueidc.com,True IDC Thailand,Web Host
 trueinternet.co.th,TRUE,ISP
 truemail.co.th,True Internet,ISP
+truespeed.ca,Truespeed Internet Services,ISP
 truespeed.com,TrueSpeed Communications,ISP
 truestreamfiber.com,Truestream Fiber,ISP
 truman.edu,Trueman State University,Education
 truphone.com,Truphone,ISP
+trusc.net,Municipal Network Services,Government
 trusted-network.de,Trusted Network,Web Host
 trustifi.com,Trustifi,Email Security
 truvista.biz,Plant TiftNet (Truvista),ISP
@@ -8815,6 +9598,7 @@ tsl.ru,Teledyne Systems Limited,ISP
 tstc.edu,Texas State Technical College,Education
 tstt.co.tt,TSTT,ISP
 tstt.net.tt,TSTT,ISP
+tsukaeru.net,"Tsukaeru.net, Web Hosting Company, Japan",Web Host
 tsukuba.ac.jp,University of Tsukuba,Education
 ttc.kz,Transtelecom Kazakhstan,ISP
 ttcl.co.tz,Tanzania Telecommunications,ISP
@@ -8823,8 +9607,10 @@ ttiinc.com,TTI,Industrial
 ttk.ru,Joint Stock Company TransTeleCom,ISP
 ttn.gob.ar,Tribunal de Tasaciones de la Nación,Government
 ttnet.com.tr,Türk Telekom,ISP
+ttnet.cz,TTNET,ISP
 ttu.edu,Texas Tech University,Education
 ttuhsc.edu,Texas Tech University Health Sciences Center,Education
+tube-hosting.com,Ferdinand Zink trading Tube-Hosting,Web Host
 tuc.gr,Technical University of Crete,Education
 tucows.com,Tucows,Web Host
 tucsonaz.gov,City of Tucson,Government
@@ -8856,6 +9642,7 @@ turontelecom.uz,Turon Telecom Uzbekistan,ISP
 tus.ac.jp,Tokyo University of Science,Education
 tusass.gl,Tusass Greenland,ISP
 tusd1.org,Tucson Unified School District,Education
+tushino.com,Tushino Telecom,ISP
 tussa.no,Tussa IKT,ISP
 tuve.fi,TUVE / Finnish State ICT Centre,Government
 tuwien.ac.at,TU Wien,Education
@@ -8867,12 +9654,16 @@ tvcabo.ao,TV Cabo,ISP
 tvcabo.mz,TVCabo Mozambique,ISP
 tvcassis.com.br,TVC de Assis (Cabonnet),ISP
 tvepa.com,Tallahatchie Valley Internet (TVEPA),ISP
+tversvyaz.ru,Rostelecom,ISP
 tvhost.ru,Sky@Net (TVHost),ISP
 tvk.pl,TVK Telka,ISP
 tvk.wroc.pl,TVK Telka,ISP
+tvkhajnowka.pl,Telewizja Kablowa Hajnowka,ISP
+tvn.net,Trenton Telephone Company,ISP
 tvoe.tv,TKT (Tvoe.tv),ISP
 tvpublica.com.ar,TVP,ISP
 tvsatrm.ro,TVSat Romania,ISP
+tvt.es,Avatel TVT,ISP
 tvymas.co,TV&MÁS,ISP
 tw1.com,Transworld Associates Pakistan,ISP
 twilio.com,Twilio,SaaS
@@ -8905,6 +9696,7 @@ u-tokyo.ac.jp,University of Tokyo,Education
 u-toyama.ac.jp,University of Toyama,Education
 u.com.my,U Mobile Malaysia,ISP
 u1host.com,U1 Digital Services,Web Host
+u9.com.mm,Nine Communications,ISP
 ua.edu,University of Alabama,Education
 uab.edu,The University of Alabama at Birmingham,Education
 uabc.edu.mx,Universidad Autonoma de Baja California,Education
@@ -8943,6 +9735,7 @@ ucdavis.edu,UC Davis,Education
 ucdenver.edu,University of Colorado Denver,Education
 ucell.uz,Ucell,ISP
 ucf.edu,University of Central Florida,Education
+uchc.edu,University of Connecticut Health Center,Education
 uchealth.com,UC Health,Healthcare
 uchicago.edu,University of Chicago,Education
 uchile.cl,Universidad de Chile,Education
@@ -8976,6 +9769,7 @@ udg.mx,Universidad de Guadalajara,Education
 udlap.mx,Universidad de las Americas Puebla,Education
 udm.ru,UDM Izhevsk,ISP
 udomain.hk,UDomain,Web Host
+udsm.ac.tz,University of Dar es Salaam,Education
 udusok.edu.ng,Usmanu Danfodiyo University,Education
 uel.br,Universidade Estadual de Londrina,Education
 uen.org,Utah Education Network,Education
@@ -8998,6 +9792,7 @@ ug-tele.com,UG-Telecom Serpukhov,ISP
 ug.edu.gh,University of Ghana,Education
 uga.edu,University of Georgia,Education
 ugmk-telecom.ru,UGMK-Telecom,ISP
+ugni.net,United Network Infrastructure,ISP
 ugto.mx,Universidad de Guanajuato,Education
 uh.edu,University of Houston,Education
 uhc.com,United Healthcare,Healthcare
@@ -9030,6 +9825,7 @@ ulsan.ac.kr,University of Ulsan,Education
 ultahost.com,UltaHost,Web Host
 ultimate-guitar.com,Ultimate Guitar,Entertainment
 ultimatedomain.hosting,Ultimate Domain Hosting,Web Host
+ultisat.com,Globecomm Services Maryland,MSP
 ultra.one,UltraOne,ISP
 ultralinkce.com.br,Ultralink,ISP
 ultralinkweb.com.br,Ultralink Telecom,ISP
@@ -9047,6 +9843,7 @@ umass.edu,UMass Amherst,Education
 umassd.edu,University of Massachusetts Dartmouth,Education
 umassmed.edu,UMass Chan Medical School,Education
 umbc.edu,"University of Maryland, Baltimore County",Education
+umbrellar.com,Umbrellar,MSP
 umcs.pl,Maria Curie-Sklodowska University,Education
 umd.edu,University of Maryland,Education
 umflint.edu,University of Michigan-Flint,Education
@@ -9062,6 +9859,7 @@ umnyeseti.ru,Umnyeseti,ISP
 umt.edu,University of Montana,Education
 umtelecom.com.br,Um Telecom,ISP
 umu.se,Umea University,Education
+unacs.bg,Unacs,ISP
 unal.edu.co,Universidad Nacional de Colombia,Education
 unam.mx,Universidad Nacional Autónoma de México,Education
 unav.edu,Universidad de Navarra,Education
@@ -9098,6 +9896,7 @@ unicajabanco.es,Unicaja,Finance
 unicamp.br,Unicamp,Education
 unicanetworking.com.br,Única Networking,ISP
 unicreditgroup.eu,UniCredit,Finance
+unicsbg.net,Unics,ISP
 unidata.it,Unidata,ISP
 unifesp.br,Universidade Federal de Sao Paulo,Education
 unifiedlayer.com,UnifiedLayers,Web Host
@@ -9133,8 +9932,10 @@ unitel.ao,Unitel Angola,ISP
 unitel.com.la,Unitel,ISP
 unitel.mn,Unitel Mongolia,ISP
 unitelco.com.br,Universal Telecom Brazil,ISP
+unitelme.com,Direct Communications,ISP
 uniteprivatenetworks.com,Unite Private Networks,ISP
 uniti.com,Uniti,MSP
+unittel.ru,Unittel,ISP
 unity-health.org,Unity Health,Healthcare
 unityhealth.org,Unity Health,Healthcare
 univac.com.sg,Univac,Industrial
@@ -9142,6 +9943,7 @@ univates.br,Univates,Education
 universal-shoji.co.jp,Universal Shoji,Industrial
 universalmusic.com,Universal Music Group,Entertainment
 univie.ac.at,University of Vienna,Education
+uniwa.gr,University of West Attica,Education
 uniwisp.co.za,UniWISP,ISP
 unix-solutions.be,Unix-Solutions,Web Host
 unlp.edu.ar,Universidad Nacional de La Plata,Education
@@ -9188,7 +9990,9 @@ uq.edu.au,University of Queensland,Education
 uqac.ca,Universite du Quebec a Chicoutimi,Education
 ural-net.ru,inetvdom,ISP
 ural.net,Ural Regional Net,ISP
+uran.ua,URAN,Education
 uregina.ca,University of Regina,Education
+urfu.ru,Ural Federal University,Education
 uri.edu,University of Rhode Island,Education
 urupesnet.com.br,UrupêsNet,ISP
 us-cloud.top,Arosscloud (Uscloud),Web Host
@@ -9280,6 +10084,7 @@ uwo.ca,University of Western Ontario,Education
 uws.edu.au,Western Sydney University,Education
 uww.edu,University of Wisconsin-Whitewater,Education
 uwyo.edu,University of Wyoming,Education
+uz.zgora.pl,Uniwersytet Zielonogorski,Education
 uzpak.uz,uzpak.uz,Industrial
 v-sys.org,VSYS Host,Web Host
 v0.build,Vercel,PaaS
@@ -9292,18 +10097,26 @@ valero.com,Valero,Industrial
 valley-widehealth.org,Wally-Wide Health,Healthcare
 valleyfiber.ca,Valley Fiber,ISP
 valorc3.com,ValorC3 Data Centers,Web Host
+valorit.net,Valor Information Technologies,MSP
 valverde.edu,Val Verde Unified School District,Education
+valvesoftware.com,Valve,Entertainment
+vancis.nl,Vancis Advanced ICT Services,MSP
 vandadvira.com,Vandad Vira Hooman,Web Host
 vanderbilt.edu,Vanderbilt University,Education
 vanderbilthealth.com,Vanderbilt Health,Healthcare
+vanguard.com,Vanguard,Finance
 vantagepnt.com,Vantage Point Solutions,ISP
 vanwerthospital.org,Van Wert Health,Healthcare
+varity.nl,Trans-iX,MSP
 varnamoenergi.se,Varnamo Energi,Utilities
+varnion.com,"Varnion Technology Semesta, PT",ISP
 varzeanet.com.br,Varzea Net,ISP
 vassar.edu,Vassar College,Education
 vaultica.com,Vaultica,Web Host
 vautron.de,Vautron Rechenzentrum,Web Host
+vaxxine.com,Vaxxine Computer Systems,ISP
 vccs.edu,Virginia Community College System,Education
+vch.ca,Vancouver Coastal Health,Healthcare
 vck-gmbh.de,Vestische Caritas-Klinike,Healthcare
 vcn.com,Visionary Broadband,ISP
 vcoe.org,Ventura County Office of Education,Education
@@ -9314,6 +10127,7 @@ vdonsk.ru,Microel,ISP
 vdsina.com,VDSina,Web Host
 vdsina.ru,VDSina,Web Host
 vdska.online,VDSka,Web Host
+vdtcomms.com,VDT Communications,ISP
 vea.coop,Valley Electric Association,Utilities
 vectorfibre.co.nz,Vector Fibre,ISP
 vectra.pl,Vectra,ISP
@@ -9322,6 +10136,7 @@ vedco.com,Vedco,Healthcare
 vee.com.tw,VeeTIME,ISP
 veesp.com,Veesp,Web Host
 veetime.com,VeeTIME,ISP
+vega-int.ru,Vega-Internet,ISP
 veganet.com.tr,Veganet,ISP
 vegans.it,vegan/s,MSP
 vegatele.com,Vegatele (Farlep-Invest),ISP
@@ -9344,6 +10159,7 @@ vercel.app,Vercel,PaaS
 vercel.com,Vercel,PaaS
 vercel.dev,Vercel,PaaS
 vercel.run,Vercel,PaaS
+vercom.pl,Vercom,SaaS
 verde.ag,Verde Agritech,Agriculture
 vereinigte-stadtwerke.de,Vereinigte Stadtwerke,ISP
 verginia.edu,University of Virginia,Education
@@ -9360,6 +10176,7 @@ verobroadband.com,Vero Fiber,ISP
 verointernet.com.br,Internet de Verdade,ISP
 versanet.de,1&1 Versatel,ISP
 vertikal6.com,Vertikal6,MSP
+vertv.com.br,Ver Tv Comunicações,ISP
 veseli.cz,The city of Veseli nad Luznici,Government
 vetorial.net,Vetorial Internet,ISP
 vexusfiber.com,Vexus Fiber,ISP
@@ -9368,6 +10185,9 @@ vgonline.com,Video Graphics,Web Host
 vgpinternet.net.br,VGP Internet,ISP
 vgregion.se,Västra Götalandsregionen,Government
 vgscom.ru,VGS (Gorset Vladimir),ISP
+vh-global.net,VH Global,MSP
+via.net,ViaNet,ISP
+viaccc.com,CCC (Compañía de Circuitos Cerrados),ISP
 viaccess.net,ONE Communications,ISP
 viaeuropa.net,ViaEuropa,ISP
 vialis.net,Vialis,ISP
@@ -9377,6 +10197,7 @@ viananet.net.br,VianaNet,ISP
 vianet.ca,Vianet,ISP
 vianet.com.np,Vianet Communication Nepal,ISP
 vianova.it,Vianova,ISP
+viapass.com,VIAPASS,ISP
 viarezo.fr,ViaRézo (CentraleSupélec),Education
 viasat.com,Viasat,ISP
 viasul.net.br,Via Sul,ISP
@@ -9385,6 +10206,7 @@ viawest.com,Flexential,Web Host
 vibconexao.com.br,Vib Conexão,ISP
 vibrantwellnessvoyage.com,Vibrant Wellness Voyage,Healthcare
 vicc.co,Venco Imtiaz Contracting Co,Industrial
+victoria.ac.nz,Victoria University of Wellington,Education
 victorkaiser.com,Global Transport,Logistics
 vidanet.hu,ViDaNet,ISP
 vidaoptics.com,Vida Optics,ISP
@@ -9392,6 +10214,7 @@ video-broadcast.at,Video-Broadcast,ISP
 videotron.ca,Videotron,ISP
 videotron.com,Videotron,ISP
 viecuri.nl,VieCuri,Healthcare
+viennaweb.at,Johann Baldermann,Web Host
 viethwebhosting.com,MemberLeap,Web Host
 vietserver.vn,VietServer,Web Host
 viettel.com.vn,Viettel,ISP
@@ -9412,6 +10235,7 @@ vipfibertelecom.com.br,VIP Fiber,ISP
 vipowernet.net,ONE Communications,ISP
 vipre.com,VIPRE,Email Security
 vipturbo.com.br,VIPTURBO,ISP
+vipway.net.br,VIPWAY,ISP
 virginia.edu,The University of Virginia,Education
 virginia.gov,The State of Virginia,Government
 virginm.net,Virgin Media,ISP
@@ -9421,6 +10245,7 @@ virginmediabusiness.co.uk,Vergin Media Business,ISP
 virginmobile.ca,Virgin Plus,ISP
 virginplus.ca,Virgin Plus,ISP
 virgohosting.net,Virgo Hosting,Web Host
+virmach.com,Virtual Machine Solutions,IaaS
 virtela.net,NTT Communications,ISP
 virtex.com.br,Virtex Telecom,ISP
 virtru.com,Virtu,Email Security
@@ -9439,6 +10264,7 @@ virtutel.com.au,Virtutel,ISP
 visa.com,Visa,Finance
 visabeira.co.ao,COMATEL,ISP
 visi.com,US Signal,MSP
+visionarybroadband.com,Visionary Communications,ISP
 visitmiddlesex.ca,"Middlesex County, Canada",Government
 vismap.it,Industrie Vismap,Retail
 vistabroadband.com,Vista Broadband,ISP
@@ -9461,10 +10287,13 @@ vk.com,VK,Social Media
 vk.company,VK,Social Media
 vladinfo.ru,Vladinfo,ISP
 vladlink.ru,Vladlink,ISP
+vline.pl,Toya,ISP
+vltele.com,Ufanet,ISP
 vm.bytemark.co.uk,Bytemark,Web Host
 vm.co.mz,Vodacom Mozambique,ISP
 vmedia.ca,VMedia,ISP
 vmi.edu,Virginia Military Institute,Education
+vmiss.ca,VMISS,IaaS
 vnet.sk,VNET Slovakia,ISP
 vnet.su,VNet,ISP
 vng.com.vn,VNG Online,SaaS
@@ -9475,10 +10304,12 @@ vnr.de,VNR Group,SaaS
 vnrgroup.com,VNR Group,SaaS
 vntelecom.com.br,VN Telecom,ISP
 vo.lu,Visual Online Luxembourg,ISP
+voanet.com.br,VOANET,ISP
 voartelecom.com.br,Voar Telecom,ISP
 vocalocity.com,Vonage Business (Vocalocity),SaaS
 vocetelecom.com.br,Voce Telecom,ISP
 vocom.com,Vocom International,ISP
+voconnect.co.za,VOffice Solutions,ISP
 vocus.co.nz,2degrees,ISP
 vocus.com.au,Vocus,ISP
 vodacom.co.ls,Vodacom Lesotho,ISP
@@ -9511,6 +10342,7 @@ vodafoneidea.com,Vi,ISP
 vodien.com,Vodien,Web Host
 voe.ch,VOe Multimedia,ISP
 voicehost.co.uk,VoiceHost,PaaS
+voip-unlimited.net,VOIP-UN,ISP
 voip.kz,Voip Kazakhstan Network,ISP
 voith.com,Voith,Industrial
 volcano.net,Volcano Communications,ISP
@@ -9518,8 +10350,11 @@ volcengine.com,Volcengine (ByteDance),IaaS
 volhighspeed.at,VOLhighspeed,ISP
 volia.com,Volia,ISP
 volico.com,Volico Data Centers,Web Host
+volkswagenag.com,Volkswagen,Automotive
 volkswagengroupamerica.com,Volkswagen of America,Automotive
+volo.net,Volo Broadband,ISP
 volstate.net,IT Voice,MSP
+volta.net.pl,Volta Communications,ISP
 voltbb.com,Volt Broadband,ISP
 voluy.com.br,Voluy Telecom,ISP
 volvo.com,Volvo,Manufacturing
@@ -9529,7 +10364,9 @@ voo.be,VOO,ISP
 voonami.com,Voonami,MSP
 vootelecom.com.br,Voo Telecom,ISP
 vorboss.com,Vorboss,ISP
+vortexnetsol.com,Vortex Netsol Private,ISP
 vosnet.ru,Home.Net Voskresensk,ISP
+vostrom.com,VOSTROM,MSSP
 vote4mentalhealth.org,NAMI,Healthcare
 votervoice.net,VoterVoice,SaaS
 voxdsl.co.za,Vox Telecom,ISP
@@ -9552,8 +10389,10 @@ vt.edu,Virginia Tech,Education
 vtal.com,V.tal,ISP
 vtc.vn,VTC Digicom,Government Media
 vtel.jo,VTEL Jordan,ISP
+vtelecom.pl,Virtual Telecom,ISP
 vtelecom.ru,Vostoktelecom,ISP
 vtext.com,Verizon SMS,ISP
+vtg.at,VTG,MSP
 vtgus.com,Virtual Technologies Group,MSP
 vtr.com,VTR,ISP
 vtr.net,VTR,ISP
@@ -9569,6 +10408,7 @@ vusercontent.net,Vercel,PaaS
 vut.cz,Brno University of Technology,Education
 vutbr.cz,Brno University of Technology,Education
 vwhs.org,Valley-Wide Health,Healthcare
+vxtream.com,vXtream,IaaS
 vyvebroadband.com,Vyve Broadband,ISP
 vyvebroadband.net,Vyve,ISP
 wa-k20.net,Washington K-20 Network,Education
@@ -9607,10 +10447,12 @@ wavenet.co.uk,Wavenet,ISP
 wavenetuk.net,Wavenet,MSP
 waveruralconnect.com,Wave Rural Connect,ISP
 wavetech.co.za,WaveTech,Industrial
+wavex.co.ke,Wavex Internet Service Provider,ISP
 waxcreative.com,Waxcreative Design,Marketing
 waypointcentre.ca,Waypoint Centre,Healthcare
 wbhcp.com,Williams Bros Pharmacy,Healthcare
 wbroadband.net.au,Wholesale Communications Group,ISP
+wci.com,Allstream,ISP
 wcoil.com,Watch Communications,ISP
 wconect.com.br,WCONECT,ISP
 wctatel.com,WCTA Winnebago Cooperative Telecom,ISP
@@ -9639,7 +10481,9 @@ webair.com,Webair Internet Development,Web Host
 webbingsolutions.com,Webbing,ISP
 webbytelecom.com.br,Webby Internet,ISP
 webd.pl,WEBD.PL,Web Host
+webdade.com,Web Dadeh Paydar,Web Host
 webdiscount.net,Webdiscount,Web Host
+webdock.io,Webdock.io,IaaS
 webe.com.my,Unifi (webe Digital),ISP
 webetic.net,Webetic,Web Host
 webex.com,Cisco Webex,SaaS
@@ -9678,8 +10522,11 @@ webspaceconfig.de,Mittwald,Web Host
 websupport.se,Websuport,Web Host
 websupport.sk,Websupport,Web Host
 websurfer.com.np,Websurfer Nepal,ISP
+webtasy.com,Webtasy,Web Host
+webtrekk.com,Mapp,Marketing
 webwerks.in,Iron Mountain Data Centers,IaaS
 webworld.ie,WebWorld Ireland,Web Host
+webyne.com,Webyne Data Centre Private,IaaS
 webzi.mx,Webzi,Web Host
 webzilla.com,Webzilla,Web Host
 webzine1.com,Webzine Online,Web Host
@@ -9688,7 +10535,10 @@ wecenergygroup.com,WEC Energy,Utilities
 weclix.com.br,Weclix,ISP
 weconnect.tech,Connect Managed Services,MSP
 weendeavor.com,Endeavor Communications,ISP
+wekudata.se,Wekudata,IaaS
 welcomeitalia.it,Vianova,ISP
+weld.co.us,Weld County Government,Government
+well-comm.ru,Wellcom,ISP
 well.com,The WELL,Email Provider
 wellesley.edu,Wellesley College,Education
 wellington.com,Wellington Management,Finance
@@ -9699,6 +10549,7 @@ wemacom-breitband.de,WEMACOM Breitband,ISP
 wemaconnect.de,Wemaconnect,ISP
 wescor.com,ELITechGroup,Healthcare
 weserve.nl,Weserve,ISP
+weservit.nl,RouteLabel V.O.F,IaaS
 wesleyan.edu,Wesleyan University,Education
 wessexinternet.com,Wessex Internet,ISP
 westbrook.ms,Westbrook Construction,Construction
@@ -9709,10 +10560,12 @@ westcoastinternet.com,West Coast Internet (WCI),ISP
 westdc.net,WestHost,Web Host
 westianet.com,Western Iowa Networks,ISP
 westmancom.com,Westman Communications,ISP
+westnet.ie,Westnet Broadband Mayo,ISP
 westpac.com.au,Westpac,Finance
 westriv.com,WRT,ISP
 weverfastfiber.com,Everfast Fiber Networks,ISP
 wewehost.com,WeWeHost,Web Host
+wexnet.se,Vaxjo Kommun,Government
 wexzone.com,WexZone,Web Host
 wf.net,Web Fire Communications,MSP
 wfn.ca,Westbank First Nation,Government
@@ -9735,11 +10588,14 @@ whizcomms.com.sg,WhizComms,ISP
 whmpanels.com,WHM Panels,Web Host
 who.int,World Health Organization,Nonprofit
 whoi.edu,Woods Hole Oceanographic Institution,Science
+wholesaleconnections.nl,Wholesale Connections,ISP
 wholesaleinternet.net,WholeSale Internet,ISP
 whplanet.com,WH Planet Web Hosting,Web Host
 wi-fiber.io,Wi-Fiber,ISP
 wi.gov,The State of Wisconsin,Government
+wia.co.tz,WIA Tanzania,ISP
 wia.cz,WIA Telecommunications,ISP
+wiber.com.ar,Wiber Internet,ISP
 wicam.com.kh,WiCAM Cambodia,ISP
 wichita.edu,Wichita State University,Education
 wicity.it,WicitY,ISP
@@ -9756,9 +10612,11 @@ wightfibre.com,WightFibre,ISP
 wightman.ca,Wrightman Telecom,ISP
 wigner.hu,Wigner Research Centre for Physics,Science
 wiit.cloud,WIIT,IaaS
+wiitgroup.com,WIIT,IaaS
 wikitelecom.com.br,Wki Telecom,ISP
 wiktel.com,Wiktel Wikstrom,ISP
 wiland.ru,Wiland,ISP
+wildcard.net.uk,Wildcard UK,ISP
 wildpark.net,WildPark,ISP
 wilhelm-tel.de,wilhelm.tel,ISP
 wiline.com,WiLine Networks,ISP
@@ -9777,6 +10635,7 @@ win.be,Win Belgium,ISP
 win.pe,Win Telecom Peru,ISP
 wind.com.do,WIND Telecom,ISP
 wind.it,WINDTRE,ISP
+windmobile.ca,Vidéotron,ISP
 windriver.com,Wind River,SaaS
 windstream.net,Windstream,ISP
 windtre.it,WINDTRE,ISP
@@ -9785,6 +10644,8 @@ wingo.ch,Wingo,ISP
 winknet.ne.jp,Himeji Cable Television,ISP
 winnermedical.com,Winner Medical,Healthcare
 wintek.com,Wintek,ISP
+wiocc.net,West Indian Ocean Cable Company,ISP
+wipet.com,Liberty Technologies,ISP
 wire3.com,Wire 3,ISP
 wiredblade.com,Wired Blade,Web Host
 wiredisp.com,WiredISP,ISP
@@ -9802,11 +10663,14 @@ wise.net.lb,WISE,ISP
 wishisp.com,Priority of Fashion ISP,ISP
 wishnet.co.in,Wish Net,ISP
 wisperisp.com,Wisper,ISP
+witcom.de,WiTCOM Wiesbadener Informations- und Telekommunikations,Utilities
+witelecom.com.br,WI de,ISP
 wiu.edu,Western Illinois University,Education
 wix.com,Wix,SaaS
 wixsite.com,Wix,SaaS
 wixstudio.com,Wix,SaaS
 wixstudio.io,Wix,SaaS
+wizard.de,Wizard Computersysteme,MSP
 wizmoworks.com,Wizmo,MSP
 wjhtedu.com,Beijing WangJu,ISP
 wktelecom.net.br,WK Telecom,ISP
@@ -9830,6 +10694,7 @@ wntpr.net,WorldNet Telecommunications,ISP
 wobcom.de,Wobcom Wolfsburg,ISP
 wockhardt.com,Wockhardt,Healthcare
 wolfpaw.com,Wolfpaw Data Centres,Web Host
+wolfram.com,Wolfram,SaaS
 wolnet.it,Wolnet,ISP
 wolseleyinc.ca,Wolseley Canada,Industrial
 wolve.com,Wolverine Trading,Finance
@@ -9858,6 +10723,7 @@ worldline.com,Worldline,SaaS
 worldlink.com.np,WorldLink Communications,ISP
 worldnetpr.com,WorldNet Telecommunications,ISP
 worldphone.in,World Phone India,ISP
+worldspice.net,WorldSpice,ISP
 worldstream.com,Worldstream,Web Host
 worria.com,Cloudie,Web Host
 worthingtonenterprises.com,Worthington Enterprises,Manufacturing
@@ -9883,13 +10749,16 @@ wtctx.com,WesTex Connect (Telstar1),ISP
 wtvk.pl,Winogradzka Telewizja Kablowa,ISP
 wu-wien.ac.at,Vienna University of Economics and Business,Education
 wustl.edu,Washington University in St. Louis,Education
+wvnet.at,WVNET Information und Kommunikation,ISP
 wvnet.edu,WVNET,Education
 wvu.edu,West Virginia University,Education
 wvusd.k12.ca.us,Walnut Valley Unified School District,Education
+wwt.net,West Wisconsin Telcom,ISP
 wwu.edu,Western Washington University,Education
 www.nic.in,National Informatics Centre,Government
 wwwowww.co.za,wwwOwww,Marketing
 wwz.ch,WWZ,Utilities
+wyandotte.net,City of Wyandotte,Government
 wylance.com,Emma Solutions (Formerly Wylance),MSP
 wyo.gov,State of Wyoming,Government
 wyocore.com,Wyocore Technologies,Web Host
@@ -9906,8 +10775,10 @@ xbiz.ne.jp,Xserver,Web Host
 xcelenergy.com,Xcel Energy,Utilities
 xceleratorsoftware.com,Key Software Systems Xcelerator,SaaS
 xchangetelecom.com,Skywire (Xchange Telecom),ISP
+xcien.com,XCIEN,ISP
 xcitium.com,Xcitium,SaaS
 xecu.net,Xecunet,MSP
+xefi.fr,XEFI,MSP
 xen.prgmr.com,prgmr.com,Web Host
 xerox.com,Xerox,Technology
 xfernet.com,Xfernet,Web Host
@@ -9943,6 +10814,7 @@ xtfibra.com.br,XT Fibra,ISP
 xtglobal.vg,XT Global Networks,ISP
 xtom.com,xTom,IaaS
 xtrim.com.ec,Xtrim,ISP
+xtudionetcore.com,XNET Core,MSP
 xturbo.com.br,Xturbo,ISP
 xxlnet.nl,XXLnet,ISP
 xyzservers.com,XYZ Servers,Web Host
@@ -9963,10 +10835,13 @@ yandex.net,Yandex,Email Provider
 yandexcloud.net,Yandex Cloud,IaaS
 yardi.com,Yardi,SaaS
 yarnet.ru,Yarnet,ISP
+yarteleservice.ru,YarTeleservice,ISP
 yas.mg,Yas,ISP
 yas.sn,Yas Senegal,ISP
 yas.tg,Yas Togo,ISP
+yatanarpon.net.mm,Yatanarpon Teleport,ISP
 yecaoyun.com,Yecaoyun (LucidaCloud),Web Host
+yelcot.com,Yelcot Telephone Company,ISP
 yellow-inbox.com,Yellow Imbox,Marketing
 yellowinbox.com,Yellow Imbox,Marketing
 yelpcorp.com,Yelp,Social Media
@@ -9979,6 +10854,7 @@ yisu.com,Yisu Cloud,Web Host
 ykwc.com,Yellowknife Wireless,ISP
 ync.ac.kr,Yeungnam College of Science Technology,Education
 ynu.ac.kr,Yeungnam College of Science Technology,Education
+yokozunanet.mn,Yokozunanet,ISP
 yonsei.ac.kr,Yonsei University,Education
 yorku.ca,York University,Education
 yotta.com,Yotta Network Services,IaaS
@@ -9991,6 +10867,7 @@ yourconnect.com,Yourconnect,Web Host
 yourhosting.nl,Yourhosting,Web Host
 yourhostingaccount.com,Newfold Digital,Web Host
 yourmailgateway.de,netcup,Web Host
+yournorthland.com,Vyve Broadband,ISP
 yoursitesecure.net,REDCITEL,Physical Security
 ysu.edu,Youngstown State University,Education
 ytelecom.com.br,Hootix Telecom,ISP
@@ -10008,7 +10885,9 @@ z.com,Z.com,Web Host
 zaansmc.nl,Zaans Medical Center,Healthcare
 zaansmedischcentrum.nl,Zaans Medical Center,Healthcare
 zaaztelecom.com.br,Zaaz Telecomunicacoes,ISP
+zafirotelecom.com,Informatica Fuentealbilla,ISP
 zain.com,Zain,ISP
+zainomantel.com,Zain Omantel International,ISP
 zajil.com,KEMS,ISP
 zamix.com.br,Zamix Multiplay,ISP
 zamren.zm,ZAMREN,Education
@@ -10016,6 +10895,7 @@ zamtel.zm,Zamtel,ISP
 zap-hosting.com,ZAP-Hosting,Web Host
 zap.cloud,ZAP-Hosting,Web Host
 zap.co.ao,ZAP,ISP
+zappiehost.com,Zappie Host,IaaS
 zapto.org,No-IP,Web Host
 zaq.ne.jp,ZAQ,Email Provider
 zare.com,Zare,Web Host
@@ -10032,6 +10912,7 @@ zebra.lt,15min,News
 zecnet.com.br,ZEC-NET,ISP
 zedality.com,Zedality,Web Host
 zen.co.uk,Zen Internet,ISP
+zenex5ive.com,Zenex 5ive,IaaS
 zenlayer.com,Zenlayer,IaaS
 zentrointernet.com,Zentro Internet,ISP
 zeonet.co.in,Zeonet,ISP
@@ -10051,6 +10932,7 @@ zid.com,ZiD Internet,ISP
 ziggo.nl,Ziggo,ISP
 ziggozakelijk.nl,Ziggo,ISP
 zillion.network,Zillion Network,ISP
+zimcom.net,Zimcom Network Solutions,IaaS
 zimonline.co.za,Zimbabwe Online,ISP
 zinca.com,Zinca (Cesena Net),ISP
 ziplyfiber.com,Ziply Fiber,ISP
@@ -10063,6 +10945,7 @@ zixsmbhosted.com,Zix,Email Security
 zixworks.com,Zix,Email Security
 zjtelecom.com.cn,China Telecom,ISP
 zlidc.net,Zhilian Technology IDC,Web Host
+znet.com.ua,Znet,ISP
 zoho.com,Zoho,SaaS
 zoho.com.au,Zoho,SaaS
 zoho.eu,Zoho,SaaS

--- a/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
+++ b/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
@@ -5,6 +5,7 @@
 140-pgftelecom.com.br
 182-airtel.com
 19-connectba.com.br
+1cent.host
 1host.cc
 1jli.site
 228-netco.uz
@@ -36,6 +37,7 @@
 9services.com
 a2-cross.asia
 a2u2.com
+a5.com
 a7e.ru
 a94434500-blog.com
 aaaamath.com
@@ -47,6 +49,7 @@ aams8.jp
 abcle.co.kr
 abcom.al
 abed-tahan.com
+abhinawanetwork.com
 abmtelecom.net.br
 aboba67139protonmail.com
 abolishpropertytaxes.com
@@ -156,6 +159,7 @@ alyrica.net
 alzewayed.com
 ama.pf
 amaazingcoach.com
+amanah.com
 amatureswingers.com
 ambyrenodes.net
 americanannex.com
@@ -183,11 +187,13 @@ antis.edu
 antonaoll.com
 anviklass.org
 anwrgrp.lat
+anyconnecting.com
 anythingemail.com
 anzamanagement.com
 aogss.ru
 aosau.net
 aparadiserental.com
+apeironco.com
 apexihl.com
 api-db.com
 apollomech.com
@@ -214,11 +220,13 @@ arpa-hireachdns.com
 arpa-mithriltele.net
 arpa.db
 arrow.com
+artofautomation.net
 arts-n-craftshardware.com
 artspan.com
 aryva.com.ar
 as15758.net
 as18186.com
+as215727.net
 as262543.net.br
 as28220.net
 as328576.net
@@ -226,6 +234,7 @@ as35100.net
 as51129.net
 as55850.net
 as63182.net
+as835.net
 asahachimaru.com
 asahi-hp.jp
 asbaumhosting.com
@@ -236,9 +245,11 @@ ashrapidslodge.com
 asiaituhost.com
 asiawhere.com
 asicontrols.com
+asj.ad.jp
 asj.ne.jp
 askartechsolutions.com
 asline.net
+asmanfaraz.com
 asmecam.it
 asphostserver.org
 astratelekom.com
@@ -270,6 +281,7 @@ avi-on.cam
 aviccable.com
 avistaadvantage.com
 avonet.cz
+avur.no
 awesomestore.shop
 awxsites.com
 axway.net
@@ -293,6 +305,7 @@ balsabandits.com
 banaras.co
 bandalargaupnet.com.br
 barbhudson.com
+barebox.com.bd
 basefarm.net
 baseopedia.net
 bauchi.net
@@ -329,6 +342,7 @@ beveiligdverzonden.nl
 bhfibra.net.br
 bhjui.com
 bho.pl
+bi.lt
 biancalana.us
 biff.org.uk
 bigfibratelecom.com.br
@@ -342,6 +356,7 @@ billetweb.fr
 biocorp.com
 biosophy.net
 bisnet.co.za
+bitgravity.com
 bitmatix.biz
 bitter-echo.com
 bitternet.ua
@@ -398,6 +413,7 @@ brazilianoffers.de
 breezeline.net
 brellatransplc.shop
 bridevibe.hu
+britneighbour.top
 brmais.net.br
 brnonet.cz
 broadwaycover.com
@@ -438,6 +454,7 @@ c5ace.com
 ca-expressive.site
 cableatlantico.com
 cablecolor.com.sv
+cac-cosme.com
 caccaweb.com
 caem-it.co
 cafeelindio.us
@@ -479,6 +496,7 @@ cashflowmasterypro.com
 caspian.trade
 castleaccess.com
 catalystdiscoverysolutions.my
+cateringuk.top
 cavabeen.com
 cbanewname-com.icu
 cbsolt.net
@@ -489,6 +507,7 @@ cchd-wa.org
 cchealthcare.com
 ccidns.net
 ccstv.com.br
+cct-llc.net
 cda.gov.bd
 cdcservices.com
 cdn1000.com
@@ -608,12 +627,14 @@ coloriuris.net
 com.com.br
 com.ru
 combell-ops.net
+comelecservices.com
 commerceinsurance.com
 commufa.jp
 compacta.net.br
 comparepsdns.com
 competitivecleaning.co.uk
 completeweb.net
+compucreations.com
 comsharempc.com
 comsumersearch.com
 concatservices.com
@@ -626,6 +647,7 @@ conexaovm.com.br
 conexiona.com
 conhostdns.com
 connect2b.net
+connected.pl
 consoftmg.com.br
 contabilicoy.co
 contactmusic.net
@@ -680,6 +702,7 @@ crt.fr
 crystallations.com
 csii.com.hk
 cspirefiber.net
+cstechnologies.com
 ct.co.cr
 ctinets.com
 ctk.ne.jp
@@ -701,6 +724,7 @@ cwj.ad.jp
 cyberinternet.net.br
 cyberironclad.com
 cyberwaybd.net
+cyberways.net
 cyboxmail.com
 cznet.com.br
 d-bk.de
@@ -739,6 +763,7 @@ delhaize.be
 delicatesignature.com
 delicious-fukuoka.com
 deliquesce.shop
+deltaepa.coop
 deltahost.com.ua
 democompunera.com
 demos2clients.com
@@ -756,6 +781,7 @@ desmoineshomes.net
 despertadores.shop
 desquamate.shop
 destadfw.com
+desync.com
 detroitarearealestate.com
 detrot.xyz
 dettlaffinc.com
@@ -776,12 +802,14 @@ dieupart.fr
 digi.net.my
 digiactif.net
 digicom-al.net
+digital-all.jp
 digitalcashtrack.com
 digitalsatinternet.com.br
 dima.hu
 dimensionesrl.eu
 dinofelis.cn
 dipelnetfoz.com.br
+dipt.ua
 directcom.com
 directlan.net.br
 directorysecure.com
@@ -838,6 +866,7 @@ dowelldesigngroup.com
 doyenhost.com
 doyoulooklikeyourmate.com
 dpchems.com
+dpunicom.com
 dqt.com.cn
 dr.com.tr
 draffin-tucker.com
@@ -888,6 +917,7 @@ econet.co.ls
 economiceagles.com
 ecova.com
 ecuahosting.net
+edaptivity.com
 edcor.com
 edit.ne.jp
 edmclain.com
@@ -901,6 +931,7 @@ egosimail.com
 eilopu.iki.fi
 einbecker-buergerspital.de
 ejssweets.com
+ekran39.ru
 electricityforum.info
 electronic-consultants.net
 electroplastcr.com
@@ -984,6 +1015,7 @@ ewqsddg.online
 exa.com.mx
 example.com
 exaservers.com
+exatech.ltd
 excbase.com
 exclusiveoffersnow.xyz
 exfy.io
@@ -996,6 +1028,7 @@ expo-catering.com
 exposervers.com-new
 extendcp.co.uk
 extranet.cz
+extride.ad.jp
 eyecandyhosting.xyz
 eyeeighty.us
 ezewebpro.ca
@@ -1012,6 +1045,7 @@ faisal.my
 fakat.net
 famsfundgroup.com
 fangio.net
+farah.jo
 fastcloudpr.net
 faster.com.br
 fastestgrowthreview.com
@@ -1039,6 +1073,7 @@ fiberstate.com
 fibramaxbandalarga.com.br
 fibranetbrasil.net.br
 fibravip.net
+fibrefi.co.za
 fibroidinfo.com
 fibron.br
 ficial.net
@@ -1070,9 +1105,11 @@ flex.ru
 flix.psi.br
 floralands.com
 flourishfusionlife.com
+fly-group.ru
 flynet.com.py
 fnbalaska.com
 fnxtelecom.net.br
+focus.life
 folkanimals.com
 folksfestival.com
 fontele.com.br
@@ -1083,6 +1120,7 @@ forteline.net.br
 fosterheap.com
 fotographix.com
 fotomaury.com
+fourway.biz
 foxfiber.net.br
 foxitsign.com
 foxnew.de
@@ -1130,6 +1168,7 @@ gaysino.net
 gbmooneybooks.com
 gcplearning.com
 gdigitalindia.in
+gds-services.com
 gds.vn
 geekcommerce.net
 geisenhainer.net
@@ -1152,6 +1191,7 @@ gidroagregat-nn.ru
 giganet.net.py
 giganetmg.net.br
 gigantara.net
+gigapacket.net
 gigasat.net.br
 gigasoftsystems.com
 gigidea.net
@@ -1168,6 +1208,7 @@ glenpondia.xyz
 glenporch.cam
 glenverra.shop
 glidesystems.lat
+global-netcore.jp
 globalcapacity.com
 globalglennpartners.com
 globall.net.br
@@ -1177,6 +1218,7 @@ globaltransitsystems.online
 globalvistatech.com
 globetrotgal.info
 globoinfo.net.br
+gmai.com
 gnc.net
 gnd.ro
 gnetelecom.net.br
@@ -1206,6 +1248,7 @@ graytongue.com
 greatestworldnews.com
 greennutritioncare.com
 greenwingtechnology.com
+greywolf.sg
 grfast.com
 gridcomm-plc.com
 groovetherapyam.com
@@ -1223,6 +1266,7 @@ gs-bates.com
 gsbb.com
 gstackhosting.com
 gstsoft.in
+gtnt.ru
 gtt.co.gy
 guardiandigital.com
 guardianswipe.net
@@ -1233,6 +1277,7 @@ gumbolimbo.net
 gumpertz.com
 guru.net.uk
 gutzilla.de
+guzel.net.tr
 gyr-falcon.com
 gzo.com
 h-serv.co.uk
@@ -1352,6 +1397,7 @@ hsoberoibuildtech.com
 hsp.net
 htel.cc
 htlap.com
+htsnet.id
 hubtelecom.com.br
 hubteltelecom.net.br
 hugel.co.kr
@@ -1386,8 +1432,10 @@ icipresent-pro.com
 icipresent-pro.fr
 iconmarketingguy.com
 icontimeclock.com
+icore.com
 icpbounce.com
 icpnet.pl
+idccun.com
 idcfcloud.net
 idcloudhosting.com
 idealconcept.live
@@ -1417,6 +1465,7 @@ imazu-chemical.co.jp
 imjtmn.cn
 immenzaces.com
 imobie.com
+imperial.net.ua
 impey.shop
 improvation.us
 impuls-perm.ru
@@ -1426,6 +1475,7 @@ in2cable.com
 inaka.co.jp
 incentre.net
 incnets.com
+incx.net
 index.or.jp
 indiaonlinehealth.com
 individuallymanagedaccounts.com
@@ -1436,7 +1486,9 @@ industry123.com
 inet.co.kr
 infiniteprofitflow.com
 infinitysrv.com
+infinium.co.uk
 influxreview.com
+infogro.co.za
 infonetconect.net.br
 informratio.com
 infotechcenters.com
@@ -1448,6 +1500,7 @@ ingate.pl
 ingenit.com
 iniciativasonline.com
 inmar-inc.net
+inn.ru
 innernetmarketing.com
 inocweb.com
 inorpel.com.br
@@ -1460,6 +1513,7 @@ intelliwire.net
 intentional-daydreaming.com
 interactivedns.com
 interbat.com
+interbourg.com.ar
 intercom-47-160.pro
 interdata.vn
 interdigi.info
@@ -1478,6 +1532,7 @@ intocpanel.com
 intservers.com
 investgenesis-ai.net
 invisionitbd.com
+invitesys.ro
 ip-147-135-37.us
 ip-15-204-35.us
 ip-15-235-183.net
@@ -1506,14 +1561,17 @@ iranita.com
 irapture.com
 ireo-perigord.com
 irrestal.com
+iserv.net
 isidors.net
 isiline.org
 ismtj.co
 isn.com.ng
 isomedia.com
 ispconecta.com.br
+ispconnected.com
 ispguatemala.com.gt
 ispservices.us
+istqservers.com
 iswhatpercent.com
 isx.net.nz
 it-nextstep.com
@@ -1562,6 +1620,7 @@ jimcoady.net
 jimishare.com
 jjnl1keaq25396.shop
 jjsstitching.com
+jkns.pl
 jlccptt.net.cn
 jlconect.com.br
 jlenterprises.co.uk
@@ -1575,8 +1634,10 @@ journalpost.info
 joyomokei.com
 js-hpbs.jp
 jscndata.com
+jt.iq
 jumanra.org
 jump.bg
+jump.net.uk
 juniornetfibra.com.br
 justlongshirts.com
 justplayer.ne.jp
@@ -1619,6 +1680,8 @@ kitchenaildbd.com
 kkr-ta-hp.gr.jp
 klaomi.shop
 klaviyomail.com
+kli.lt
+kma.net.il
 knkconsult.net
 knockservices.me
 knology.net
@@ -1637,6 +1700,7 @@ krillaglass.com
 ksasaudi.net
 ksnet.com.br
 ktr.or.kr
+ktv-sk.com
 kujtesa.com
 kula.co.mz
 kulttsolutions.co.in
@@ -1692,6 +1756,7 @@ lighthouse-media.com
 lightpath.net
 ligueme.com
 lihamylly.iki.fi
+limericktechnologies.com
 limogesporcelainboxes.com
 lindsaywalt.net
 lineadns.com
@@ -1755,6 +1820,7 @@ luxebidet.com
 luxemburtij.net
 lwegatech.info
 lwl-puehringer.at
+lynk-networks.com
 lynx.net.lb
 lyse.net
 m-sender.com.ua
@@ -1853,6 +1919,7 @@ megalinkbandalarga.com.br
 meganet.net
 meganetscm.net.br
 megasrv.de
+megatel.co.nz
 megaturbointernet.com.br
 mei.co.jp
 melinked.email
@@ -1879,11 +1946,13 @@ mikedunn.life
 milleniumsrv.com
 mindworksunlimited.com
 mine4biz.com
+miramo.cz
 mirasoft.pl
 mirgiga.net
 mirth-gale.com
 misk.com
 misorpresa.com
+miss.net.ba
 missani33.shop
 mitastelecom.com.br
 mitgr81.com
@@ -1933,6 +2002,7 @@ mspnet.pro
 mssco.com
 mtjapan.or.jp
 mts-nn.ru
+mtu.ru
 mucampus.net
 muhnegc.com
 multi.fi
@@ -1944,6 +2014,7 @@ muvdns.com
 mv.ru
 mvftelecom.com.br
 mvisolutions.com
+mvnet.co.id
 mxof.com
 mxserver.ro
 mxt.net.br
@@ -1992,6 +2063,7 @@ navybluesky.com
 ncbb.kz
 ncport.ru
 ncsdi.ws
+nctaiwan.com
 nctu.edu.tw
 ncu.edu.tw
 ndcinternet.com.br
@@ -2013,6 +2085,7 @@ netcell.inf.br
 netcentertelecom.net.br
 netcom.host
 netcom.psi.br
+netcraftersou.com
 netcrew.fi
 netdoor.com
 netfiber.inf.br
@@ -2021,6 +2094,7 @@ netflexbr.com
 netglobal.it
 netglowstudios.pl
 neti.ee
+netird.ad.jp
 netjoin.it
 netkl.org
 netkom.de
@@ -2032,6 +2106,7 @@ netorn.ru
 netrack.ru
 netscan.hu
 netsky.net.br
+netsolir.com
 netstartech.sg
 netsystemrn.com.br
 networkiowa.com
@@ -2049,6 +2124,8 @@ newyorkhonorlodge.com
 newyorkmarketanalytics.com
 nex-tech.com
 nexa.tr
+nexiu.net
+nexqloud.com
 nextadvance.com
 nextdoor.com.eg
 nextlevelinternet.com
@@ -2094,7 +2171,9 @@ nossanettelecom.net.br
 novanetnp.net.br
 novast.com
 novuscom.net
+novuslabslimited.com
 npbnl.net
+nptel.com
 nqntv.com.ar
 nque.com
 ns360.net
@@ -2115,6 +2194,7 @@ nwo.giize.com
 nwonkac.com
 nwwhalewatchers.org
 ny.adsl
+nymlyria.com
 nyt1.com
 nyumc.org
 o-i.hr
@@ -2145,9 +2225,11 @@ ollatelecom.net.br
 ololos.space
 omakase.jp
 omegabrasil.inf.br
+omniaccess.com
 omnifibernet.net
 omprompt.net
 onbuden.shop
+onefone.pl
 onehappydog.us
 onehundredfortywords.com
 onesteppad.info
@@ -2164,6 +2246,7 @@ onumubunumu.com
 opcaonet.com.br
 openaccessjrnl.info
 opentouch.site
+oplink.net
 oppt-ac.fit
 opsmgmt.net
 optic-com.bg
@@ -2253,11 +2336,13 @@ phedx.com
 phhyd.com
 philgregorylaw.us
 phillyfoos.com
+phoenix-dnr.ru
 phonewave.net
 photoselects.com
 piensanet.com
 pigelixval1.com
 pillsnpackagepharmacy.com
+pinehurstbojin.com
 pipefittingsindia.com
 pivot5daily.com
 placedesarts.com
@@ -2296,6 +2381,7 @@ postzaus-home.life
 potia.net
 pottingcompounds.com
 powerconnect.net.br
+powernethk.com
 powersrv.de
 pr-m.eu
 pravnagroup-m.pl
@@ -2305,6 +2391,7 @@ prevail-portal.com
 priawesta.store
 prima.com.ar
 prima.net.ar
+primesecuritycorp.com
 privatedns.biz
 produce.eu.com
 profactura.cl
@@ -2329,6 +2416,7 @@ proxado.com
 proximitychannel.com
 prsei.com
 prtc.net
+prtsystems.net.uk
 pshgroup.net
 psmanaged.com
 psnm.ru
@@ -2396,6 +2484,7 @@ regruhosting.ru
 rejuvana.net
 relaxhouse.shop
 reliablepanel.com
+relline.ru
 reloadhard.com
 renchildbirth.com
 renkus-hainz.com
@@ -2485,11 +2574,13 @@ salon-junior.com
 samentor.com
 samridhiluxuriyaavenue.info
 samsales.site
+samtecoserv.ro
 sandhilldealerservices.com
 sanluisctv.com.ar
 santa-fe.nm.us
 sante-lorraine.fr
 saransk.ru
+sasg.de
 satirogluet.com
 sats.spb.ru
 sauk-rapids.mn.us
@@ -2508,6 +2599,7 @@ sean.taipei
 seaspraymta3.net
 secdeturizmfatih.com
 secoin.ru
+secom.net
 secorp.mx
 sectorshared.net
 secure-svr.jp
@@ -2586,17 +2678,21 @@ simonmosheshvili.com
 simoresta.lt
 simplediagnostics.org
 simtelecomms.com.br
+simtronic.com.au
+sinam.net
 sincroniza.net.br
 sion.net
 siriuscloud.jp
 sisglobalresearch.com
 site4now.net
+sitenetwork.ru
 sitetackle.com
 sixpacklink.net
 sjestyle.com
 sk.uz
 sk004.ru
 skbt.us
+skknet.net
 sko.kz
 skok.cz
 skybroadband.com.ph
@@ -2605,11 +2701,13 @@ skytecnetdns.com.br
 slav.net.ua
 sls-angels.com
 sltelecom.net.br
+sm117.ru
 smallvillages.com
 smart9.net.br
 smartape-vps.com
 smartcity.com
 smartfindslive.com
+smartlinkindia.com
 smartstockboost.com
 smewell.com
 smoothcandles.com
@@ -2633,6 +2731,7 @@ sollutium.com
 solucija.eu
 solusoftware.com
 solutionspal.com
+sontheimer.de
 sopricom.fr
 soultelecom.net.br
 sounditaly.com
@@ -2640,6 +2739,7 @@ sourcedns.com
 sousat.com.br
 southcoastwebhosting12.com
 southsidechild.com
+space.ru
 spacemail.com
 spacenetwork.psi.br
 spamfri.dk
@@ -2659,6 +2759,7 @@ spiritualtechnologies.io
 spkrl.com
 sporthotelalacati.com
 sportsimpressionsonline.com
+sprint.pl
 sprout.org
 srhc.com
 srshta.in
@@ -2688,6 +2789,7 @@ statlerfa.co.uk
 statussecure.com
 steadfastdns.net
 steemchina.com
+stel.it
 sterling.net
 sterlingescrow.org
 sterlinggroupusa.com
@@ -2715,6 +2817,7 @@ sudikub.com
 sugarhosts.net
 suksangroup.com
 sulnet.net.br
+sunnet.ua
 super-dns.net
 supercanal.com.ar
 superdata.vn
@@ -2770,6 +2873,7 @@ techpaperonline.com
 techscape3.com
 techxtrasoft.com
 tecnoadsl.it
+tecnogeneral.it
 tecnoxia.net
 tecweb-us.com
 tedra.es
@@ -2794,6 +2898,7 @@ tenriyorozu.jp
 tenten.vn
 terawiz.com
 terminavalley.com
+teta.eu
 tetrocapital.com
 texasgs.net
 tffenterprises.com
@@ -2813,6 +2918,7 @@ thedx.co.uk
 thegermainetruth.net
 thehandmaderose.com
 theinternetstore.net
+theinternetsubway.us
 thekindsofbusiness.com
 thepushcase.com
 thesaigroup.org
@@ -2852,6 +2958,7 @@ tomcity.net
 tomtelnet.ru
 tondyfree.vip
 tongx.com.tw
+tonquanghuy.com
 tonyscharthub.com
 topdns.com
 topdogwebhost.com
@@ -2872,6 +2979,7 @@ trainhrlearning.com
 transfer-biz.shop
 transylvaniacountytennis.com
 traveleza.com
+travelskyir.com
 trazodoneforsale.online
 treelefthot.com
 tresguerras.com.mx
@@ -2928,6 +3036,7 @@ ucn.org.hk
 ucndns.in
 ucs.ro
 udm.net
+udtonline.com
 uftgt.ru
 ugent.be
 ugtelecom.info
@@ -2936,6 +3045,8 @@ uiyum.com
 ujezd.net
 uknoc.co.uk
 ukontrack.com
+ukr-com.net
+ultel.net
 ultradesic.com
 ultragate.com
 ultrasrv.de
@@ -2967,6 +3078,7 @@ usskilledserve.com
 utopia.ai
 utopiafiber.com
 utopianhomespa.com
+uvensys.de
 v-tal.net.br
 vadlodes.com
 vagebond.net
@@ -3010,8 +3122,10 @@ viaprovedor.com.br
 viartelecom.com.br
 vibrantbb.net
 vibrantwellnesscorp.com
+vicusluxlink.net
 viggoss.com.au
 viking.com
+vikinghost.nl
 vilaebrequin.com
 violin.co.th
 vipnetprovedor.com.br
@@ -3046,6 +3160,7 @@ vst.net.br
 vtal.net.br
 vulterdi.edu
 vvondertex.com
+vxbits.net
 w-link.com
 w1o.com
 wacminus.com
@@ -3197,6 +3312,7 @@ yourciviccompass.com
 yourfinanceforesight.com
 yourinvestworkbook.com
 yoursmartbusinessplan.com
+yrga.ru
 yssh.cam
 yuanlih.com.tw
 yuccahosting.com
@@ -3220,6 +3336,7 @@ zh-with-leisu.com
 zimbramail.cl
 zmml.uk
 znlc.jp
+zray.net
 zsttk.net
 ztomy.com
 zu.edu.kz


### PR DESCRIPTION
## Summary

Continued the MMDB ASN-domain coverage walk into the 14k-10k IPv4-weight band, adding 883 new map entries and 117 new known-unknown entries from the top 1,000 unmapped candidates.

ASN-domain coverage:
- By IPv4 weight: **96.5% -> 96.8%**
- By domain count: **11.0% -> 12.4%**

Composition: ~50 globally-known brands (Vanguard, AIG, Aon, Equifax, Mercedes-Benz USA, BP, BHP, Bechtel, Tetra Pak, Anheuser-Busch, Air Canada, Maersk, NFL, NHL, MGM Resorts, Wolfram, Red Hat, Palo Alto Networks, New Relic, Travelport, Epicor, IQVIA, Dassault Systemes, Disney+, Valve, Seagate, Analog Devices, Renesas, Dow Jones, Lee Enterprises, IGN, Mondadori, AtkinsRealis, Eiffage, Ogilvy, Interpublic, Ooredoo Maldives, MTN Zambia, Movistar Costa Rica, Telekom Romania Mobile, Sparkle, Vodafone Ireland, etc.); ~30 universities and government / state agencies (City of San Jose, City of Phoenix, Bulgarian gov, Region Uppsala, Weld County, Long Beach Unified, Escambia School District, Region 4 ESC, Merced COE, Santa Cruz COE, Politechnika Warszawska, Bogazici, Korean universities, Ural Federal University, etc.); the long tail of regional ISPs / hosters / MSPs / data-center operators classified via MMDB `as_name` + homepage / WHOIS corroboration.

117 added to known-unknown where the two-corroborating-sources bar wasn't met (Cloudflare-blocked sites with privacy-redacted WHOIS, generic-token AS-names with empty homepages, parked domains, etc.). Files remain disjoint per the workflow guardrail.

`sortlists.py` validates clean (types, sort, dedupe). CRLF preserved.

## Test plan
- [x] `python parsedmarc/resources/maps/sortlists.py` exits 0
- [x] `comm -12` of map and known-unknown produces no overlap
- [x] CRLF line endings preserved in `base_reverse_dns_map.csv`
- [x] `find_unknown_base_reverse_dns.py` runs cleanly against the updated lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)