### PR TITLE
docs(AGENTS.md): require fresh branch off origin/master per batch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,26 @@ load_psl_overrides(offline=True)
 assert get_base_domain("host01.netlify.app") == "netlify.app"
 ```
 
+### Starting the next batch
+
+Each batch gets its own branch off `origin/master`. Before starting a new batch:
+
+```bash
+git fetch origin
+git checkout -b <new-batch-name> origin/master
+```
+
+Do not reuse a previous batch's branch — even if it looks like the previous batch is "still pending". If the previous batch's commit has already merged via a PR pushed from elsewhere (a co-worker's session, an unsynced laptop, an earlier Claude session), your local copy of that commit is still sitting on the old branch, and stacking new commits on top makes the new PR conflict with master: the merged commit and your local copy both insert the same map rows at the same sorted positions, so the same lines collide.
+
+If you discover this after the fact (PR shows conflicts and `git diff <local-stale-commit> <upstream-merged-commit> --stat` is empty), recover with:
+
+```bash
+git rebase --onto origin/master <stale-commit> <branch>
+git push --force-with-lease
+```
+
+then trim the PR title and description to reflect just the surviving batch.
+
 ### After a batch merge
 
 - Re-sort `base_reverse_dns_map.csv` alphabetically (case-insensitive) by the first column and write it out with CRLF line endings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,7 +290,15 @@ assert get_base_domain("host01.netlify.app") == "netlify.app"
 
 ### Starting the next batch
 
-Each batch gets its own branch off `origin/master`. Before starting a new batch:
+Before starting a new batch, **check for open PRs that already touch the maps**. Someone else (or another session) may already have a pending batch in flight; running a fresh batch on top duplicates work and splits attention across two competing PRs.
+
+```bash
+gh pr list --state open --search 'base_reverse_dns OR "reverse DNS map"'
+```
+
+If anything comes back, read its diff before starting — wait for it to merge, or coordinate with whoever opened it. Only proceed once the queue is clear.
+
+Each batch then gets its own branch off `origin/master`:
 
 ```bash
 git fetch origin


### PR DESCRIPTION
## Summary
- Add a \"Starting the next batch\" subsection to the reverse-DNS-maps workflow in AGENTS.md.
- Each batch must start from a fresh checkout of origin/master, not from the previous batch's branch.
- Documents the failure mode (PR conflicts when a previous batch merged via an out-of-band PR) and the recovery (\`git rebase --onto origin/master <stale-commit> <branch>\` + force-push).

Hit live this batch in #749 and recovered manually; documenting so the next contributor avoids the trap.

## Test plan
- [x] Section renders correctly in markdown preview
- [x] No code changes; doc-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)