### PR TITLE
Classify reverse DNS map: final cleanup batch + multilingual classifier expansion

### DIFF
--- a/parsedmarc/resources/maps/base_reverse_dns_map.csv
+++ b/parsedmarc/resources/maps/base_reverse_dns_map.csv
@@ -11,6 +11,7 @@ base_reverse_dns,name,type
 099.net.il,099 Primo Communications,ISP
 1-2-1marketing.com,foreUP,SaaS
 1-grid.com,1-grid,Web Host
+1-msp.com,1 MSP,MSSP
 1-msp.net,"Internet de Nuevo Laredo, S.A de C.V.",ISP
 1-net.com.sg,1-Net Singapore,ISP
 1.me,One Crna Gora,ISP
@@ -64,6 +65,7 @@ base_reverse_dns,name,type
 1fbusa.com,1FBU,Education
 1fibra.com.br,1Fibra,ISP
 1fire.de,1fire Hosting,Web Host
+1firstbank.com,FirstBank,Finance
 1gservers.com,1GServers,Web Host
 1mile.co.za,One Mile Telecoms (Pty),ISP
 1n.de,1N,ISP
@@ -151,6 +153,7 @@ base_reverse_dns,name,type
 3dprintingindustry.com,3D Printing Industry,Industrial
 3ds.com,Dassault Systèmes,SaaS
 3dsc.co,3ds Communications,ISP
+3dsn.net,3ds Communications,ISP
 3dtelecom.com.br,3D Telecomunicacoes,ISP
 3dwirelessplus.com,3D Wireless Plus,ISP
 3enet.com.br,3E Telecom,ISP
@@ -232,6 +235,7 @@ base_reverse_dns,name,type
 73s.com.br,73s Telecom,ISP
 76telecom.com.br,76 Telecomunicação,ISP
 777network.net,777 Network Broadband,ISP
+780.ir,Tehran Internet Co,ISP
 7bull.net,7BullNet (MyTek Trading),ISP
 7bulls.com,7bulls,MSP
 7dc.net,7DC.NET,Web Host
@@ -256,6 +260,7 @@ base_reverse_dns,name,type
 8it.ca,Infinite IT Solutions,MSP
 8thfirecommunications.com,8th Fire Communications,ISP
 8x8.com,8x8,SaaS
+911enable.com,ConneXon Telecom,ISP
 911net.com.ua,Провайдер 911NET,ISP
 96335.com,Guangxi Radio & Television,ISP
 99cloudhosting.com,99CloudHosting,Web Host
@@ -320,6 +325,7 @@ aatelekom.com,AA Telekom,ISP
 aaup.edu,Arab American University,Education
 ab-group.biz,AsiaBell,ISP
 ab.kg,Aiyl Bank,Finance
+aba.com,ABA.com,Finance
 aba2net.com,ABA2Net,ISP
 ababank.com,Advanced Bank of Asia,Finance
 abacusgroupllc.com,Abacus Group,Healthcare
@@ -329,6 +335,7 @@ abaricom.co.bw,Abari Communications,ISP
 abaricom.co.mz,Abari Communications Mozambique LDA,ISP
 abasetelecom.com.br,Abase Telecom,ISP
 abastonet.com.ar,abastonet,ISP
+abb-bank.az,ABB,Finance
 abb.com,ABB,Industrial
 abbastelecom.net,Abbas Servicios DE Informatica Y Telecomunicaciones,ISP
 abbatech.com,Abba Technologies,MSP
@@ -358,7 +365,9 @@ abidenet.com.np,Wifi Nepal,ISP
 abilitynetwork.com,Ability Network,Healthcare
 abinet.id,Andal Berjaya Infomedia,ISP
 abissnet.al,Abissnet,ISP
+abitaveraswireless.com,abitaveraswireless.com,ISP
 abix.mx,Abix Ho,ISP
+abkegypt.com,ABK,Finance
 abl.com,Allied Bank,Finance
 ablative.hosting,Ablative Hosting,Web Host
 ablbrasil.com.br,ABL Brasil,Healthcare
@@ -376,6 +385,7 @@ abonet.ro,ABO NET,Web Host
 abonnet.az,ABONNET,ISP
 abranet.net.br,ABRANET- Associação Brasileira de Internet,ISP
 abraxas.ch,Abraxas Informatik,MSP
+abs.am,Global Credit,MSP
 abs.gov.au,Australian Bureau of Statistics,Government
 absa.co.za,Absa,Finance
 absamhost.com.br,AbsamHost Internet Data Center,Web Host
@@ -387,6 +397,7 @@ absolutbank.ru,Absolut Bank,Finance
 absolutehosting.co.za,Absolute Hosting (Pty),Web Host
 absolutetechnologies.net,Absolute Technologies,MSP
 abstract.fi,Abstract,Web Host
+abtbank.com,Adams Bank & Trust,Finance
 abtechtechnologies.com,Abtech Technologies,MSP
 abtecnet.com,Abtec Network Systems,MSP
 abtel.in,Abronics Communications,ISP
@@ -593,9 +604,11 @@ adaptivedatanetworks.com,Adaptive Data Networks,MSP
 adau.net.id,AdauNet,ISP
 adbl.gov.np,Agricultural Development Bank,Government
 adbnetinformatica.com.br,Adbnet Telecom,ISP
+adc.co.th,"Advance Datanetwork Communications Co.,Ltd. BuddyB service. Bangkok",ISP
 adc.net.ar,Aguas del Colorado,Utilities
 adcb.com,Abu Dhabi Commercial Bank PJS,Finance
 adcdata.com,Adcdata,Web Host
+adcl.co.nz,ADC,Web Host
 adcstack.com,ADC Group,Web Host
 addaxtelecom.com.br,Addax Telecomunicacoes,ISP
 addiko.si,Addiko Bank,Finance
@@ -614,6 +627,7 @@ adept.co.za,Adept ICT,ISP
 adertis.hu,ADERTIS Kft,ISP
 adesso-service.com,adesso as a service,MSP
 adfinis.com,Adfinis,MSP
+adhesivesresearch.com,Adhesives Research,Healthcare
 adient.com,Adient,Manufacturing
 adif.es,ADIF,Government
 adinformaticatelecom.com.br,AD Telecom,ISP
@@ -635,6 +649,7 @@ admintek.net,Admintek,Web Host
 admintekcr.net,Admintek,Web Host
 adminvps.ru,AdminVPS,Web Host
 admiral.ne.jp,ASJ,ISP
+admirasolutions.co.bw,Admira Solutions,ISP
 adnbroadband.com,ADN Broadband,ISP
 adnettelecom.ro,AdNet Telecom,ISP
 adnex.pl,Adnex,ISP
@@ -643,12 +658,14 @@ adnlink.com.br,ADN LINK,ISP
 adnoc-development.com,ADNOC,Industrial
 adnotes.co.za,AdNotes (Pty),ISP
 adnsl.com,ADN Telecom,ISP
+adnsolutions.com,Advanced Data and Network Solutions,Web Host
 adntel.com.bd,ADN Telecom Bangladesh,ISP
 adntelecom.pe,ADN Telecom S.A.C,ISP
 adoard.com,Adoard Global Reach,ISP
 adobe.com,Adobe,Technology
 adotnet-bd.com,A Dot Net,ISP
 adp.com,ADP,Finance
+adpc.ae,ABU Dhabi Ports Company,Logistics
 adrianodainternet.com.br,Adriano DA Internet,ISP
 adryano.com.br,Adriano Telecomunicacoes,ISP
 adryanotelecom.com,Centenaro Adriano (Adryano Telecom),ISP
@@ -672,6 +689,7 @@ advancedinfo.com.br,Advanced Info,ISP
 advancedisp.com,Advanced Internet,ISP
 advanceditservices.co.uk,Advanced IT Services,ISP
 advancedstream.com,Advanced Stream,ISP
+advancedwireless.com,Advanced Wireless,ISP
 advancenet.com.au,AdvanceNet Telecom,ISP
 advancetelbd.com,Advance Telecom,ISP
 advania.com,Advania,MSP
@@ -680,6 +698,7 @@ advania.is,Advania Iceland,MSP
 advania.no,Advania Norway,MSP
 advantage.co.nz,Advantage,Web Host
 advantagedental.com,Advantage Dental+,Healthcare
+advantiscu.org,Advantis Credit Union,Finance
 advatel.net.au,Advatel Wireless,ISP
 advcomsolutions.com,Advanced Communications Solutions,ISP
 adventconstructions.co.tz,Advent Construction Limited,Industrial
@@ -697,13 +716,16 @@ adygtelecom.com,Adygei Telephone Company,ISP
 adyl.com.br,Adyl Telecom,ISP
 ae.com.br,Agência Estado,News
 aebc.com,AEBC Internet,ISP
+aebs.com,AE Business Solutions,Technology
 aecero.com,AECERO,Web Host
 aegean.gr,University of the Aegean,Education
+aegeanbalticbank.com,Aegean Baltic Bank A.T.E,Finance
 aegon.com,Aegon,Finance
 aeneas.com,Aeneas Internet and Telephone,ISP
 aeneas.net,Aeneas Internet and Telephone,ISP
 aep.com,American Electric Power,Utilities
 aeris.com,Aeris Communications,ISP
+aernnova.com,Aernnova,Manufacturing
 aero.org,The Aerospace Corporation,Defense
 aerocom.co.za,Aerocom,ISP
 aeroinc.net,The Areo Group,Industrial
@@ -723,6 +745,7 @@ aeza.ru,Aeza,IaaS
 af-k.de,I-NetPartner GmbH,ISP
 af.mil,U.S. Air Force,Defense
 afad.gov.tr,T.C. Basbakanlik Afet ve Acil Durum Yonetim Baskanligi,Government
+afba.com,Afba,Finance
 afcinfotelecom.net,AFC Informatica & Internet,ISP
 afcom.sl,Afcom (SL),Web Host
 afdb.org,African Development Bank - AFDB,Finance
@@ -756,6 +779,7 @@ afrihost.com,Afrihost,ISP
 afriminesa.com,Afrimine Southern Africa,Industrial
 afrinic.net,AFRINIC,Nonprofit
 afriqnetworks.co.ke,AFRIQ NETWORK SOLUTIONS,Web Host
+afs.net,AFS Logistics,Logistics
 afstelecom.com.br,AFS Telecom,ISP
 aftabtelecom.com,Aftab Communications and Informatics Private Joint Stock Company,ISP
 aftc.co,AFT Communications,ISP
@@ -849,6 +873,7 @@ aim.co.id,Adi Inti Mandiri,MSP
 aimfirms.com,AIM Firms,MSP
 aims.com.my,AIMS Data Centre Malaysia,Web Host
 aims.edu,Aims Community College,Education
+aims.edu.gh,AIMS Ghana,Education
 ainet.at,Ainet,ISP
 ainetfactory.com,American Information Network,ISP
 ainetworks.sl,AI Networks,ISP
@@ -972,6 +997,7 @@ ais.th,AIS,ISP
 aisicloud.net,HK AISI Cloud Computing,Web Host
 aisipl.com,AISIPL,ISP
 aislecom.com,Affordable Island Communications Inc. (AIsleCom),ISP
+aisnsw.edu.au,THE Association OF Independent Schools OF NEW South Wales,Education
 aist.biz,AIST,ISP
 aist.go.jp,National Institute of Advanced Industrial Science and Technology,Government
 ait.ac.th,Asian Institute of Technology,Education
@@ -981,6 +1007,7 @@ aitinternetservices.com,AIT Internet Services Private,ISP
 aiu.ac.jp,Akita International University,Education
 aiwacorp.co.jp,Aiwa,Industrial
 aixit.com,Aixit,Web Host
+aixp.or.tz,TISPA - Tanzania Internet Service Providers Association,ISP
 aja.digital,AJA Digital,ISP
 ajib.com,AJIB,Finance
 ajnet.net.br,Antonio G DE Sousa Junior,ISP
@@ -988,6 +1015,7 @@ ajofreerange.com,Free Range Internet,ISP
 ajrmexico.com,AJR,Logistics
 ajrmexico.net,AJR,Logistics
 ajtn.net,Agung Jaya Telekomunikasi Nusantara,ISP
+aju.co.kr,AJU Internet Technology,ISP
 ajums.ac.ir,Ahvaz Jundishapur University of Medical Sciences,Education
 ajusa.com,AJ-USA,Retail
 ajyalfi.ps,AjyalFi Company for Information and Communication Technology,ISP
@@ -1007,6 +1035,7 @@ akbars.ru,Joint-Stock Commercial Bank Ak Bars (OJSC),Finance
 akcept.ru,Bank Accept,Finance
 akcommercialindustries.com,AK Commercial Industries,ISP
 akilecloud.com,AkileCloud,Web Host
+akima.com,Akima,Logistics
 akinet.net,AKI NET Telecom,ISP
 akiwifi.es,Akiwifi,ISP
 akkodis.com,AKKODiS,Staffing
@@ -1069,6 +1098,7 @@ alberon.cz,"Alberon Letohrad, s. r. o",Web Host
 alberta.ca,Government of Alberta,Government
 albertahealthservices.ca,Alberta Health Services,Healthcare
 albion.edu,Albion College,Education
+albion.lviv.ua,Інтернет-провайдер ALBION,ISP
 alcans.com.br,Alcans,ISP
 alcansservicos.com.br,Alcans Telecom,ISP
 alcanstelecom.com.br,Alcans Telecom,ISP
@@ -1081,6 +1111,7 @@ alcom.ax,Alcom Aland,ISP
 alconn.it,Alconn,ISP
 alcontelecom.com,Alcon Telecom,ISP
 alcort.es,Alcort,MSP
+alctel.com.br,Alctel Telecomunicações e Informatica,ISP
 aldera.ca,Aldera Communications,ISP
 alea.gov,Alabama Law Enforcement Agency,Government
 alef.com,Alef Distribution RO,Web Host
@@ -1133,6 +1164,7 @@ alibabagroup.com,Alibaba,Technology
 alienbroadband.in,Alien Broadband,ISP
 alienfiber.net,Alien Dns,ISP
 alif.tj,OJSC Alif Bank,Finance
+alignet.com,Alignet,Retail
 alimov.net,Terra-Telecom,ISP
 alink.com.br,Anil Link Telecomunicacoes,ISP
 alink.net,A-Link Network Services,ISP
@@ -1143,6 +1175,7 @@ aliorbank.pl,Alior Bank,Finance
 alishalink.com.np,Alisha Communication Link Pvt,ISP
 alivenet.com.br,R2 Tecnologia E Telecomunicacoes,ISP
 aliyun.com,Alibaba Cloud,Web Host
+aljazeera.com,Al Jazeera International (USA),News
 aljeel.ly,Aljeel Aljadeed,ISP
 alkafeelomnnea.com,AlkafeelOmnnea,ISP
 alkan.com,ALKAN Telecom,ISP
@@ -1203,6 +1236,7 @@ allpointsfibre.uk,AllPoints Fibre,ISP
 allrede.com.br,Allrede Telecom,ISP
 allrede.tec.br,Allrede,ISP
 allsafe.ch,allsafe,MSP
+allsafeit.com,AllSafe IT,MSP
 allscripts.com,Allscripts (India) LLP,Healthcare
 allsimple.net,All Simple Internet Services,Web Host
 allstate.com,Allstate,Finance
@@ -1314,6 +1348,7 @@ altimatel.com,Altima Telecom,ISP
 altinc.ca,Alt Telecom,ISP
 altitudeinfra.fr,Altitude Infra,ISP
 altitudeisp.com,Altitude ISP,ISP
+altius.org,Altius Institute for Biomedical Sciences,Education
 altiusbb.com,ALTIUS Broadband,ISP
 altiusinfra.com,Elevar Digitel Infrastructure,ISP
 altmanadvisors.com,Altman Advisors,Finance
@@ -1333,6 +1368,7 @@ aluhost.com,Aluhost,Web Host
 alurium.com,Alurium Hosting,Web Host
 alvarezcablehogar.com.ar,Alvarez Cable Hogar,ISP
 alvernia.edu,Alvernia University,Education
+alvinisd.net,Alvin Independent School District,Education
 alvsbyn.se,Alvsbyn Kommun,Government
 alwaronline.net,Alwar Online,ISP
 alwaysdata.com,alwaysdata,Web Host
@@ -1371,9 +1407,14 @@ ambiente.gob.ar,Secretaria DE Gobierno DE Ambiente Y Desarrollo Sustentable,Gove
 ambisys.net,Ambisys,Healthcare
 ambit.com.tw,Ambit Microsystem,Manufacturing
 ambrogio.com,Ambrogio,ISP
+ambrose.edu,Ambrose University,Education
+ambulance.vic.gov.au,Ambulance Victoria,Government
+amcbridge.com,AMC Bridge,Manufacturing
+amcon.com.ng,Asset Management Corporation OF Nigeria,Finance
 amcor.com,Amcor,Healthcare
 amctelecom.com,AMC Telecom,ISP
 amd.com,AMD,Manufacturing
+amda.edu,American Musical & Dramatic Academy,Education
 amdatex.com,AMDATEX,MSP
 amdintl.com.tw,Kangjian Biomedical Technology,Healthcare
 amdocs.com,Amdocs,SaaS
@@ -1386,6 +1427,7 @@ americainter.net,America Internet & Communications,ISP
 americamovil.com,LATAM Telecommunications,ISP
 american.edu,American University,Education
 americanam.org,American Advanced Management,Healthcare
+americancampus.com,American Campus Communities,Education
 americanet.com.br,Vero,ISP
 americanetww.com,Americanet,ISP
 americanexpress.com,American Express,Finance
@@ -1404,6 +1446,7 @@ ameslab.gov,Ames Laboratory,Government
 amethyst.co.jp,Amethyst,Healthcare
 amfabank.se,Svea Bank,Finance
 amfam.com,American Family Insurance,Finance
+amgnational.com,AMG National Trust,Finance
 amherst.edu,Amherst College,Education
 amherstcomm.net,Amherst Communications,ISP
 amiapisonet.com,Amia Pisonet,ISP
@@ -1442,6 +1485,7 @@ amsavingsbank.com,"American Savings Bank, FSB",Finance
 amt.ru,AMT Telecom,ISP
 amtechbd.net,Amtech Communications,ISP
 amteck.com.br,Amteck Informatica,ISP
+amtelco.com,Amtelco,Healthcare
 amtelkom.com,AMTEL,ISP
 amtservices.it,AMT Services,MSP
 amu.ac.in,AMU,Education
@@ -1458,6 +1502,7 @@ analog.com,Analog Devices,Manufacturing
 ananintelecom.net.br,Conecta Internet,ISP
 ananthtelecomservices.com,Ananth Telecom Services,ISP
 anantrajcloud.com,Anant Raj Cloud,Web Host
+anatel.gov.br,Anatel,Government
 anb.com,Amarillo National Bank,Finance
 anb.com.sa,Arab National Bank Saudi Stock Co,Finance
 anbia.com,American National Bank,Finance
@@ -1471,6 +1516,7 @@ ancoriabank.com,Ancoria Bank: Banking Redefined,Finance
 andaina.net,Jose Antonio Vazquez Quian,Web Host
 andeo.ch,Andeo,MSP
 andernettelecom.net.br,Andernet Telecom,ISP
+andersonhospital.org,Anderson Hospital,Healthcare
 andersonuniversity.edu,Anderson University,Education
 andira.net.id,Andira Infomedia,ISP
 anditel.com,Anditel,ISP
@@ -1488,6 +1534,8 @@ anexia.com,Anexia,Web Host
 angelbroadband.com,Angel Broadband,ISP
 angelo.edu,Angelo State University,Education
 angelstelecom.com.br,Angels Telecom,ISP
+anglicands.org.au,Anglican Diocesan Services,Religion
+angola-ixp.ao,Ponto de Intercambio Internet Angola (Angola IXP),ISP
 angolacables.co.ao,Angola Cables,ISP
 angolatelecom.com,Angola Telecom,ISP
 anheuser-busch.com,Anheuser-Busch,Food
@@ -1519,6 +1567,7 @@ ans-elblag.pl,Akademia Nauk Stosowanych w Elblagu,Education
 ans.co.uk,ANS,MSP
 ansbd.net,Saharea Hossain t/a Authentic Network,ISP
 anschlusswerk.de,AnschlussWerk,ISP
+anselm.edu,Saint Anselm College,Education
 anshinsoft.com,Nomura Research Institute Financial Technologies India,Education
 ansi.org,American National Standards Institute,Education
 ansluten.net,Ansluten Hosting,Web Host
@@ -1549,6 +1598,7 @@ antilles-sante.com,AAS Medical,Healthcare
 antispamcloud.com,N-able,Email Security
 antispameurope.com,Hornetsecurity,Email Security
 anttel.com.au,XYZ Telecom,ISP
+antwifi.com.tr,Antvvifi Bilisim ve Telekomunikasyon Hiz. San. ve Ticaret LTD STI,ISP
 anum.co.id,Anum Nusantara Media,ISP
 anw.at,Alpha NetWork,ISP
 anyang.ac.kr,anyang University,Education
@@ -1621,6 +1671,7 @@ aponit.com,Apon IT,ISP
 app-ionos.space,IONOS,Web Host
 app-tec.com,Applied Technologies,ISP
 appalachianwireless.com,Appalachian Wireless,ISP
+appfolio.com,Appfolio,Real Estate
 apple.com,Apple,Email Provider
 applefibernet.com,Apple Fibernet,ISP
 applenetbd.com,Apple Net,ISP
@@ -1643,7 +1694,9 @@ aps-inc.co.jp,Arahi Polyslider,Industrial
 aps.edu,Albuquerque Public Schools,Education
 apsbank.com.mt,APS Bank P.L.C,Finance
 apsfl.in,APSFL Andhra Pradesh State FiberNet,ISP
+apsiscom.com,Apsis,ISP
 apstar.com,AS # for peering purpose with IX and ISP,ISP
+apsu.edu,Austin Peay State University,Education
 apt.al,APT cable,ISP
 aptalaska.com,AP&T,ISP
 aptalaska.net,AP&T,ISP
@@ -1680,9 +1733,11 @@ arainternet.com.br,Ara Telecom,ISP
 aramcoinc.com,Saudi Aramco,Industrial
 arana.net.id,Arana Networks,ISP
 aranetplay.com.br,Aranet Play,ISP
+aranets.com.br,Ara Nets Telecom,ISP
 aranettelecomma.com.br,Aranet Telecom,ISP
 aranik.net,Aranik Communications Technology,ISP
 arapabruzzo.it,ARAP,Industrial
+arapatelecomunicaciones.com,Arapa Telecomunicaciones E.I.R.L,ISP
 aratwifi.com.tr,Arat Telekominikasyon Tek. Bil.Hiz.San. ve Tic. Ltd.Sti,ISP
 araujosat.com.br,Araujo SAT Servicos DE Multimidia,ISP
 arax.md,Arax-Impex,ISP
@@ -1693,6 +1748,7 @@ arbuz.ru,ARBUZ Co,ISP
 arcade.ch,Arcade Solutions,MSP
 arcadia.edu,Arcadia University,Education
 arcadiz.com,Arcadiz,ISP
+arcep.bf,Autorite de Regulation des Communications Electroniques et des Postes,ISP
 arcep.tg,Autorité de Régulation des Communications Electroniques et des Postes (ARCEP),ISP
 archerirm.us,Archer GRC,SaaS
 archimedianet.it,Archimedia,Retail
@@ -1718,6 +1774,7 @@ ardmore.net,Ardmore Telephone (ATC),ISP
 ardot.gov,Arkansas Department of Transportation,Government
 area51telecom.com.br,Area 51 Provedor DE Internet,ISP
 area9.com.au,Area9,MSP
+areafinancial.com,Area Financial Services,Finance
 arealink.com.bd,Area Link BD,ISP
 arealnet.com.br,Areal Net,ISP
 areiter.com,Moundridge Telephone Co,ISP
@@ -1788,11 +1845,13 @@ arquia.es,Arquia Banca,Finance
 arra.ie,Fast Wireless Internet,ISP
 arrab.id,Arrab.id,MSP
 arrayhealth.nz,Array Health Solutions,Healthcare
+arrc.com,Alaska Railroad,MSP
 arris.com,ARRIS Technology,ISP
 arrobabandalarga.com.br,Arroba Banda Larga,ISP
 arrobanettelecom.com.br,@Net Telecom,ISP
 arrowcalgary.ca,Arrow Group,Web Host
 arrowcommunications.co.uk,Arrow Business Communications,ISP
+arrowenergy.com.au,Arrow Energy,Agriculture
 arrownet.com.np,Arrownet,ISP
 arrownetsylhet.com,Arrow Net,ISP
 arrowtouch.in,Arrow Touch Wireless Internet,ISP
@@ -1884,6 +1943,7 @@ as6723.net,AS6723 Ukrainian Operator,ISP
 as835.net,GoCodeIT,Web Host
 as8540.net,AMA netwoRX,ISP
 as979.net,NetLab Global,ISP
+asa.gob.mx,Aeropuertos y Servicios Auxiliares,Government
 asabrancatelecom.com.br,ASA Branca Telecomunicações,ISP
 asahankab.go.id,Pemerintah Kabupaten Asahan,Government
 asahi-net.jp,ASAHI Net,ISP
@@ -1901,8 +1961,10 @@ asatrionetwork.id,Asa Trio Network,ISP
 asavie.com,Akamai,Technology
 asb.co.nz,ASB Bank,Finance
 asblink.net,ASBLINK,ISP
+asbnet.com.pa,Atlantic Security Bank,Finance
 asbnetwork.co.in,Ashok Broadband Network Services,ISP
 asbury.edu,Asbury University,Education
+asbury.org,Asbury,Healthcare
 asbyte.net,Asbyte Telecomunicacoes E Servicos EM Informatica,ISP
 asc.edu,Alabama Supercomputer Authority,Education
 ascend.com,Ascend.com,ISP
@@ -1931,6 +1993,7 @@ asgtelecom.in,ASG Telecom,ISP
 ashanetbd.com,AshaNet BD,ISP
 ashesi.edu.gh,Ashesi University College,Education
 ashgoal.com,Ashgoal,MSP
+ashland.edu,Ashland University Ho,Education
 ashlandfiber.net,Ashland Fiber Network,Healthcare
 ashlandmmc.com,Memorial Medical Center,Healthcare
 ashmcomunicaciones.com,ASHM Comunicaciones,ISP
@@ -1955,6 +2018,7 @@ asianvision.com.ph,Asian Vision Cable Philippines,ISP
 asianvision.ph,Asian Vision,ISP
 asiaone.net,AsiaTech Telecom,ISP
 asiatech.ir,Asiatech Data Transmission,ISP
+asiawebhost.net,Asia Cloud Hosting,Web Host
 asibroadband.com,ASI Broadband,ISP
 asic.gov.au,ASIC Ho,Government
 asicentral.com,Advertising Specialty Institute,Education
@@ -2082,7 +2146,9 @@ ateneatelecomunicaciones.com,Atenea Telecomunicaciones,ISP
 ateneo.edu,Ateneo de Manila University,Education
 atexplus.net,Atexs Plus,ISP
 atextelecom.com.br,ATEX Telecom,ISP
+atfenix.com,Atfenix Data Centre,Web Host
 atg-inc.com,Applied Technology Group,MSP
+atg-rappido.com,Alliance Telecoms Group,ISP
 atg.net,ATG Arrow Technology Group Limited Partnership,ISP
 atha.net.id,AthaNet Internet,ISP
 athabascau.ca,Athabasca University,Education
@@ -2123,6 +2189,7 @@ atlantic.net,Atlantic.Net,Web Host
 atlanticatelecom.com.br,Atlantica Telecomunicações,ISP
 atlantichealth.org,Atlantic Health System,Healthcare
 atlanticmetro.net,365 Data Centers,Web Host
+atlantico.ao,Banco Millennium Atlantico,Finance
 atlantictechfibre.com,Atlantic Tech Fiber,ISP
 atlantiquetelecom.net,Atlantique Telecom Cote d'Ivoire,ISP
 atlantisgames.lt,Atlantis Games,Entertainment
@@ -2159,6 +2226,7 @@ atomdata-innopolis.ru,Atomdata-Innopolis,Web Host
 atomic.ac,Atomic,ISP
 atomic.co.uk,Atomic IT,MSP
 atomicdata.com,Atomic Data,MSP
+atomicnetworks.co,Atomic Networks,Web Host
 atomidata.fi,atomidata.fi,Web Host
 atomlink.ru,Telecom GKhK,ISP
 atomonetworks.com,Atomo Networks SRL,ISP
@@ -2205,6 +2273,7 @@ au-net.ne.jp,KDDI,ISP
 au.com,au,ISP
 au.dk,Aarhus Universitet,Education
 au.edu,Assumption University of Thailand,Education
+auarts.ca,Alberta University of the Arts,Education
 aub.edu.lb,AUB,Education
 aubg.bg,AUBG,Education
 aubix.net,Aubix,Web Host
@@ -2243,6 +2312,7 @@ auriga.com,Auriga,Technology
 auriganet.in,Auriganet Digital Technologies,ISP
 auris.com,Auris,SaaS
 aurologic.com,aurologic,Web Host
+aurora.il.us,City OF Aurora,Government
 auroragov.org,City of Aurora Colorado,Government
 aurorahealthcare.org,Advocate Health,Healthcare
 auroratelecom.ru,Aurora Telecom,ISP
@@ -2257,6 +2327,7 @@ aussiebroadband.com.au,Aussie Broadband,ISP
 austincollege.edu,Austin College,Education
 austinenergy.com,Austin Energy,Government
 austintexas.gov,AustinTexas.gov,Government
+austral.edu.ar,Universidad Austral,Education
 australiacloud.com.au,Sovereign Cloud Australia,MSP
 australianjewishnews.com,The Australian Jewish News,News
 australiaonline.net.au,Australia Online,ISP
@@ -2328,10 +2399,12 @@ avis.ne.jp,Densan Avis,ISP
 aviso.ci,Orange,ISP
 avk-com.ru,Avk-Computer,ISP
 avnam.net,VPS Argentina,Web Host
+avondale.edu.au,Avondale University,Education
 avondaleaz.gov,City OF Avondale,Government
 avsisp.com,AVS ISP,ISP
 avsystem.com,AVSystem,ISP
 avur.no,AVUR,ISP
+avxnetworks.com,AVX Networks,ISP
 awal.ly,AWAL telecom & Technology,ISP
 awandata.co.id,AwanData,Web Host
 awantigabintang.com,Awan Tiga Bintang,ISP
@@ -2374,6 +2447,7 @@ axis.com,Axis Communications,ISP
 axisbank.com,Axis Bank,Finance
 axishosted.com,AXIS HOSTED,ISP
 axisnetworks.org,AxisNetworks,Web Host
+axivora.uk,Axivora Connect,ISP
 axnet.ax,Network for AXNet,ISP
 axnet.com.br,Axnet Provedor de Internet Comercio,ISP
 axnonlinebd.net,AXN-Online,ISP
@@ -2401,6 +2475,7 @@ aysatecsas.com.co,Aysatec,ISP
 ayshait.net,Aysha IT Solutions,ISP
 aysima.com,Aysima,Web Host
 aytelekom.com,Ay Telekom,ISP
+ayto-murcia.es,Ayuntamiento de Murcia,Government
 ayva.network,Ayva,ISP
 aywifi.com.tr,AY Wifi Telekomunikasyon Sanayi VE Ticaret Limited Sirketi,ISP
 ayy.fi,Aalto University Student Union,Education
@@ -2460,6 +2535,7 @@ ba24.ir,Ayandeh Bank,Finance
 baaderbank.de,Baader Bank,Finance
 baaqmd.gov,Bay Area Air Quality Management District,Government
 babanettelecom.com.br,Babanet,ISP
+babcock.edu.ng,Babcock University,Education
 babelprov.go.id,Pemerintah Provinsi Kepulauan Bangka Belitung,Government
 babiel.com,CONET Deutschland,MSP
 babilon-t.com,Babilon-T,ISP
@@ -2470,6 +2546,7 @@ baca-bank.vn,BAC A BANK,Finance
 bacavalley.com,Sierra Communications,ISP
 bacb.bg,Bulgarian-American Credit Bank,Finance
 bacbpl.in,Bhorer Alo Cable And Broadband,ISP
+baccredomatic.com,BAC,Finance
 bacgiang.gov.vn,Bac Giang Department of Information and Communications,ISP
 backblaze.com,Backblaze,Web Host
 backbone.ch,Backbone Solutions,ISP
@@ -2496,6 +2573,7 @@ bage.dev,BAGE CLOUD,Web Host
 baghdad-link.com,Baghdad Link to Internet Services Provider and Information Technology,ISP
 baglanti.net,Baglanti.net,Web Host
 bagusnet.net.id,Borneo Broadband Technology,ISP
+bahakel.com,Bahakel Communications,Education
 baharinetwork.net,Bahari Nusantara Network,ISP
 baharnet.ir,Pars Fonoun Ofogh Information Technology and Communications Company,ISP
 bahiadados.com.br,BAHIADADOS,ISP
@@ -2508,6 +2586,7 @@ baidu.com,Baidu,Search Engine
 baikal-telecom.ru,Baikal Telecom,ISP
 baikonur.net,Viza-4,ISP
 bainbridgecity.com,City of Bainbridge,Government
+bainbridgeinternet.com,Bainbridge Internet Services,ISP
 baipailnetwork.com,BaipaIlNetwork,ISP
 bairronetpe.com.br,Bairronet Telecomunicacoes,ISP
 baitacloud.com.br,RFC DE Souza,Web Host
@@ -2515,6 +2594,7 @@ baitushum.kg,Ojsc Bank Bai-Tushum,Finance
 baj.com.sa,Bank AL Jazira,Finance
 bajadatacenter.com.mx,"Baja Datacenter, SA de CV",Web Host
 bakai.kg,BAKAI,Finance
+bakamla.go.id,Badan Keamanan Laut RI,Government
 bakanas.net.br,Allyson Diniz Melo,ISP
 bakcom.in,Star Broadband (Bakcom),ISP
 baker.edu,Baker College,Education
@@ -2553,25 +2633,38 @@ bancoagrario.gov.co,Banco Agrario DE Colombia,Finance
 bancoagricola.com,Banco Agricola,Finance
 bancoaliado.com,Banco Aliado,Finance
 bancoamazonia.com.br,Banco da Amazonia S/A,Finance
+bancoazteca.com.gt,Banco Azteca de Guatemala,Finance
+bancoazteca.com.hn,Banco Azteca Hondur,Finance
 bancoazteca.com.pa,Banco Azteca Panamá,Finance
+bancobai.ao,BAI,Finance
 bancobai.cv,Banco BAI Cabo Verde,Finance
 bancobcr.com,Banco de Costa Rica,Finance
+bancobcs.ao,BCS- Banco de Credito do Sul,Finance
 bancobmg.com.br,Banco Bmg,Finance
+bancobnc.com,Banco Nacional de Credito,Finance
 bancobpi.pt,Banco BPI,Finance
 bancobpmspa.it,Banco BPM,Finance
 bancocci.hn,Banco DE Occidente,Finance
 bancochile.cl,Banco de Chile,Finance
+bancocolumbia.com.ar,Banco Columbia,Finance
 bancocredicoop.coop,Banco Credicoop Cooperativo Limitado,Finance
+bancocuscatlan.com,Banco Cuscatlan SV,Finance
 bancodebogota.com,Banco de Bogotá,Finance
 bancodeloja.fin.ec,Banco DE Loja,Finance
 bancodelpacifico.com,Banco DEL Pacifico,Finance
 bancodesio.it,Banco di Desio e della Brianza,Finance
 bancodonordeste.gov.br,Banco do Nordeste,Government
+bancoeconomico.ao,Banco Economico,Finance
 bancoestado.cl,Banco DEL Estado DE Chile,Finance
+bancoexterior.com,Banco Exterior,Finance
 bancofie.com.bo,Banco Para EL Fomento A Iniciativas Economic,Finance
+bancofinandina.com,Banco Finandina,Finance
 bancofrances.com.ar,BBVA Banco Frances,Finance
 bancogalicia.com,Banco Galicia,Finance
+bancognb.com.py,Banco GNB Paraguay,Finance
 bancoguayaquil.com,Banco Guayaquil,Finance
+bancokeve.ao,Banco Keve,Finance
+bancomediolanum.es,Banco Mediolanum,Finance
 bancomercantil.com,Banco Mercantil,Finance
 banconal.com.pa,Banco Nacional DE Panama,Finance
 bancopan.com.br,Banco PAN,Finance
@@ -2581,6 +2674,7 @@ bancopromerica.com.gt,Banco Promerica Guatemala,Finance
 bancoprovincia.com.ar,Banco DE LA Provincia DE Buenos Aires,Finance
 bancor.com.ar,Banco DE LA Provincia DE Cordoba,Finance
 bancoripley.cl,Banco Ripley en Línea,Finance
+bancosol.ao,Banco Sol,Finance
 bancosol.com.bo,BancoSol,Finance
 bancounion.com.bo,Banco Unión,Finance
 bancovalor.ao,"Banco Valor, S.A (BV)",Finance
@@ -2599,7 +2693,10 @@ bandung.go.id,Pemerintah Kota Bandung,Government
 bandungkab.go.id,"Dinas Komunikasi, Informatika dan Statistik Kabupaten Bandung",Government
 bandwidth.co.uk,Bandwidth Technologies,ISP
 bandwidth.com,Bandwidth,SaaS
+banesco.com,Banesco Banco Universal,Finance
+banesco.com.pa,Banesco International Bank,Finance
 banese.com.br,Banco DO Estado DE Sergipe S/A,Finance
+banfield.net,Banfield Pet Hospital®,Healthcare
 bangkalankab.go.id,Dinas Komunikasi dan Informatika Kabupaten Bangkalan,Government
 bangkok.go.th,Bangkok Metropolitan Administration,Government
 bangla.net,ISN Bangla,ISP
@@ -2667,8 +2764,10 @@ banksumut.co.id,Bank Sumut,Finance
 banksyd.com.au,Bank of Sydney,Finance
 bankvanbreda.be,Bank J. Van Breda & Co,Finance
 bankvostok.com.ua,Pjsc Bank Vostok,Finance
+bankwindhoek.com.na,Bank Windhoek,Finance
 bankwithbos.com,Bank Of Springfield,Finance
 bannerhealth.com,Banner Health,Healthcare
+banpais.hn,Banco del Pais,Finance
 banpro.com.ni,Banpro,Finance
 banque-es.ch,Banque Eric Sturdza,Finance
 banque-france.fr,Banque de France,Finance
@@ -2711,6 +2810,7 @@ bariguitelecom.com.br,Barigui Telecom,ISP
 barilochew.com.ar,Bariloche Wireless,ISP
 barinet.com.br,BariNET,ISP
 barings.com,Barings,Finance
+barker.nsw.edu.au,Barker College,Education
 barracuda.com,Barracuda,Email Security
 barradochoca.ba.gov.br,Municipio DE Barra DO Choca,Government
 barranet.com.br,Barra Net,ISP
@@ -2740,6 +2840,7 @@ basketnews.lt,BasketNews,Sports
 basmail.jp,TOKI Communications Corporation,ISP
 basnet.by,BASNET,Education
 bassac.fr,Bassac,Construction
+bassett.org,Bassett Healthcare Network,Healthcare
 bataanspacecable.com,Bataan Space Cable Network,ISP
 batam.go.id,Pemerintah Kota Batam,Government
 batamix.net,Batam Internet Exchange,ISP
@@ -2768,6 +2869,7 @@ baycity.co.nz,Baycity Communications,ISP
 baycix.de,BayCIX,Web Host
 bayer.com,Bayer,Healthcare
 bayer.de,Bayer,Healthcare
+bayfed.com,BAY Federal Credit Union,Finance
 baykonur.ru,Baykonur Svyazinform,ISP
 baylor.edu,Baylor University,Education
 baynet.ne.jp,Tokyo Bay Network,ISP
@@ -2818,6 +2920,7 @@ bc.edu,Boston College,Education
 bc.net,BCNET,Education
 bc.sc.gov.br,Prefeitura de Balneário Camboriú,Government
 bc9.ne.jp,Kanuma Cable Television,ISP
+bca.co.ao,Banco Comercial Angolano,Finance
 bca.co.id,Bank Central Asia (BCA),Finance
 bcaa.com,BCAA,Finance
 bcaggregation.ru,LTD BCA Home Internet,ISP
@@ -2841,6 +2944,7 @@ bch.org,Boulder Community Hospital,Healthcare
 bci.ao,Banco De Comercio e Industria,Finance
 bci.cl,Banco de Credito e Inversiones,Finance
 bcianswers.com,BCI,MSP
+bcimiami.com,Banco DE Credito E Inversiones,Finance
 bcinfonet.com.br,B C Informatica E Telecomunicacoes,ISP
 bcit.ca,British Columbia Institute of Technology,Education
 bclan.ru,BCLan,ISP
@@ -2863,11 +2967,13 @@ bcs-ea.com,Bandwidth and Cloud Services Group (BCS),ISP
 bcs.org,BCS,Nonprofit
 bcsbeavers.org,Madison-Oneida BOCES,Education
 bct.org,Beaver Creek Telephone Company,ISP
+bctbank.com.pa,BCT Bank,Finance
 bctconsulting.com,BCT Consulting,MSP
 bcv.ch,BCV,Finance
 bcv.org.ve,Banco Central DE Venezuela,Finance
 bcw.edu,Blood Center of Wisconsin,Education
 bcx.co.za,BCX,MSP
+bd.com,BD,Healthcare
 bda.vn,Vietnam BDA technology and communication joint stock company,ISP
 bdb.bt,Bhutan Development Bank,Finance
 bdc.ca,BDC,Finance
@@ -2990,6 +3096,7 @@ belwave.com,BelWave Communications,ISP
 belwue.de,BelWü,Education
 bemis.com,Bemis,Healthcare
 ben.edu,Benedictine University,Education
+benchmarkemail.com,Benchmark Email,Marketing
 bendersom.com.br,Bendersom,ISP
 bendigotelco.com.au,Bendigo Telco,ISP
 bendtel.com,BendTel,ISP
@@ -2999,6 +3106,7 @@ benilde.edu.ph,De La Salle – College of Saint Benilde,Education
 benintelecoms.bj,SBIN Benin,ISP
 benkan.co.jp,Benkan,Industrial
 benlomandconnect.com,Ben Lomand Rural Telephone Cooperative,ISP
+bennington.edu,Bennington College,Education
 bensoft.ro,Bensoft Telecom,ISP
 bentelecom.com.br,BEN TELECOM,ISP
 bentley.edu,Bentley University,Education
@@ -3021,6 +3129,7 @@ berneyassocies.com,Berney Associés,Consulting
 bernofarm.com,Bernofarm,Healthcare
 berry.edu,Berry College,Education
 berrycomm.org,BerryComm,ISP
+berryglobal.com,Berry Global,Healthcare
 berrymouse.in,Berrymouse Infocom,ISP
 beskidmedia.pl,Beskid Media,ISP
 bespoke.tech,Bespoke Technology,MSP
@@ -3040,8 +3149,10 @@ bestwestern.com,Best Western,Travel
 bet365.com,bet365,Entertainment
 beta.net.ua,Betanetua,ISP
 betanet.pl,BetaNET,ISP
+betanxt.com,BetaNXT,Finance
 betatech.bm,Beta Technologies,MSP
 betatel.com,Betatel,ISP
+betenbough.com,Betenbough Homes,Construction
 beth.k12.pa.us,Bethlehem Area School District,Education
 bethel.edu,Bethel University,Education
 bethnet.co.za,BETHNET cc,ISP
@@ -3058,10 +3169,12 @@ bezeqint.net,Bezeq International,ISP
 bezerraspeednet.com.br,Bezerra Speed Net,ISP
 bfa.ao,Banco de Fomento Angola,Finance
 bfb.one,BFB,Web Host
+bfcm.com,Bluefin Trading,Finance
 bfh.ch,Berner Fachhochschule,Education
 bfiber.in,B-Fiber,ISP
 bfibernet.com,Bfibernet,ISP
 bfix.bf,Burkina Faso Internet EXchange Point ( BFIX),ISP
+bfp.com.ni,Banco DE Fomento A LA Produccion,Finance
 bfs.bf,BFS,ISP
 bfsfcu.org,Bank-Fund Staff Federal Credit Union,Finance
 bfsu.edu.cn,Beijing Foreign Studies University,Education
@@ -3070,6 +3183,7 @@ bg.net.ua,BG.NET internet service provider,ISP
 bgcb.com.bd,Bengal Commercial Bank,Finance
 bgctv.com.cn,Beijing Gehua CATV,ISP
 bgeneral.com,Banco General,Finance
+bgk.pl,Bank Gospodarstwa Krajowego,Finance
 bgocloud.com,BGOCloud,Web Host
 bgp.net,BGP Network HK,ISP
 bgpnet.com,BGPNET,IaaS
@@ -3094,6 +3208,7 @@ bhrbroadband.com,BHR Broadband,ISP
 bhsu.edu,Black Hills State University,Education
 bhtelecom.ba,BH Telecom,ISP
 bhuiyan-online.com,Md Golam Kibria,ISP
+bhvr.com,Behaviour Interactive,Entertainment
 bhznet.com.br,Gerencia Telecomunicações,ISP
 bi.fr,Bi.fr,Web Host
 bi.go.id,Bank Indonesia,Government
@@ -3175,6 +3290,7 @@ biovet.com,Biovet,Healthcare
 bip.net.id,Berkat Internet Perka,ISP
 bipnet.co.id,BIPNET,ISP
 bipnet.com.br,bipNET Telecom,ISP
+bir.ao,Banco de Investimento Rural,Finance
 birbir.net.tr,Birbir | Web Hosting,Web Host
 bird.com,Bird (Formerly SparkPost),Marketing
 birlink.az,Birlink,ISP
@@ -3241,6 +3357,7 @@ biznetnetworks.com,Biznet Networks,ISP
 bizon.net.ua,BIZON.net.ua,ISP
 biztel.ru,Biz Telecom,ISP
 bizvox.net,BizVox,ISP
+bizzarroagency.com,Bizzarro Agency,Real Estate
 bizzinternet.com.br,Bizz Internet,ISP
 bjarekraft.se,Bjare Kraft,Utilities
 bjc.org,BJC HealthCare,Healthcare
@@ -3293,6 +3410,7 @@ blazenetworks.co.uk,Blaze Networks,MSP
 blazingfast.io,BlazingFast (Softech),Web Host
 blazingseollc.com,Rayobyte (Blazing SEO),SaaS
 blbinfo.com.br,Bfcom Internet,ISP
+blc.edu,Bethany Lutheran College,Education
 blc.fi,BLC Telecom,ISP
 bledsoe.net,BTC Fiber (Bledsoe),ISP
 blendaisp.com,Blenda Internet Services India,ISP
@@ -3373,6 +3491,7 @@ bluetelecomunicaciones.com,Blue Telecomunicaciones,ISP
 bluetie.com,BlueTie,MSP
 bluetowertech.com,BlueTower Hosting,Web Host
 bluevalley.net,Blue Valley,ISP
+bluevalleyk12.org,Blue Valley USD NO 229,Education
 bluevps.com,BlueVPS,Web Host
 blueweb.co.kr,BlueWeb,Web Host
 blueweb.com.br,Blueweb Internet,ISP
@@ -3412,6 +3531,7 @@ bmtinternet.com.br,BMT,ISP
 bmw.com,BMW,Automotive
 bn-t.de,bn:t Blatzheim Networks Telecom,ISP
 bn.by,Business Network Belarus,ISP
+bna.ao,Banco National Angola (BNA),Finance
 bnb.be,Banque Nationale de Belgique,Finance
 bnb.bg,Bulgarian National Bank,Finance
 bnb.bt,Bhutan National Bank,Finance
@@ -3419,6 +3539,7 @@ bnb.by,"Open Joint Stock Company ""Belarusian People's Bank""",Finance
 bnb.com.bo,Banco Nacional DE Bolivia,Finance
 bnc.ca,National Bank of Canada,Finance
 bncollege.com,Barnes & Noble College Booksellers,Education
+bncr.fi.cr,Banco Nacional de Costa Rica (BNCR),Finance
 bndes.gov.br,BNDES,Government
 bne.catholic.edu.au,Brisbane Catholic Education,Education
 bnehost.com.au,Bnehosting,Web Host
@@ -3492,6 +3613,7 @@ bolmongkab.go.id,Pemerintah Kabupaten Bolaang Mongondow,Government
 boltfiber.com,BOLT Fiber Optic Services,ISP
 boltnetbrasil.com.br,Boltnet Brasil,ISP
 bombbomb.com,BombBomb,Marketing
+bomjesus.br,Colégio Bom Jesus,Education
 bond.edu.au,Bond University,Education
 bondhonbd.com,Bondhon Online Network,ISP
 bondhonbd.net,Bondhon Communication,ISP
@@ -3518,6 +3640,7 @@ boriananet.com,Boriana-Eood,ISP
 borille.net.br,Borille Serviços de Telecomunicações,ISP
 borkow.org,borkow.org PPHU,ISP
 borneo.kg,Ak Bulut Soft,Web Host
+borneofiberteknologi.id,Borneo Fiber Teknologi,ISP
 bornfiber.dk,BornFiber Service Provider,ISP
 bosbank.pl,Bank Ochrony Srodowiska,Finance
 bosch.com,Bosch,Manufacturing
@@ -3532,6 +3655,7 @@ bostonbroadband.org,Boston Broadband,ISP
 bostonfiber.net,Boston Fiber,ISP
 bostrad.com,Bostrad Supply Chain Ltd,Logistics
 bosveld.co.za,Bosveld Communcations,ISP
+bot-tz.org,Bank of Tanzania,Finance
 bot.com.tw,Bank Of Taiwan,Finance
 bot.or.th,"Bank of Thailand, Bangkok, Thailand",Finance
 botinternet.com.br,Bot Internet,ISP
@@ -3544,6 +3668,7 @@ bouyguestelecom-business.fr,Bouygues Telecom Business,ISP
 bouyguestelecom.fr,Bouygues Telecom,ISP
 bov.com,Bank of Valletta,Finance
 bowdoin.edu,Bowdoin College,Education
+bowenuniversity-edu.org,Bowen University,Education
 bowvalleycollege.ca,Bow Valley College,Education
 box.ca,Whatbox,Web Host
 box.nl,InterBox Internet,ISP
@@ -3554,6 +3679,8 @@ boxis.net,Boxis,ISP
 boycom.com,Boycom,ISP
 boyolali.go.id,Pemerintah Kabupaten Boyolali,Government
 boz.zm,Bank of Zambia,Finance
+bozeman.net,City Of Bozeman,Government
+bozemanhealth.org,Bozeman Health,Healthcare
 bp.com,BP,Industrial
 bpa.gov,Bonneville Power Administration,Utilities
 bpbatam.go.id,Badan Pengusahaan Batam,Government
@@ -3561,6 +3688,7 @@ bpc.ao,Banco de Poupança e Crédito,Finance
 bpddiy.co.id,Bank Pembangunan Daerah DIY,Finance
 bper.it,BPER Banca,Finance
 bph.pl,BPH,Finance
+bpi.com.ph,BPI,Finance
 bpi.ir,Pasargad Bank,Finance
 bpip.go.id,Badan Pembinaan Ideologi Pancasila,Government
 bpjs-kesehatan.go.id,Bpjs Kesehatan,Government
@@ -3573,6 +3701,7 @@ bplaced.de,bplaced,Web Host
 bplaced.net,bplaced,Web Host
 bpm.net.id,Berdikari Prima Mandiri,ISP
 bpn.go.id,Badan Pertanahan Nasional,Government
+bps-suisse.ch,BPS (SUISSE),Finance
 bps.go.id,"Dinas Komunikasi, Informatika Dan Statistik Kabupaten Kepulauan Anamb",Government
 bpsnetworks.com,BPS Networks,ISP
 bpweb.net,BPWEB,Web Host
@@ -3649,10 +3778,12 @@ brebeskab.go.id,Dinas Komunikasi Informatika dan Statistika Kabupaten Brebes,Gov
 bred.fr,BRED,Finance
 bredband2.com,Broadband2,ISP
 breedbanddelft.nl,Stichting Breedband Delft,ISP
+breezeair.net,BreezeAir Networks,ISP
 breezehost.io,BreezeHost,Web Host
 breezein.net,BRIZ,ISP
 breezeline.com,Breezeline,ISP
 breezelineohio.net,Breezeline,ISP
+brela.go.tz,BRELA,Government
 bremmar.com.au,Bremmar Communications,ISP
 bren.bg,BREN Bulgarian Research and Education Network,Education
 brennanit.com.au,Brennan IT,MSP
@@ -3672,11 +3803,13 @@ bridgenet-inc.com,BridgeNET Fiber,ISP
 bridgeport.edu,University of Bridgeport,Education
 bridgetelecom.com.ec,Bridge Telecom,ISP
 bridgew.edu,Bridgewater State University,Education
+bridgewater.com,Bridgewater Associates,Finance
 bridgewater.edu,Bridgewater College,Education
 bright.net,CNI,ISP
 brightbox.com,Brightbox,Web Host
 brightcloudgroup.global,Brightcloud,Government
 brightok.net,BrightNet Oklahoma,ISP
+brightongrammar.vic.edu.au,Brighton Grammar School,Education
 brightridge.com,BrightRidge,Utilities
 brightsolid.com,Brightsolid,Web Host
 brightspace.com,D2l Brightspace,SaaS
@@ -3694,6 +3827,7 @@ brisbane.qld.gov.au,Brisbane City Council,Government
 brisktel.net,BRISKTEL,ISP
 brisnet.com.br,Brisnet,ISP
 bristol.gov.uk,Bristol City Council,Government
+britam.com,Britam Holdings,Finance
 briteline.de,Bremen Briteline,ISP
 britishairways.com,British Airways,Travel
 britneighbour.top,BritNeighbour Net,ISP
@@ -3707,6 +3841,7 @@ brmemc.com,Blue Ridge Mountain EMC,Utilities
 brnchost.com,Brnchost,Web Host
 brnet.com.br,BRNet Telecomunicações,ISP
 brnetinfo.com,BRNET Infocom,ISP
+brnets.com,RLC Internet,ISP
 brnetworks.com.br,Brnetworks Telecom,ISP
 bro.net.id,Bintang Networks Solusindo,ISP
 broadband.hu,One Hungary,ISP
@@ -3745,6 +3880,8 @@ brooketel.coop,Brooke Telecom Cooperative,ISP
 brookhavenny.gov,"Brookhaven, NY",Government
 brookings.edu,Brookings,Education
 brooklaw.edu,Brooklyn Law School,Education
+brooks.com,Brooks Automation,Manufacturing
+broomfield.org,City and County of Broomfield,Government
 brosbroadband.com,Bro's Broadband,ISP
 brosiscommunication.com,Brosis Communication,ISP
 brother-internet.com,Brother Telecom (Cambodia),ISP
@@ -3758,6 +3895,7 @@ brownrice.com,Brownrice Internet,Web Host
 brownsvilletx.gov,"Brownsville, TX",Government
 browsepointtelecom.com.ng,BrowsePoint Telecom Nigeria,ISP
 brphonia.com.br,BrPhonia Provedor Ip,ISP
+brrb.by,"""Development Bank of the Republic of Belarus""",Finance
 brsk.co.uk,Brsk,ISP
 brsnetworks.se,BRS Networks,MSP
 brsulnet.com.br,Brsulnet,ISP
@@ -3777,7 +3915,9 @@ brz.gv.at,BRZ,Government
 bs-telecom.net,БС-Телеком (BS-Telecom),ISP
 bs.ch,Canton of Basel-Stadt,Government
 bs.limanowa.pl,Bank Spoldzielczy w Limanowej,Finance
+bs2.com,Banco BS2,Finance
 bs2.com.br,BS2 Sistemas para Internet,Web Host
+bsasoftware.com,BS&A,Government
 bsb.by,"""BSB Bank""",Finance
 bsblinkfibra.com.br,BSB Link Fibra,ISP
 bsc.iq,Shams Sara Company for General Contracting,ISP
@@ -3804,6 +3944,7 @@ bsnl.in,BSNL,ISP
 bsp.com.bn,Brunei Shell Petroleum,Industrial
 bspb.ru,Bank Saint Petersburg,Finance
 bssn.go.id,Badan Siber DAN Sandi Negara (Bssn),Government
+bsu.by,Belarusian State University,Education
 bsu.edu,Ball State University,Education
 bsvyazi.ru,PE Timonin Alexey Valerievich,ISP
 bt-blue.com,Bretagne Telecom,Web Host
@@ -3812,6 +3953,7 @@ bt.bt,Bhutan Telecom,ISP
 bt.com,BT,ISP
 bta.net.cn,China Networks Inter-Exchange,ISP
 btc-net.bg,Viacom,ISP
+btc.bm,The Bermuda Telephone Company,ISP
 btc.bw,Botswana Telecommunications,ISP
 btcbahamas.com,BTC Bahamas Telecommunications,ISP
 btcentralplus.com,BT,ISP
@@ -3820,6 +3962,7 @@ btcl.gov.bd,BTCL Bangladesh Telecommunications,ISP
 btcnbd.com,Bottola Cyber Net,ISP
 btcom.kz,BTcom,ISP
 btconline.net,Brantley Telephone,ISP
+btd.co.id,SKY Base Technologhy Digital,ISP
 btelbroadband.com,B-Tel,ISP
 btes.net,BTES Bristol Tennessee,Utilities
 btfibre.net,BT Fibre | (+254) 755 488 854,ISP
@@ -3886,6 +4029,7 @@ bulkvm.com,BulkVM,Web Host
 bull.com,Bull,MSP
 bullittcomm.com,Bullitt Communications,ISP
 bulloch.net,Bulloch County RTC,ISP
+bullroartel.com,Bullroar Telecom,ISP
 bullseyetelecom.com,Bullseye Telecom,ISP
 bulsat.com,Bulsatcom,ISP
 bulshofiberlink.com,Bulsho Fiber Link,ISP
@@ -3899,6 +4043,7 @@ bundeskanzleramt.gv.at,Bundeskanzleramt,Government
 bundesnetzagentur.de,Bundesnetzagentur,ISP
 bundunetworx.co.za,Bundu NetworX,ISP
 bunea.eu,Bunea TELECOM,ISP
+bunge.com.br,Bunge,Food
 bungi.net,Bungi Communications,ISP
 bunkaren.or.jp,Japan Culture and Welfare Federation of Agricultural Cooperatives,Agriculture
 bunnycommunications.com,Bunny Communications,ISP
@@ -3949,6 +4094,7 @@ bwtelecom.com,BW Telecom,ISP
 byblosbank.com,Byblos Bank S.A.L,Finance
 bycom.by,BYCOM Systems,ISP
 byfi.com,Byfi,ISP
+bylinebank.com,Byline Bank,Finance
 bynarya.net,Bynarya,ISP
 bynet.co.il,Bynet Data Communications,ISP
 bytebroadband.com,Byte Broadband,ISP
@@ -3962,6 +4108,7 @@ bytepark.net,BytePark,Web Host
 byteplus.com,BytePlus,IaaS
 bytes.co.za,Altron Bytes,MSP
 bytes.ua,BYTES.ua,Web Host
+bytesengenharia.com.br,joselia e cesar serviços de telecomunicação ltda m,ISP
 bytesized-hosting.com,Bytesized Hosting,Web Host
 bytesizeinternet.net,Bytesize Internet,ISP
 bytetelecom.net.br,K P Silva Telecom,ISP
@@ -3986,6 +4133,7 @@ c3link.com.br,C3Link,ISP
 c3ntro.com,Bicentel SA de CV,ISP
 c3po3090.com.br,Núcleo Brasil Servidores,Web Host
 c3telecom.com.br,M. I. Internet,ISP
+c7dc.com,C7 Data Centers,Web Host
 c7fibra.com.br,NCS-Fibra ( New Central Solutions ),ISP
 c9communications.com.au,C9 Communications,ISP
 ca-cib.fr,Credit Agricole Corporate and Investment Bank,Finance
@@ -4000,10 +4148,12 @@ cable.net.co,Cablenet,ISP
 cable10.com,Cable 10,ISP
 cable4.de,Cable 4,ISP
 cableandina.com,Cable Andina S.A.C,ISP
+cableandino.com.pe,Huascaran Telecom Sociedad Anonima Cerrada,ISP
 cablearequipa.com,Cable Arequipa,ISP
 cablearmstrong.com.ar,Cable Imagen Armstrong,ISP
 cableat.net,Cable A Tierra,ISP
 cablebahamas.com,Cable Bahamas,ISP
+cablebilling.com,Great Lakes Data Systems,ISP
 cablecable.net,Cable Cable,ISP
 cablecaribecr.com,Cable Caribe,ISP
 cablecenter.net,Cable Center,ISP
@@ -4037,6 +4187,7 @@ cableonda.com,Cable Onda,ISP
 cableonda.net,Cable Onda,ISP
 cableondaoriental.com,Cable Onda Oriental Dominican,ISP
 cableone.biz,Sparklight,ISP
+cableone.co.ke,Cable ONE,ISP
 cablepar.com,Cablepar,ISP
 cableperu.pe,Cable Perú,ISP
 cables.com.tw,Yueh Feng Industrial,Manufacturing
@@ -4080,6 +4231,7 @@ caiway.nl,Caiway,ISP
 caiweb.com.br,Caiweb,ISP
 caiweb.net.br,Caiweb,ISP
 caixa.gov.br,Caixa Economica Federal,Government
+caixaangola.ao,Banco Caixa Geral Totta de Angola,Finance
 cajazeirasnet.com.br,VSC Telecom,ISP
 cajunbroadband.com,Cajun Broadband,ISP
 cal.net,Cal.net,ISP
@@ -4113,9 +4265,11 @@ cam.ac.uk,University of Cambridge,Education
 camara.gov.br,Camara dos Deputados,Government
 cambiahealth.com,Cambia Health Solutions,Healthcare
 cambotech.com,Cambo Technology(ISP) Co,ISP
+cambrian.mb.ca,Cambrian Credit Union,Finance
 cambriancollege.ca,Cambrian College,Education
 cambridge.org,Cambridge University Press (Holdings),Education
 camc.org,CAMC,Healthcare
+camdennational.com,Camden National Bank,Finance
 camelliafiber.com,Camellia Fiber,ISP
 camelot.mk.ua,FOP Nayman Olha Vladimirovna,ISP
 camh.ca,CAMH,Healthcare
@@ -4146,6 +4300,7 @@ canarabank.com,Canara Bank,Finance
 canariastelecom.es,Aietes Telecom,ISP
 canbytel.com,DirectLink (Canby Telephone),ISP
 cancer.gov,National Cancer Institute,Government
+cancilleria.gov.co,Fondo Rotatorio del Ministerio de Relaciones Exteriores,Government
 cancom.com,CANCOM Austria,MSP
 cancom.de,CANCOM,MSP
 cancun.net.mx,Internet Cancun S.A. de C.V,ISP
@@ -4164,15 +4319,18 @@ canonical.com,Canonical,Technology
 canshield.ca,Canadian Shield Data Center,Web Host
 canspace.ca,CanSpace,Web Host
 cantecsystems.com,Cantec Systems,MSP
+cantelekom.com,Can Bilgi Teknolojileri ve Telekomunikasyon Ltd.Sti,ISP
 canterbury.ac.nz,University of Canterbury,Education
 canton.edu,SUNY Canton,Education
 cantv.com.ve,CANTV,ISP
+cap.org,The College of American Pathologists,Education
 cap.ru,"Autonomous institution Center of Information Technologies of Ministry of Digital Development, Information Policy and Mass Communications of the Chuvash Republic",ISP
 capcanatel.com,Corporación DE Comunicaciones Y Telefonía Turística Juanillo,ISP
 capconnetworks.com,Capcon Networks,ISP
 cape-connect.com,Cape Connect Internet,ISP
 capecod.edu,Cape Cod Community College,Education
 capecoral.gov,City of Cape Coral,Government
+capefearvalley.com,Cape Fear Valley Health,Healthcare
 capella.edu,Capella University,Education
 capetown.gov.za,City of Cape Town,Government
 capgemini.com,Capgemini,Consulting
@@ -4205,9 +4363,11 @@ cardinalscriptnet.com,Cardinal Health,Healthcare
 cardockhosting.com,Cardock Hosting,Web Host
 carecentrix.com,CareCentrix,Healthcare
 carenewengland.org,Care New England Health System,Healthcare
+careoregon.org,CareOregon,Healthcare
 carerra.co,Carerra Holdings,MSP
 caresource.com,CareSource,Healthcare
 caretel.com.au,CareTel,ISP
+carewisehealth.com,carewisehealth.com,Healthcare
 cargill.com,Cargill,Agriculture
 caribank.org,Caribbean Development Bank,Finance
 caribbeantele.com,Caribbean Telecom,ISP
@@ -4219,6 +4379,7 @@ carle.org,Carle Health,Healthcare
 carlessi.net.br,Carlessi Internet,ISP
 carleton.ca,Carleton University,Education
 carleton.edu,Carlton College,Education
+carlow.edu,Carlow University,Education
 carltechit.com,Carl-Tech IT Solutions,MSP
 carmel.nl,Stichting Carmel College,Education
 carminered.eu,Carmine Red IT,MSP
@@ -4232,6 +4393,7 @@ carolinadigitalphone.com,Carolina Digital Phone,ISP
 carolinaeasthealth.com,CarolinaEast Medical Center,Healthcare
 carolinashealthcare.org,Carolinas Healthcare System,Healthcare
 carolinawest.com,Carolina West Wireless,ISP
+caromonthealth.org,CaroMont Health,Healthcare
 carrd.co,Carrd,SaaS
 carrier-colo.com,IPB Carrier-Colo Berlin,Web Host
 carrierzone.com,carrierzone,Email Security
@@ -4261,9 +4423,11 @@ cassclaywireless.com,Cass Clay Wireless,ISP
 casscomm.com,CassComm,ISP
 cassia.gov,"Cassia County, Idaho",Government
 cassinfo.com,Cass Information Systems,ISP
+cassregional.org,Cass Regional Medical Center,Healthcare
 castel.az,Caspian Telecom,ISP
 castilho.psi.br,Castilho@Net,ISP
 castlerock.co.za,Castlerock Managed IT Services Company (Pty),Web Host
+castoinfo.com,CASTO,Real Estate
 castornetworks.com,Castor Communications,ISP
 castrotelecom.com.br,Castro Telecom,ISP
 castrum.com.br,Castrum Internet,ISP
@@ -4290,6 +4454,7 @@ catlabroadband.in,Catla IT and Engg.Co.Pvt,ISP
 catnet.jp,Honjo Cable,ISP
 catonetworks.com,Cato Networks,SaaS
 cats-net.co.tz,Cats-Net,MSP
+cattco.gov,Cattaraugus County,Government
 catupi.com,Catupi.com,ISP
 catv-ads.jp,advanscope,ISP
 catv296.co.jp,296 Broad Net,ISP
@@ -4300,6 +4465,7 @@ cau.edu,Clark Atlanta University,Education
 caveo.nl,Caveo,Web Host
 caviesa.com,Cable Vision E. Gonzalez,ISP
 caweb.com.br,Caweb Informatica,ISP
+caxias.rs.gov.br,Municipio de Caxias do Sul,Government
 caznet.com.au,"Caznet â Business Internet, Phone Systems & Data Centre",ISP
 cb.nl,CB,Healthcare
 cba.am,Central Bank of the Republic of Armenia,Finance
@@ -4313,6 +4479,7 @@ cbctech.com,CBC Tech International,Web Host
 cbdtelecom.cn,Beijing CBD Telecom CO,ISP
 cbe.ac.tz,The Governing Body of College of Business Education,Education
 cbe.ae,CBE,Construction
+cbe.org.eg,Central Bank of Egypt,Finance
 cbeyondsal.com,C BEYOND s.a.l,MSP
 cbg.com.gh,Consolidated Bank Ghana,Finance
 cbhslewisham.nsw.edu.au,Christian Brothers High School Lewisham,Education
@@ -4345,6 +4512,7 @@ cbxnet.de,CBXNET,ISP
 cbxnettelecom.com.br,R Rodrigues Menezes Servicos DE Internet,ISP
 cc-wireless.com,Cedar Creek Wireless,ISP
 cc9.jp,Cable TV Tochigi (CC9),ISP
+cca.edu,CCA | California College of the Arts,Education
 ccac.edu,Community College of Allegheny County,Education
 ccamp.res.in,Centre For Cellular And Molecular Platforms,ISP
 ccapcable.com,CCAP Cable,ISP
@@ -4353,6 +4521,7 @@ ccb.ru,CentroCredit Bank Moscow,Finance
 ccbank.bg,Central Cooperative Bank,Finance
 ccbcmd.edu,Ccbc,Education
 ccc-group.com,Canada Colors and Chemicals Limited (CCC),Industrial
+ccc.cc.ms.us,Coahoma Community College,Education
 ccc.co.il,Triple C Cloud Computing,Web Host
 ccc.de,Chaos Computer Club,Nonprofit
 ccc.qld.gov.au,Crime and Corruption Commission,Government
@@ -4383,6 +4552,7 @@ ccs.co.kr,CCS,ISP
 ccsd.edu,Clarkstown Central School District,Education
 ccsd.k12.co.us,Cherry Creek School District #5,Education
 ccsd.net,Clark County School District,Education
+ccsfundraising.com,CCS Fundraising,Consulting
 ccsius.com,CCSI,MSP
 ccsl.com.np,Computer Land Communications Global,ISP
 ccsleeds.co.uk,CCS Leeds,ISP
@@ -4399,6 +4569,7 @@ ccu.edu,Colorado Christian University,Education
 ccvision.cl,Comunicaciones Cablevision,ISP
 ccwis.com,WiConnect Wireless,ISP
 cdac.in,Centre for Development of Advanced Computing,Government
+cdatribe-nsn.gov,Coeur d' Alene Tribe,Government
 cdb.com.cy,CYPRUS Development Bank,Finance
 cdbhospital.com,CBD Hospital,Healthcare
 cdc.gov,US Centers for Disease Control and Prevention,Government
@@ -4452,6 +4623,7 @@ cegedim.fr,Cegedim,SaaS
 cegeka.com,Cegeka,MSP
 cei.edu,College of Eastern Idaho,Education
 cei.gov.cn,China eGovNet Information Center,Government
+ceibs.edu,CEIBS,Education
 ceifibratelecom.com.br,Cei Fibra Telecom,ISP
 celcom.com.my,Celcom Axiata,ISP
 celcom.pl,CELCOM,ISP
@@ -4502,7 +4674,9 @@ centaur.de,CENTAUR,Web Host
 centaurcablenetwork.com,Centaur Cable,ISP
 centauricom.com,Centauri Communications,ISP
 centenarybank.co.ug,Centenary Rural Development Bank,Finance
+centenaryuniversity.edu,Centenary University,Education
 centene.com,Centene,Healthcare
+centennialco.gov,City of Centennial,Government
 centennialcollege.ca,Centennial College,Education
 centerasecurity.com,Centera Email Defence,Email Security
 centerasecurity.dk,Centera Email Defence,Email Security
@@ -4559,6 +4733,7 @@ centricfiber.com,centricfiber.com,ISP
 centrilogic.com,Centrilogic,MSP
 centrin.net.id,Centrin Utama,ISP
 centrinvest.com,Public Joint-stock company commercial Bank Center-invest,Finance
+centrisfcu.org,Centris FCU,Finance
 centrixweb.net,Centrix Web Services,Web Host
 centro.net.id,Centro Network,ISP
 centroin.net,Centroin Provedor DE Serv. Internet,ISP
@@ -4578,6 +4753,7 @@ cepain.com.br,Cepain C2 Telecom,ISP
 cepanet.com.ar,CEPA,Utilities
 cepatmultidata.id,CEPAT MULTI DATA,ISP
 cera.net,CeraNet,Web Host
+cerberus.com,Cerberus Capital Management LP,Finance
 cerberusnetworks.co.uk,Cerberus Networks,ISP
 cerebel.com,CereBel Interactive,Marketing
 cerennet.com.tr,Cerennet,ISP
@@ -4607,11 +4783,13 @@ cetin.hu,CETIN Hungary,ISP
 cetin.rs,CETIN,ISP
 cetinbg.bg,CETIN Bulgaria,ISP
 ceu.edu,CEU,Education
+ceuma.br,Ceuma-Associacao DE Ensino Superior,Education
 ceunet.com.br,Ceunet Telecom,ISP
 ceys.com.ar,CEyS,Utilities
 ceystel.com.ar,CeySTEL,ISP
 ceznet.cz,ČEZNET,ISP
 cfa.vic.gov.au,Country Fire Authority,Government
+cfainstitute.org,CFA Institute,Education
 cfbisd.edu,Carrollton-Farmers Branch Independent School Dist,Education
 cfbtel.com,Cfbtel,MSP
 cfe.mx,CFE,Utilities
@@ -4623,6 +4801,7 @@ cfn.ltd,Cambridge Fibre Networks,ISP
 cfnc.org,College Foundation,Education
 cfnet.in,C Fiber Communications,ISP
 cfolks.pl,cyber_Folks,Web Host
+cfsmi.com,Client Financial Services of Michigan,Finance
 cfts.co,CFTS,MSP
 cfu.net,Cedar Falls Utilities,Utilities
 cg-bd.com,Digicon Telecommunication,ISP
@@ -4644,9 +4823,11 @@ ch-saintcalais.fr,Centre Hospitalier du Mans,Healthcare
 chair6data.com,Covered Bridge Data,Web Host
 chaiyohosting.com,Chaiy oHosting,Web Host
 chaktomuk-dc.com.kh,Chaktomuk Data Center,Web Host
+challiance.org,Cambridge Public Health Commission,Healthcare
 chalmers.se,Chalmers University of Technology,Education
 chaminade.edu,Chaminade University of Honolulu,Education
 champ.aero,CHAMP,MSP
+champaignil.gov,"City of Champaign, Illinois",Government
 champlain.edu,Champlain College,Education
 chandleraz.gov,City of Chandler,Government
 chandra.ac.th,Chandrakasem Rajabahat University,Education
@@ -4656,6 +4837,7 @@ channels.com.sa,Channels By Saudi Telecom Company (STC),ISP
 channelwireless.com,Channel Wireless,ISP
 chaojikh.com,Chaoji Super High Internet Technology,ISP
 chaparralwireless.com,Chaparral Wireless,ISP
+chapinschool.org,Chapin School,Education
 chapman.edu,Chapman University,Education
 chargeditsolutions.com,Charged IT Solutions,MSP
 charlescatv.com,Charles Catv Systems,ISP
@@ -4690,6 +4872,7 @@ chello.sk,UPC,ISP
 chemeketa.edu,Chemeketa Community College,Education
 chemgineering.com,Chemgineering Holding,Healthcare
 chemungcountyny.gov,"Chemung County, NY",Government
+cheneybrothers.com,Cheney Bros,Food
 cheops-technology.ch,Cheops Technology Switzerland,MSSP
 chereda.net,Chereda,ISP
 cherokee.org,Cherokee Nation Ho,Government
@@ -4698,14 +4881,17 @@ cherokeetel.com,Cherokee Telephone Company,ISP
 cherrycapitalconnection.com,Cherry Capital Connection,ISP
 cherrynet.kz,Sirius-2014,ISP
 cherryservers.com,Cherry Servers,Web Host
+chesapeakeregional.com,Chesapeake Regional Healthcare: Innovative For Life,Healthcare
 chesco.net,Chesconet,Education
 cheshireeast.gov.uk,Cheshire East Council,Government
 chess.no,Telia Norge,ISP
 chessict.com,Chess ICT,ISP
+chesterfield.gov,County of Chesterfield,Government
 chevalier.net,Chevalier (Internet) Limited autonomous system # 1,ISP
 chevron.com,Chevron,Industrial
 cheyney.edu,Cheyney University Of Pennsylvania,Education
 chiba-u.jp,Chiba University,Education
+chibiphoenix.com,Phoenix Media,Entertainment
 chic-finds.com,chic-finds,ISP
 chicago.gov,City of Chicago,Government
 chickamaugatelephone.net,Chickamauga Telephone,ISP
@@ -4715,6 +4901,7 @@ chikamori.com,Chikamori Health Care Group,Healthcare
 childrenscolorado.org,Children's Hospital Colorado,Healthcare
 childrensdayton.org,Dayton Children's Hospital,Healthcare
 childrenshospital.org,Boston Children's Hospital,Healthcare
+childrensnational.org,Children’s National Hospital,Healthcare
 childrensomaha.org,Children's Hospital & Medical Center,Healthcare
 childrenswi.org,Children's Wisconsin,Healthcare
 chime.org,Chimes,Healthcare
@@ -4753,6 +4940,7 @@ choptankfiber.com,Choptank Fiber,ISP
 chosting.solutions,Cloud Hosting Solutions,Web Host
 chosun.ac.kr,Chosun University,Education
 chriscomco.net,Christensen Communications Company,ISP
+christcathedralca.org,Christ Catholic Cathedral,Religion
 christieinnomed.com,Christie Innomed,Healthcare
 christushealth.org,CHRISTUS Health,Healthcare
 chrobinson.com,C.H. Robinson,Logistics
@@ -4770,6 +4958,7 @@ chubu.ac.jp,Chubu University,Education
 chudonet.net,Chudo Telecom,ISP
 chudotelecom.ru,IT Business,ISP
 chugye.ac.kr,Chugye University FOR THE Arts,Education
+chuh.org,Cleveland Heights University Heights City Schools,Education
 chuhai.edu.hk,Hong Kong Chu Hai College,Education
 chukai.co.jp,Chukai Television,ISP
 chula.ac.th,Chulalongkorn University,Education
@@ -4778,6 +4967,8 @@ chunkychips.net,ChunkyChips.net,MSP
 chuo-u.ac.jp,Chuo University,Education
 chupicom.jp,Chupicom,ISP
 churchdev.com,ChurchDev,Web Host
+churchdwight.com,Church & Dwight Co,Religion
+churchmutual.com,"Church Mutual Insurance Company, S.I",Finance
 chuvsu.ru,Fedaral State Educational Institution of higher professional Education 'Chuvash State University',Education
 ciabrasnet.com.br,Wnkbr Telecom,ISP
 ciachef.edu,Culinary Institute of America,Education
@@ -4792,6 +4983,7 @@ cib.hu,CIB Bank,Finance
 cibc.com,CIBC,Finance
 cibergoldwifi.com,Lizarsoain Gregorio Luis Alberto (Cibergold Wifi),ISP
 ciberlynx.com,CiberLynx,Technology
+cibnor.gob.mx,Centro de Investigaciones Biologicas del Noroeste SC,Government
 cic.ch,Bank CIC (Schweiz),Finance
 cic.de,CIC,ISP
 cic.net.id,Cipta Informatika Cemerlang,ISP
@@ -4920,6 +5112,7 @@ citynet.net.br,SEA Telecom,ISP
 citynetz-halle.de,Muth Citynetz Halle,ISP
 cityofadelaide.com.au,City of Adelaide,Government
 cityofammon.us,"City of Ammon, Idaho",Government
+cityofboise.org,City of Boise,Government
 cityofevanston.org,"City of Evanston, Illinois",Government
 cityofgastonia.com,City of Gastonia,Government
 cityofgolden.net,City of Golden,Government
@@ -4934,9 +5127,12 @@ cityofportlandtn.gov,"Portland, TN",Government
 cityofprineville.com,City of Prineville,Government
 cityofrc.us,City of Rancho Cucamonga,Government
 cityofredding.org,City of Redding,Government
+cityofrochester.gov,City of Rochester,Government
 cityofsacramento.org,City of Sacramento,Government
+cityofsantacruz.com,City of Santa Cruz,Government
 cityofscottsburg.com,City OF Scottsburg,Government
 cityoftacoma.org,City of Tacoma,Government
+cityofthornton.net,City of Thornton,Government
 cityoftulsa.org,City of Tul,Government
 cityofvallejo.net,"City of Vallejo, A municipal",Government
 cityofvancouver.us,City Of Vancouver,Government
@@ -4955,6 +5151,7 @@ cityzoneinfonet.com,Cityzone Infonet,ISP
 ciu.com.uy,Cámara de Industrias del Uruguay,Nonprofit
 civica.com,Civica UK,Government
 civitelecom.com,"Civilisation Information Technology, communication and internet services",ISP
+civix.ci,Cote d'Ivoire Internet Exchange Point,ISP
 civo.com,Civo,Web Host
 cix.com.ve,CiX!,ISP
 cizgi.net.tr,Cizgi Telekomunikasyon,ISP
@@ -4981,6 +5178,7 @@ clarienbank.com,Clarien Bank Bermuda,Finance
 claritev.com,Claritev,Healthcare
 clarix.com,Clarix,MSP
 clarkcountynv.gov,"Clark County, Nevada",Government
+clarke.edu,Clarke University,Education
 clarkson.edu,Clarkson University,Education
 clarksvilleconnected.net,Clarksville Connected Utilities,Utilities
 clarksvillede.com,Clarksville Department of Electricity,Utilities
@@ -5048,6 +5246,7 @@ clickfibratelecom.com.br,Click Fibra Telecomunicacoes,ISP
 clickinternetfoz.com.br,Click Internet,ISP
 clickip.com.br,Click IP,ISP
 clickisp.net,Click Communication,ISP
+clickmaistelecom.com.br,JFC Provedor DE Internet,ISP
 clicknavegue.com.br,Click & Navegue,ISP
 clicknet.com.br,Clicknet,ISP
 clicknet.inf.br,Click NET Soluções EM Internet,ISP
@@ -5089,11 +5288,14 @@ clonix.com.br,Clonix Telecom,ISP
 clonix.srv.br,Clonix Telecom,ISP
 closeness.es,Closeness,ISP
 cloud-connect.in,Cloudconnect Communications,ISP
+cloud-connect.sa,Cloud Connect Co,Web Host
 cloud-mail.jp,CloudMail,Email Provider
 cloud-sec-av.com,Check Point Avanan,Email Security
+cloud-solutions.ru,Ltd. Cloud Solutions,Web Host
 cloud-tel.it,Solunet,ISP
 cloud-telecom.fr,Cloud-Telecom,ISP
 cloud-temple.com,Cloud Temple,Web Host
+cloud.net.ua,Service Provider OBLAKO Kyiv,ISP
 cloud.nl,"Jouw cloud, onze zorg",Web Host
 cloud.ru,Cloud.ru,IaaS
 cloud365.com.au,Cloud365,Web Host
@@ -5204,6 +5406,7 @@ cloudx.group,Limited Liability Company Cloud Solutions,Web Host
 cloudxon.in,Cloudxon Datainfra Solutions,Web Host
 cloudzme.com,Cloudzme FZE,Web Host
 cloudzy.com,Cloudzy,Web Host
+cloustrix.com,Cloustrix,Web Host
 clouvider.co.uk,Clouvider,Web Host
 clouvider.com,Clouvider,Web Host
 clovertv.jp,Clover TV (Nisiowari CATV),ISP
@@ -5226,6 +5429,7 @@ cmctelecom.com.br,CMC Telecom,ISP
 cmctelecom.vn,CMC Telecom,ISP
 cmdcable.com,CMD Cable Vision,ISP
 cmedia.net.id,CMedia ISP,ISP
+cmh.edu,The Children's Mercy Hospital,Healthcare
 cmhc.org,Central Maine Medical Family,Healthcare
 cmhshealth.org,Community Memorial Health System,Healthcare
 cmich.edu,Central Michigan University,Education
@@ -5234,6 +5438,7 @@ cmkl.ac.th,CMKL University,Education
 cmo.de,CMO,Web Host
 cmorlando.com.ar,Carpintería Metálica Orlando,Manufacturing
 cmpwill.cl,CmpWill,ISP
+cmrefsi.com,CMRE,Finance
 cmri.org.au,Children's Medical Research Institute,Education
 cmsinter.net,CMS Internet,ISP
 cmtelecompe.com.br,M A G DE Moraes Telecomunicações,ISP
@@ -5304,15 +5509,19 @@ co-fi.es,Co-FI,ISP
 co-mo.net,Co-Mo Connect,ISP
 co-opbank.co.ke,Co-operative Bank of Kenya,Finance
 co-operativebank.co.nz,THE Co-Operative Bank,Finance
+co.cu,Empresa DE Telecomunicaciones DE Cuba S.A. (Ixp Cuba),ISP
 co.ge,Caucasus Online,ISP
 coastalhosting.net,coastalhosting.net,Web Host
 coastalwatch.com,Coastalwatch,Entertainment
 coastcommunications.com,Coast Communications,ISP
 coastconnect.com,CoastConnect,ISP
 coaxial.cc,Coaxial Cable,ISP
+cobaltcu.com,Cobalt Credit Union,Finance
 cobbcounty.org,Cobb County Georgia,Government
 cobranet.ng,Cobranet,ISP
 cobytes.com,Cobytes,Web Host
+cocha.com,COCHA,Travel
+cochise.net,Cochise Internet Services,ISP
 cochranetel.ca,CochraneTel,ISP
 coconet.com,Coconet,ISP
 cod.edu,College of DuPage,Education
@@ -5356,11 +5565,13 @@ coldwater.org,Coldwater Board of Public Utilities,Utilities
 coldwellbankerhomes.com,Coldwell Banker,Real Estate
 coles.com.au,Coles,Retail
 colgate.edu,Colgate University,Education
+colin.edu,Copiah-Lincoln Community College,Education
 collascrill.com,Collas Crill,Legal
 collectivhosting.com,Collectiv,Web Host
 collectorsaddition.com,The Collector's Addition,Retail
 collegeboreal.ca,College Boreal,Education
 collegenet.com,CollegeNET,Education
+collegiate.tas.edu.au,St Michael's Collegiate School,Education
 collier.gov,Collier County Government,Government
 collin.edu,Collin County Community College District,Education
 collinsaerospace.com,Collins Aerospace,Defense
@@ -5411,6 +5622,7 @@ columbiabasinhospital.org,Columbia Basin Hospital,Healthcare
 columbiacountyga.gov,"Columbia County, GA",Government
 columbiamemorial.org,Columbia Memorial Hospital,Healthcare
 columbiasc.gov,City of Columbia,Government
+columbiasouthern.edu,Columbia Southern University,Education
 columbiawireless.ca,Columbia Wireless,ISP
 columbus-networks.hn,Liberty Networks Honduras,ISP
 columbus-telephone.com,Columbus Telephone Company,ISP
@@ -5489,6 +5701,7 @@ communications-etc.com,Communications Etc,ISP
 communilink.com,CommuniLink,Web Host
 communilink.net,CommuniLink,Web Host
 communitect.com,Solutionreach,SaaS
+communityamerica.com,CommunityAmerica Credit Union,Finance
 communitybank.net,Community Bank,Finance
 communitybankbd.com,Community Bank Bangladesh,Finance
 communitycable.top,Community Cable,ISP
@@ -5572,12 +5785,14 @@ comunicktelecom.com.br,Comunick Telecom,ISP
 comunitel.net,Vodafone,ISP
 comvergence.com.au,Comvergence,ISP
 comvive.es,Comvive,Web Host
+comvoz.com,Comvoz Communication,ISP
 comwave.net,Comwave (Rogers),ISP
 comway.com.ar,Comway,ISP
 comway.ro,Comway Telecommunication,ISP
 comwifi.pe,ComWifi,ISP
 comwireit.com.au,Comwire IT,MSP
 conab.gov.br,Con,Government
+conabio.gob.mx,Comision Nacional para el Conocimiento y Uso de la,Government
 conacom.net,Conacom,ISP
 conapto.se,Conapto,Web Host
 conaservices.com,Cona,MSP
@@ -5590,6 +5805,7 @@ concordia.ab.ca,Concordia University of Edmonton,Education
 concordia.ca,Concordia University,Education
 concordiacollege.edu,Concordia College,Education
 concordma.gov,"Concord, MA",Government
+concordps.org,Concord-Carlisle Regional School District,Education
 concurcompleat.com,Concur Compleat,SaaS
 concursolutions.com,SAP Concur,SaaS
 condosites.com,CondoSites,SaaS
@@ -5728,6 +5944,7 @@ connectlife.it,ConnectLife,ISP
 connectlinksp.com.br,Connect Link,ISP
 connectmaster.com.br,Wcom COM E Serv Telecom,ISP
 connectmax.com.br,Algar Mogi (ConnectMax),ISP
+connectmevoice.com,Connect,ISP
 connectpa.com.br,Connect Telecom,ISP
 connectplusprovider.com,Markan comercio e serviços,Web Host
 connectprovedor.com,Connect Servicos DE Internet,ISP
@@ -5751,6 +5968,7 @@ connesi.it,Connesi,ISP
 connetical.it,Planetel Nordest,ISP
 connetrix.com,Connetrix,ISP
 connexin.co.uk,Connexin,Government
+connexity.com,Connexity,Marketing
 connextelecom.com.br,Connex Fibra,ISP
 connextelecom.net,Connex Telecom Servicos DE Telecomunicacoes,ISP
 connextra.it,Connextra,ISP
@@ -5771,9 +5989,11 @@ consolidated.coop,Consolidated,Utilities
 consolidatedlabel.com,Consolidated Label,Print
 consolidatednd.com,Consolidated Telcom,ISP
 consolidatedsmart.com,Smartaira (Consolidated Smart Systems),ISP
+consorcio.cl,Consorcio,Finance
 constant.com,Vultr,Web Host
 constantcontact.com,Constant Contact,Marketing
 constellation.com,CONSTELLATION ENERGY GENERATION,Utilities
+constellationhb.com,Constellation Web Solutions,Construction
 consulta.se,Consulta,Web Host
 consultic.be,ConsulTIC,Web Host
 consultix.net,Consultix,MSP
@@ -5811,12 +6031,14 @@ convergia.io,Convergia,ISP
 conversebank.am,Converse Bank,Finance
 convex.com.br,CONVEX,Web Host
 convivial.ne.jp,ConvivialNet,ISP
+convoke.com,Convoke Communications,ISP
 convoso.com,Convoso,SaaS
 convotis.ch,CONVOTIS Swiss,IaaS
 conwaycorp.com,Conway Corp,ISP
 conxion.net,ConXion EU,Web Host
 cookcountyil.gov,Cook County,Government
 cookeville-tn.gov,"Cookeville, TN",Government
+cookgroup.com,Cook Group,Healthcare
 cooksonhillsconnect.com,Cookson Hills Connect,ISP
 cooleydickinson.org,Cooley Dickinson Hospital,Healthcare
 coolhousing.net,Coolhousing,Web Host
@@ -5844,6 +6066,7 @@ copaco.com.py,Copaco,ISP
 copatel.com.br,Copatel,ISP
 copca.com.ar,Cooperativa DE Provision DE Obras Y Servicios Publicos Y Sociales DE Cruz Alta,Web Host
 copelnet.com.ar,Copelco (Cutral-Co),Utilities
+copercampos.com.br,Cooperativa Regional Agropecuária de Campos Novos,Food
 copetel.net.ar,Cooperativa Telefónica Carlos Tejedor,ISP
 copreltelecom.com.br,Coprel Telecom,ISP
 coprosys.cz,Coprosys,ISP
@@ -5902,6 +6125,7 @@ correo.gob.es,Spanish Ministry of Digital Transformation,Government
 correos.com,Correos,ISP
 cortavis.com,Cortavis,Web Host
 cortland.edu,SUNY Cortland,Education
+cortlandcountyny.gov,"Cortland County, NY",Government
 cosantelecom.net.ve,Cosan Telecom,ISP
 cosmicguard.com,Cosmic Global Networks,ISP
 cosmiqbroadband.co.za,Cosmiq Broadband,ISP
@@ -5918,6 +6142,7 @@ costalogistica.com,Costa Logística,Logistics
 costco.com,Costco Wholesale,Manufacturing
 costelho.com.ar,Costelho PLAN MUNDIAL,ISP
 costelnetworks.com,Costel Networks,ISP
+cosvi.com,COSVI | Cooperativa de Seguros de Puerto Rico,Finance
 cot.net,Cal-Ore Telephone,ISP
 cotapnet.com.bo,COTAP,ISP
 cotas.com,Cotas,ISP
@@ -5932,10 +6157,13 @@ cotelcam.com.ar,Cotelcam Argentina,ISP
 cotelser.com.ar,Coop DE Provision DE Telecomunicaciones Y Servicios DE Gral Lagos,ISP
 cotesma.coop,Cotesma San Martin de los Andes,ISP
 cotic.rn.gov.br,Governo do Estado do Rio Grande do Norte,Government
+cotr.bc.ca,College of the Rockies,Education
 cotton-warehouse.com,Cotton Warehouse Classic Cars,Automotive
+coty.com,Coty,Beauty
 cou.ac.bd,Comilla University,Education
 coucou-networks.fr,Free Mobile,ISP
 couldithosting.com,Could IT Hosting,Web Host
+counterpath.com,CounterPath,ISP
 country-connect.co.uk,Country Connect,ISP
 countrycom.ru,AO Countrycom,ISP
 countrymilewireless.com,Country Mile Wireless,ISP
@@ -5993,7 +6221,9 @@ cra.cz,České Radiokomunikace,Web Host
 cra.ir,Communication Regulatory Authority,ISP
 crabtechpte.com,Micro Cloud Technology,ISP
 cradlepoint.com,Cradlepoint (Ericsson),Manufacturing
+crain.com,Crain.com,ISP
 cranbrook.edu,Cranbrook Educational Community,Education
+cranbrook.nsw.edu.au,Cranbrook School,Education
 crawkan.net,Craw-Kan Telephone Cooperative,ISP
 crazynetbd.com,Crazy Net,ISP
 crazyweb.co.za,Crazyweb Tech (Pty),ISP
@@ -6010,7 +6240,9 @@ creativait.net,creativait.net,ISP
 creative.co.id,Kreatif Global Solusindo,ISP
 creaworld.com.sg,Creative eWorld,Marketing
 credexbank.ro,Credex Bank,Finance
+credibanco.com,Credibanco,Finance
 credibom.pt,Banco Credibom,Finance
+credicorpbank.com,Credicorp Bank,Finance
 credit-agricole.com,Crédit Agricole,Finance
 credit-agricole.pl,Bank Credit Agricole,Finance
 credit-agricole.ua,ТОП-3 найнадійніших в Україні | Credit Agricole Bank,Finance
@@ -6019,6 +6251,7 @@ creditcoop.ro,CREDITCOOP,Finance
 creditdnepr.com.ua,Public Joint-Stock Company BANK CREDIT DNEPR,Finance
 crediteurope.ru,Credit Europe Bank,Finance
 creditonebank.com,Credit One Bank,Finance
+creditoycaucion.es,"Atradius Credito Y Caucion SA, DE Seguros Y Reaseguros",Finance
 creditural.ru,Credit Ural Bank Joint Stock Company,Finance
 creditwest.ua,Creditwest Bank,Finance
 creditwestbank.com,Creditwest Bank,Finance
@@ -6034,6 +6267,7 @@ creraltelecom.com.br,CRERAL TELECOM,ISP
 crevinet.com,"CREVINET, seguramente la conexión MÁS RÁPIDA y ESTABLE de Crevillent",ISP
 crew-gmbh.de,Wieske's Crew,Web Host
 crexendo.com,Crexendo,ISP
+crh.org,Columbus Regional Hospital,Healthcare
 criarenet.com,Criare Telecomunicações e Consultoria,ISP
 criativasolucoes.net.br,L R Provedor DE Internet,ISP
 crif.com,CRIF,Finance
@@ -6060,6 +6294,7 @@ cronoadsl.it,Crono Ad,ISP
 cronomagic.com,Cronomagic,Web Host
 cronon.net,Cronon,Web Host
 cronosinternet.co.uk,Cronos Internet,ISP
+cronostelecomnet.com.br,Cronos Telecom,ISP
 cronusc.com,Cronus Communications,ISP
 cross-t.ru,Cross-I,ISP
 crosscomm.lu,Crosscomm,ISP
@@ -6077,11 +6312,13 @@ crowncloud.net,CrownCloud,Web Host
 crowsnestbb.net,Crowsnest Broadband,ISP
 crrstv.net,Crrs-Tv,ISP
 crsnetworks.ca,CRS Networks,MSP
+crst.com,CRST,Logistics
 crt.gob.mx,Comisión Reguladora de Telecomunicaciones,Government
 crtchile.cl,Conexiones Redes Y Telecomunicaciones,ISP
 crucialwebhost.com,Crucial Web Hosting,Web Host
 crusoe.ai,Crusoe,IaaS
 crxmgmt.com,The Medicine Shoppe Franchisee,Healthcare
+crye-leike.com,Crye-Leike Real Estate Services,Real Estate
 crystalintbd.com,Crystal International,ISP
 cs-inc.com,Communication Specialists,ISP
 cs2r.fr,CS2R Availability Services,MSP
@@ -6101,6 +6338,7 @@ cscom.com.ar,CScom,ISP
 csd.co,CSD Network Services,ISP
 csd99.org,Community High School District 99,Education
 csed.net.ec,CSEDnet,ISP
+csenergy.com.au,CS Energy,Utilities
 csf-group.com,CSF Advisers,Web Host
 csf.ne.jp,Cable Station Fukuoka (CSF),ISP
 cshl.edu,Cold Spring Harbor Laboratory,Education
@@ -6140,12 +6378,14 @@ cspirefiber.com,C Spire,ISP
 csquared.com,CSquared,ISP
 csr24.com,Applied Systems,SaaS
 css.edu,College of St. Scholastica,Education
+cssla.com,Computer Sales & Services,MSP
 cssnw.com,CSS Integration,MSP
 cst.gov.sa,"Communications, Space & Technology Commission (Saudi Arabia)",ISP
 cst.st,CST (Companhia Santomense de Telecomunicações),ISP
 cstar.pe,Cable Star TV SAC,ISP
 cstechnologies.com,CS Technologies,MSP
 cstnet.ru,Center for Network Technologies (CSTNET),ISP
+cstx.gov,City of College Station,Education
 csu.edu,Chicago State University,Education
 csu.edu.au,Charles Sturt University,Education
 csuc.cat,CSUC,Education
@@ -6277,6 +6517,8 @@ cvhp.org,Citrus Valley Health Partners,Healthcare
 cvi.ar,Cable Video Imagen Canal 5,ISP
 cvin.com,Vast Networks,Healthcare
 cvip.es,CVIP,ISP
+cvixp.cv,CVIXP,ISP
+cvmc.org,Central Vermont Medical Center,Healthcare
 cvph.org,Champlain Valley Physicians Hospital Medical Center,Healthcare
 cvpp.com.ar,Cable Vision Puerto Piray,ISP
 cvsinternet.com.br,CVS,ISP
@@ -6284,11 +6526,13 @@ cvtc.org,Copper Valley Long Distance,ISP
 cvtelecom.cv,Cabo Verde Telecom,ISP
 cvtsv.com,Cvent,SaaS
 cw-e.ca,Connecting Windsor-Essex,Nonprofit
+cw.edu,The College of Westchester,Education
 cwc.com,Cable and Wireless Turks and Caicos,ISP
 cwcbusiness.com,Liberty Business Caribbean,ISP
 cwcs.co.uk,Compuweb Communications Services,Web Host
 cwdom.dm,Cable & Wireless Dominica,ISP
 cwgo.net,Community Wireless,ISP
+cwidaho.cc,College of Western Idaho,Education
 cwie.com,CWIE,MSP
 cwmc.com.br,CWMC,ISP
 cwnet.com.au,CWNet,ISP
@@ -6347,6 +6591,7 @@ cybernet.co.tz,Cybernet,ISP
 cybernet.info.pl,CyberNET,ISP
 cybernet.su,Cybernet (Varyagi),ISP
 cybernet1.com,Cybernet1,ISP
+cybernetbd.com,CyberNetBD,ISP
 cybernetcom.ca,Cybernet Communications,ISP
 cybernetcom.com,Cybernet Communications,IaaS
 cybernetcommunications.net,Cyber Net Communications,ISP
@@ -6422,6 +6667,7 @@ dadepardazimobin.com,Dade Pardazi Mobin,Web Host
 daebauru.sp.gov.br,DAE,Government
 daegu.ac.kr,Daegu University,Education
 daejin.ac.kr,Daejin University,Education
+daemen.edu,Daemen University,Education
 daemonmail.ner,DaemonMail,Email Provider
 daemonmail.net,TierraNet,Web Host
 daffodilnet.com,Daffodil Online,ISP
@@ -6634,6 +6880,7 @@ dataxion.com,DataXion,Web Host
 datayard.us,DataYard,MSP
 datazonedc.com,datazonedc,Web Host
 datazonenetworks.net,DataZone Networks,ISP
+datco.net,Grupo Datco,ISP
 datec.com.pg,Datec PNG,MSP
 datel-dessau.de,DATEL Dessau,ISP
 datev.de,DATEV,SaaS
@@ -6668,6 +6915,7 @@ daystar.io,Daystar Email Service,Email Provider
 daystarrfiber.net,Daystarr Communications,ISP
 daytonabeach.gov,"Daytona Beach, FL",Government
 daytonastate.edu,Daytona State College,Healthcare
+daytontn.net,City of Dayton,Government
 db.com,Deutsche Bank,Finance
 dbank.bg,D Commerce Bank AD,Finance
 dbcity.com,Waller Creek Communications,ISP
@@ -6699,6 +6947,7 @@ dcbank.ca,Digital Commerce Bank,Finance
 dcblox.com,DC BLOX,Web Host
 dcboces.org,Dutchess BOCES,Education
 dcc.bg,Cifrova Kabelna Korporacia,ISP
+dcc.edu,Delgado Community College,Education
 dccc.edu,DCCC,Education
 dcceew.gov.au,Australian Department of Climate Change Energy Environment Water,Government
 dccllc.net,Digital Communications Consulting,ISP
@@ -6727,6 +6976,7 @@ dcs.net,DCS Networks,ISP
 dcsindia.co,Dcs Internet Services,ISP
 dcsmanage.com,DCS Pacific Star,MSP
 dcso.de,DCSO,MSP
+dcsoftworks.com,DC Softworks,Technology
 dcspine.nl,Eurofiber Cloud Infra,IaaS
 dcta.mil.br,DCTA Brazil Aerospace Science and Technology,Defense
 dctechmicro.com,DC Tech Micro Services,ISP
@@ -6858,6 +7108,7 @@ demirbank.kg,Demir Kyrgyz International Bank,Finance
 democrats.com,Democrats.com,Nonprofit
 denonline.in,DEN Networks India,ISP
 denovo-us.com,Denovo Ventures,Web Host
+denshi.bg,Denshi AD,Technology
 dentanet.id,Denta Sejahtera Group,ISP
 denteltelecom.com.br,Dentel Telecom,ISP
 denvergov.org,City and County of Denver,Government
@@ -6868,6 +7119,7 @@ dephub.go.id,Ministry of Transportation Republic of Indonesia,Government
 depkeu.go.id,Pusat Sistem Informasi dan Teknologi Keuangan ( Pusintek ),Government
 depkop.go.id,Kementerian Koperasi dan Usaha Kecil dan Menengah RI,Government
 depok.go.id,Dinas Komunikasi dan Informatika Pemerintah Kota Depok,Government
+depperin.go.id,Departemen Perindustrian Republik Indonesia,Government
 derbytech.com,DerbyTech Computer Works,ISP
 dereki.co.ke,Dereki,ISP
 derkom.pl,Dariusz Klimczuk trading as DERKOM Sp. J.,ISP
@@ -6921,6 +7173,7 @@ dewabiz.com,DewaBiz,Web Host
 dewanenterprise.com,Dewan Enterprise,ISP
 dewannet.com,Dewan Dot Net,Web Host
 dewata.net.id,DewataNet,ISP
+dewpoint.com,Dewpoint,MSP
 dewr.gov.au,Australian Department of Employment and Workplace Relations,Government
 dexanet.co.id,Dexanet,ISP
 dexano.co.id,Dexano Ryu Fusena,ISP
@@ -6972,6 +7225,7 @@ dhl.com,DHL,Logistics
 dhlbroadbandnet.com,DHL Broadband NET,ISP
 dhost.su,Digital Hosting Provider,Web Host
 dhosting.pl,dhosting.pl • Niezawodny Hosting • Domeny • Darmowa migracja,Web Host
+dhs.com.tr,DHS İnternet Teknolojileri,Web Host
 dhs.gov,US Department of Homeland Security,Government
 dhu.ac.kr,KyungSan University,Education
 di-di.ru,Digital Dialogue-Nets,ISP
@@ -7003,6 +7257,7 @@ dictu.nl,Ministerie van Economische Zaken,Government
 didichuxing.com,DiDi,Travel
 dido.ca,Dido Internet,ISP
 die-ig.de,DIE Immobiliengesellschaft mbH,Web Host
+dierbergs.com,Dierbergs Markets,Healthcare
 difesa.it,Ministero della Difesa,Defense
 differ.ca,DiFFER,ISP
 differnet.es,DifferNET,ISP
@@ -7048,6 +7303,7 @@ digitalc.org,DigitalC,ISP
 digitalcraftsmen.com,Digital Craftsmen,Web Host
 digitaledgedc.com,Digital Edge,Web Host
 digitalesuisse.com,Digitale Suisse,ISP
+digitalfilmtree.com,DigitalFilm Tree,Entertainment
 digitalfyre.com,DigitalFyre Internet Solutions,ISP
 digitalglobe.it,Offerte Internet per aziende | Digitalglobe,ISP
 digitalhasanah.co.id,Digital Hasanah,MSP
@@ -7070,6 +7326,7 @@ digitalpacific.com.au,Digital Pacific,Web Host
 digitalpassage.com,Digital Passage,ISP
 digitalpath.net,DigitalPath,ISP
 digitalpolicy.gov.hk,Hong Kong Digital Policy Office,Government
+digitalprima.id,Digital Prima Solution,ISP
 digitalprovedor.net.br,Digital,ISP
 digitalrealty.com,Digital Realty,Web Host
 digitalredzone.com,Digital Red Zone,Marketing
@@ -7136,6 +7393,7 @@ dipt.ua,FTICOM (DIPT),ISP
 diptelecom.com.br,DIP telecom,ISP
 dirams.re.kr,Dongnam Institute of Radiologycal Sciences,Education
 direct-booker.com,Direct Booker,Travel
+direct.com,Direct Federal Credit Union,Finance
 directcomfiber.com,Direct Communications Cedar Valley,ISP
 directconnectwales.co.uk,Direct Connect (ISP),ISP
 directcustomersolutions.com,Direct Customer Solutions,Healthcare
@@ -7192,6 +7450,7 @@ djasanet.id,Djasanet,ISP
 djaweb.dz,Telecom Algeria,ISP
 djemba.ro,DJEMBA IT&C,ISP
 dji.com,DJI,Technology
+djiboutidatacenter.com,Djibouti Data Center,Web Host
 djiboutitelecom.dj,Djibouti Telecom,ISP
 dju.ac.kr,Daejeon University,Education
 dkiros.com.br,Dkirosnet Serviços de Internet,ISP
@@ -7230,6 +7489,7 @@ dmsfibra.com.br,DMS Fibra,ISP
 dmt.net.id,Digital Media Telematika,Web Host
 dmu.edu,Des Moines University,Education
 dmwireless.com,DM Wireless,ISP
+dmz-petrovka.dp.ua,"Privat Joint-Stok Company ""Evraz - Dnepr Metallurgical Plant""",Manufacturing
 dmzhost.co,Techoff SRV,Web Host
 dn-systems.de,DN-Systems Enterprise Internet Solutions,ISP
 dna.fi,DNA,ISP
@@ -7321,6 +7581,7 @@ domrf.ru,"Joint Stock Company ""Bank DOM.RF""",Finance
 domru.ru,ER-Telecom,ISP
 domtel.com.pl,DOMTEL,ISP
 domustelecom.com.br,DOMUS TELECOM,ISP
+donaana.gov,Dona Ana County,Government
 donapex.ru,Don Apex,ISP
 donau-informatik.eu,DONAU INFORMATIK,Web Host
 donewifi.it,Studio Armonia,ISP
@@ -7336,6 +7597,7 @@ donweb.com,DonWeb (Dattatec),Web Host
 doorsancharstspl.com,Doorsanchar Sts Telecom Services,ISP
 doosan.com,Doosan,Conglomerate
 doratelekom.com.tr,DoraTelekom,ISP
+dordt.edu,Dordt University: A Top-Ranked Christianâ¦,Education
 dorseylaw.com,Dorsey & Whitney,Legal
 doruk.net.tr,DorukNet,Web Host
 dosarrest.com,Dosarrest Internet Security,ISP
@@ -7351,6 +7613,7 @@ dotcombroadband.net,Dotcom Broadband,ISP
 dotcomglobalmedia.com,DotCom Global Media,Marketing
 dotdigital.com,Dotdigital,Marketing
 doteasy.com,Doteasy,Web Host
+dotinc.net,Dot Internet Solutions,ISP
 dotinternetbd.com,DOT Internet,ISP
 dotmailer.com,Dotdigital,Marketing
 dotname.co.kr,Dotname Korea,Web Host
@@ -7360,9 +7623,11 @@ dotroll.com,DotRoll,Web Host
 dotsisnetwork.com,Dotsis Network,ISP
 dotto-one.com,Dotto-One,ISP
 doubledogcommunications.com,Double Dog Communications,ISP
+douglascountynv.gov,"Douglas County, Nevada",Government
 douglascountyor.gov,Douglas County School District RE.1,Government
 douzone.com,Douzone Bizon,SaaS
 doverdigital.net,Dover Digital â High-Speed Internet & IT,ISP
+doverinternet.com,Dover Internet Services,ISP
 dowjones.com,Dow Jones,News
 downcity.net,DownCity,ISP
 downloaddatarecovery.com,KernelApps,Technology
@@ -7460,6 +7725,7 @@ dstelecom.pt,dstelecom,ISP
 dstl.gov.uk,Defence Science and Technology Laboratory,Defense
 dstny.com,Dstny,SaaS
 dstsystems.com,SS&C Technologies (DST),SaaS
+dsu.dp.ua,Dnepropetrovsk National University of Oles Gonchar,Education
 dsu.edu,Dakota State University,Education
 dsusd.us,Desert Sands Unified School District,Education
 dsv.com,DSV,Logistics
@@ -7546,6 +7812,7 @@ dus.net,dus.net,ISP
 dusit.ac.th,Suan Dusit University,Education
 dustin.com,Dustin,Retail
 dutchbanglabank.com,"Dutch-Bangla Bank Limited, Your Trusted Partner",Finance
+dutchessny.gov,"County Of Dutchess, NY",Government
 dutchtelco.nl,Wholesale Dutch Telecom,ISP
 duth.gr,Democritus University of Thrace,Education
 dutil.com,Dalton Utilities,Utilities
@@ -7579,6 +7846,7 @@ dwtecsrl.com,DWTEC,ISP
 dwtelecom.com.br,DW Telecom,ISP
 dxc.com,DXC Technology,MSP
 dxc.technology,DXC Technology,MSP
+dyc.edu,D'Youville College,Education
 dyfend.net,Dyfend,ISP
 dyjix.eu,Dyjix,Web Host
 dyn-ip24.de,DDNSS,Web Host
@@ -7677,8 +7945,10 @@ easterra.com,Easterra,ISP
 eastex.com,Eastex Telephone Cooperative,ISP
 eastlink.ca,Eastlink,ISP
 eastlink.net.np,Eastlink Technology,ISP
+eastms.edu,East Mississippi Community College,Education
 eastmsconnect.com,East Mississippi Connect,ISP
 eastnet.kh.ua,"""Isp-Ukrlan""",ISP
+eastpennmanufacturing.com,East Penn Manufacturing,Utilities
 eastwest.com.pl,East&West,ISP
 eastwind.ru,Eastwind,ISP
 easy-hebergement.fr,Easy-Hébergement,Web Host
@@ -7716,12 +7986,14 @@ eaton.com,Eaton,Industrial
 eauclairecounty.gov,Eau Claire County,Government
 eauclairewi.gov,City of Eau Claire,Government
 eb.mil.br,Centro Integrado de Telemática do Exército,Government
+ebaptisthealthcare.org,Baptist Health Care,Healthcare
 ebayinc.com,eBay,Retail
 ebb.my,Extreme Broadband,ISP
 ebcgroup.co.uk,EBC Group,MSP
 ebenezar.in,Ebenezar Communications,ISP
 ebertinformatica.com.br,Microsol .Com.Repar.Equip.Eletronicos,ISP
 ebfoxfibra.com,EB FOX Telecom,ISP
+ebix.com.au,Ebix,Finance
 ebl-bd.com,Eastern Bank,Finance
 ebnhc.org,East Boston Neighborhood Health Center,Healthcare
 ebnhost.com,EbnHost,Web Host
@@ -7731,11 +8003,13 @@ ebox.ca,EBOX,ISP
 ebr.com.br,NUV Brasil (EBR),ISP
 ebranet.com.br,Ebranet,ISP
 ebsco.com,EBSCO Industries,Publishing
+ec-bank.net,ec-bank,Finance
 ec-southsudan.com,Expert Communications,ISP
 ec.com.cn,CIETNET China International Electronic Commerce,SaaS
 ec2software.com,ec² Software Solutions,Healthcare
 ecc.edu,Erie Community College,Education
 eccb-centralbank.org,Eastern Caribbean Central Bank,Finance
+eccc.edu,East Central Community College,Education
 echo-host.net,Echo-Host,Web Host
 echobroadband.net,Echo Broadband,ISP
 echoghana.com.gh,Echo Ghana,ISP
@@ -7825,6 +8099,7 @@ edgoo.com,Edgoo Networks,ISP
 edifecs.com,Edifecs,Healthcare
 edificom.ch,Edificom,ISP
 edimelo.com.br,Edimelo Telecom,ISP
+edinarealty.com,Edina Realty,Real Estate
 edinos.ru,Ediniy Operator Svyazi,ISP
 edion.co.jp,EDION,Retail
 edis.at,EDIS,Web Host
@@ -7842,6 +8117,7 @@ edpnet.net,EDPnet,ISP
 edrelixnet.com.br,Edrelix Net,ISP
 edt.de,Erdenreich Datentechnik,ISP
 edtech.rs,Edge Technology Plus,ISP
+edtns.co.id,EDT Internet Solusi Indonesia,ISP
 edu.com,InstructionalAssistant,SaaS
 edu.ru,Federal State Institution of Higher Professional Education Peoples Friendship University of Russia,Education
 eduarnet.ve,"Eduarnet Telecom, C.A",ISP
@@ -7893,6 +8169,7 @@ egstelecom.ru,EGS-Telecom,ISP
 egtechtelecom.com.br,Egtech Soluções EM Telecomunicações,ISP
 egw-telekom.at,Ertl & Gross GmbH & Co OG,ISP
 egyptian.net,Egyptian Telephone,ISP
+egyptlinx.com,Egypt Linx for Communication Services,ISP
 ehaf.com,EHAF Consulting Engineers,Construction
 ehafconsulting.org,EHAF Consulting Engineers,Construction
 ehime-u.ac.jp,Ehime University,Education
@@ -7941,6 +8218,7 @@ ekowebtech.net,Ekowebtech IT Services,ISP
 ekran39.ru,Ekran (Kaliningrad),ISP
 eksi.net,"Limited Liability Company ""EKSI-LTD""",ISP
 eku.edu,Eastern Kentucky University,Education
+ekurhuleni.gov.za,Ekurhuleni Metropolitan Municipality,Government
 elasticbeanstalk.com,Amazon AWS,PaaS
 elasticity-it.com,BE Slough DC (Elasticity-IT),Web Host
 elastx.se,ELASTX,Web Host
@@ -8013,6 +8291,7 @@ elitetelecomboise.com,Elite Telecom Boise,ISP
 elitework.com,EliteWork,SaaS
 elitnet.net.tr,Elitnet Telekomunikasyon Internet VE Iletisim Hiz.Tic Ltd.Sti,ISP
 elive.net,Elive,Web Host
+eljete.net,Eljete.Net â Lintas Jaringan Tungkal,ISP
 elkdata.ee,Elkdata,Web Host
 elkem.com,Elkem,Manufacturing
 ellcom.ru,Elektrosvyaz,ISP
@@ -8083,11 +8362,13 @@ emerson.edu,Emerson College,Education
 emerytelcom.net,Emery Telcom,ISP
 emexinternet.com.br,Emex Internet,ISP
 emfibra.net.br,EmFibra Telecom,ISP
+emfinc.net,EMF,Defense
 emgetis.se.gov.br,Empresa Sergipana DE Tecnologia DA Informação,Web Host
 emhealth.org,Ephraim McDowell Health,Healthcare
 emid.co.za,iOCO,MSP
 emigrant.com,Emigrant Bank,Finance
 emily.net,Emily Telephone,ISP
+eminnet.com.tr,Emin Net Telekomunikasyon Sanayi Ve Ticaret Limited Sirketi,ISP
 emirates.net.ae,Etisalat,ISP
 emisgroupplc.com,Egton Medical Information Systems,Healthcare
 emitel.com.br,EMITEL - Empresa de Informatica e Telecom,ISP
@@ -8098,7 +8379,9 @@ emmsoft.com,Emm Software,Web Host
 emory.edu,Emory University,Education
 empaquesmundiales.com,Empaques Mundiales,Industrial
 empatdatalink.net,Empat Data Link,ISP
+empire-hosting.net,Empire Hosting,Web Host
 empire-il.co.il,Empire IL,Web Host
+empire.ca,Empire Life,Finance
 empireaccess.com,Empire Access,ISP
 empireai.edu,Empire AI,Education
 empirecomm.com,Empire Communications,ISP
@@ -8122,6 +8405,7 @@ emu.edu,EMU,Education
 emu.edu.tr,Eastern Mediterranean University,Education
 emudhra.com,"eMudhra | Enterprise PKI, Post-Quantum Cryptography & Digital Trust Solutions",Healthcare
 emultinet.pl,E-Netkomp,ISP
+emypeople.net,eMyPeople,ISP
 en-bank.com,En-bank.com,Finance
 en.com.sg,EN Technologies,Web Host
 en.ee,European Networks,Web Host
@@ -8168,6 +8452,7 @@ engeplus.com.br,Engeplus,News
 engetronics.com.br,Engetronics,Web Host
 enginefresh.net,EngineFresh,Web Host
 enginet.az,Birlink,ISP
+englewoodhospital.com,Englewood Hospital and Medical Center,Healthcare
 enguard.com,EnGuard,Email Security
 eni.com,Eni,Industrial
 enicom.ru,Enigma Telecom,ISP
@@ -8205,10 +8490,12 @@ enterinfo.com.br,Enter Info Informatica E Serviços,ISP
 enterinfor.com.br,Enterprise Telecomunicações,ISP
 enternetprovedor.com.br,Enternet,ISP
 enterprisecloud.nu,Zitcom,Web Host
+enterprisecommunity.org,Enterprise Business Partners,Nonprofit
 enterpriseoutsourcing.co.za,Enterprise Outsourcing,Web Host
 entertelecomunicaciones.com,Enter Telecomunicaciones ®,ISP
 entirebroadband.com,Entire Cable And Broadband Opc,ISP
 entiretec.com,ENTIRETEC,MSP
+entity.nz,Entity Communications,ISP
 entitydata.com.au,Entity Data Pty,Web Host
 entornet.com.br,Entornet Fibra,ISP
 entranova.it,Entranova IT s.r.o,Web Host
@@ -8286,6 +8573,7 @@ equitybank.co.ke,Equity Bank Tanzania,Finance
 equitybank.co.rw,Equity Bank Rwanda PLC,Finance
 equitybank.co.ug,Equity Bank Uganda,Finance
 equitybank.com,Equity Bank,Finance
+equitybcdc.cd,Equity Banque Commerciale Du Congo,Finance
 eranetwork.id,Era Network Indonesia,ISP
 eranyacloud.com,Eranyacloud,IaaS
 eratelecom.net,eratelecom company,ISP
@@ -8320,6 +8608,7 @@ esa.int,European Space Agency,Government
 esacom.de,esacom,Web Host
 esafbank.com,Esaf Small Finance Bank,Finance
 esagames.ro,ESAGAMES,Web Host
+esales.com.br,E-Sales Soluções de Integração,Logistics
 esavezone.co.kr,SaveZone,Retail
 esbank.pl,ESBANK,Finance
 esboces.org,Eastern Suffolk BOCES,Education
@@ -8341,6 +8630,7 @@ eserver.sk,eServer,Web Host
 esic.edu,ESIC University,Education
 esilnet.com,Svyaz-INKOM-Servis i telekommunikatsii,ISP
 esited.com,eSited,Web Host
+eskerbroadband.org,Esker Broadband,ISP
 eskerondemand.com,Esker,SaaS
 eskhata.tj,Bank Eskhata,Finance
 eskiz.uz,Best Internet Solution XK,Web Host
@@ -8350,6 +8640,7 @@ eslporta.com.br,Famatel Telecomunicacoes,ISP
 esmonsa.com.ec,ESMON,ISP
 esnet.kz,Esnet Kazakhstan (Eurasia-Star),ISP
 eso.org,European Southern Observatory,Science
+esoftech.com,e.Soft Technologies,MSP
 esolutionsgroup.ca,Govstack (eSolutions Group),Technology
 esosoft.net,EcoSoft,Web Host
 espacodigitalinfo.com.br,Espaço Digital,ISP
@@ -8360,6 +8651,7 @@ especialnet.com.br,Especialnet Telecom,ISP
 esphere.ru,Sberkorus,ISP
 espol.edu.ec,Escuela Superior Politecnica del Litoral,Education
 esqsites123.com,ESQ Sites 123,Web Host
+esquaredc.com,E Squared,MSP
 esri.com,Esri,Education
 essainternet.com.br,Internet Norte Fluminense De Campos,ISP
 essec.edu,Essec,Education
@@ -8398,6 +8690,7 @@ etaftelecom.com,Etaf Telecom,ISP
 etapa.net.ec,ETAPA EP,ISP
 etb.com,ETB,ISP
 etb.net.co,ETB,ISP
+etbroadband.net,East Texas Broadband,ISP
 etc.uz,East Telecom,ISP
 etcc.bg,Eastern Telecommunication Company EAD,ISP
 etcnow.com,ETC,ISP
@@ -8468,6 +8761,7 @@ euro-net.co,EuroNet Internet,ISP
 euro-net.com.ua,EuroNet,ISP
 euro-net.pl,Euronet Bialystok,ISP
 euro.net.pl,EURO.NET.PL,ISP
+eurobic.pt,Banco BIC Portugues,Finance
 eurobyte.ru,EuroByte,Web Host
 eurocom.ru,EUROCOM,ISP
 eurocontrol.int,EUROCONTROL,Government
@@ -8482,6 +8776,7 @@ euronetwifi.it,Euro.net WiFi,ISP
 europa.eu,European Union,Government
 europarl.eu.int,European Parliament,Government
 europc.net.pl,EURO-PC,ISP
+europlanet.gr,Europlanet,Web Host
 euroserver.sk,EuroServer.sk,Web Host
 euroservers.com,Euroservers,Web Host
 eurotelbd.com,S.M. ZAKIR HOSSAIN t/a EUROtelbd Online,MSP
@@ -8496,6 +8791,7 @@ eut.ru,Evrasia Telecom Ru,ISP
 eutelsat.com,Eutelsat,ISP
 ev2.hu,EV2 INTERNET,ISP
 evaair.com,EVA Air,Travel
+evanhospital.com,Evangelical Community Hospital,Healthcare
 evansville.edu,University of Evansville,Education
 evanzo.de,Evanzo,Web Host
 evard.ch,Evard,MSP
@@ -8550,6 +8846,7 @@ evolutionwireless.fr,Evolution Wireless,Web Host
 evolvecellular.com,Evolve Cellular,ISP
 evolveip.net,Xtium (Formerly Evolveip),MSP
 evolverinc.com,Evolver,MSP
+evolving.com,Evolving Systems,ISP
 evolving.net.uk,Evolving Networks,ISP
 evonik.de,Evonik,Manufacturing
 evostec.com.br,Interjato Serviços de Telecomunicações,ISP
@@ -8557,6 +8854,7 @@ evox.ro,EVOX Solutions,ISP
 evoxt.com,Evoxt,Web Host
 evoxtelecom.com.br,Evox Telecom,ISP
 evpanet.com,PE Zinstein Hariton Vladimirovich,ISP
+evrazplace.com,Regina Exhibition Association,Nonprofit
 evro.net,Euro Crypt,Web Host
 evrofinance.ru,Commercial Bank Evrofinance Mosnarbank,Finance
 evrotm.ru,Evro Telecom,ISP
@@ -8602,6 +8900,7 @@ excelenti.com.br,satynet telecom,ISP
 excellmedia.net,Excell Media,ISP
 excelsior.edu,Excelsior University,Education
 exchangebank.com,Exchange Bank,Finance
+exchangetech.ca,Exchange Technology Services,MSP
 excitel.com,Excitel Broadband,ISP
 excloud.by,ExCloud,Web Host
 excloud.dev,Ahpk Technologies,Web Host
@@ -8616,14 +8915,17 @@ exelera.net,Exelera Telecom,ISP
 exeloncorp.com,Exelon,Utilities
 exepto.ru,Exepto,ISP
 exetel.com.au,Exetel,ISP
+exeterhospital.com,Exeter Hospital,Healthcare
 eximb.com,The State Export-Import Bank of Ukraine,Finance
 eximbank.co.tz,Exim Bank (Tanzania),Finance
 eximbank.com,EXIMBANK,Finance
+eximbank.gov.tr,Türk Eximbank,Government
 eximbank.ro,Exim,Finance
 eximbank.ru,State Specialized Russian Export-Import Bank (Joint-Stock Company),Finance
 exion.ch,Exion Networks,ISP
 exitovision.com,Exito Vision Cable,ISP
 exlibrisgroup.com,Ex Libris,SaaS
+exmiletechnologies.com,eXmile,ISP
 exn.uk,EX Networks,Web Host
 exnet.net.br,Ex2Net Telecomunicaçoes,ISP
 exnet.ru,Thyphone Communications,ISP
@@ -8658,6 +8960,7 @@ express.net.ua,Express,ISP
 expressfibraotica.com.br,Express Informatica,ISP
 expressinformatica.art.br,Express Fibra,ISP
 expressnetsc.com.br,Expressnet Telecom,ISP
+expressosaomiguel.com.br,Expresso São Miguel S/A,Logistics
 expressotelecom.com,Expresso (Sudatel),ISP
 expresswire.net,Express Wire,ISP
 exstream.net.ua,Donetsk Fiber-Optical Network,ISP
@@ -8678,6 +8981,7 @@ extremewi.com.br,Extreme Wi,ISP
 extride.ad.jp,extride,ISP
 exxoss.com,Exxoss,Web Host
 ey.com,Ernst and Young,Consulting
+eyc.cl,Equipos Electronicos Y Computacion,Consulting
 eylo.nl,Eylo Telecom,ISP
 eyona.com,Eyona,Web Host
 ezbit.pl,ezbit,ISP
@@ -8736,6 +9040,7 @@ faircom.co.za,Faircape (Faircom),ISP
 fairdinkum.com,Fairdinkum,MSP
 fairfax.va.us,"Fairfax County, Virginia",Government
 fairfaxcounty.gov,Fairfax County Homepage,Government
+fairfaxva.gov,City of Fairfax,Government
 fairfield.edu,Fairfield University,Education
 fairisaac.com,Fair Isaac and Company,SaaS
 fairlawngig.net,FairlawnGig,ISP
@@ -8761,6 +9066,7 @@ fale.com.br,FALE,ISP
 falesempremais.com.br,FSM Sistemas DE Telecomunicacoes,ISP
 fallschurchva.gov,"Falls Church, VA",Government
 faloutelecom.com,Falou Telecom,ISP
+familiar.com.py,Banco Familiar,Finance
 family-net.net,Hanson Information Systems (Family Net),ISP
 familybank.co.ke,"Family Bank Limited, Kenya",Finance
 famnettelecomunicacoes.com.br,Famnet Telecom,ISP
@@ -8783,6 +9089,7 @@ farahoosh.ir,Farahoosh Dena,ISP
 faraso.org,Faraso Samaneh Pasargad,Web Host
 fareastone.com.tw,FarEasTone,ISP
 farecom.it,FARECOM,ISP
+farelogix.com,Farelogix,Travel
 faridgonjbroadband.net,Faridgonj Broadband,ISP
 farknet.com.tr,FarkNet,ISP
 farlep.net,Farlep-Invest,ISP
@@ -8816,6 +9123,7 @@ fastcom.co.nz,Fastcom NZ,MSP
 fastcom.cz,FastCom,ISP
 fastcom.ie,Fastcom Broadband,ISP
 fastconnect.net.br,Fast Connect Telecomunicações,ISP
+fastdata.sa,Fast Data Company FOR Telecommunications AND Information Technology Limited Liability,ISP
 faster.cz,Faster CZ,ISP
 fasternet.com.br,Desktop,ISP
 fastfibra.com.br,Fast Telecom,ISP
@@ -8843,6 +9151,7 @@ fastnetisp.co,Fastnet Comunicaciones ISP,ISP
 fastnetisp.com,Fast Net Telecom,ISP
 fastnetllc.com,Fastnet Wireless,ISP
 fastnettelecom.com,Fastnet Telecom,ISP
+fastnettelecom.com.br,Fastnet Telecom,ISP
 fastnetwork.com.br,Fast Network,ISP
 fastpanda.co.uk,Fast Panda,Web Host
 fastpath.gr,Fastpath IKE,Web Host
@@ -8913,6 +9222,7 @@ fdc.dk,Forsikringens Datacenter,Web Host
 fdcservers.net,FDC Servers,Web Host
 fdfn.net,Friends Digital Fiber Network,ISP
 fdic.gov,Federal Deposit Insurance,Government
+fdm4.com,FDM4,Retail
 fdn.net.id,Fiber Data Nusantara,ISP
 fdu.edu,Fairleigh Dickinson University,Education
 fea.net,West Coast Internet (WCI),ISP
@@ -8924,6 +9234,7 @@ fedex.com,FedEx,Logistics
 feenix.co.nz,Feenix Communications,ISP
 feevale.br,Associacao Pro Ensino Superior em Novo Hamburgo,Education
 feldkirch.at,Stadtwerke Feldkirch,Utilities
+felnetwork.net,Felcloud - Dedicated and VPS hosting,Web Host
 felpham.com,Felpham Community College,Education
 fenice.hr,Fenice Telekom Grupa,ISP
 fenicyberlink.com,Feni Cyber Link,ISP
@@ -8950,6 +9261,7 @@ fetnet.net,FETNet,ISP
 feuerwehr.gv.at,Niederoesterreichischer Landesfeuerwehrverband,Government
 fexxio.nl,Fexxio Creative,Web Host
 ffastfill.com,ION Group (FFastFill),SaaS
+ffbf.com,First Federal Bank of Florida,Finance
 ffbtwinvalley.com,First Financial Bank,Finance
 ffcomunicacoes.com.br,F & F Comercio E Servicos DE Telecomunicacao E SEG,ISP
 ffeibr.wales,TfW Fibre,ISP
@@ -8965,9 +9277,11 @@ fhb.com,First Hawaiian Bank,Finance
 fhcp.com,Florida Health Care Plan,Healthcare
 fhcrc.org,Fred Hutchinson Cancer Research Center,Healthcare
 fhlb-pgh.com,FEDERAL HOME LOAN BANK of PITTSBURGH,Finance
+fhlbboston.com,Federal Home Loan Bank of Boston,Finance
 fhlbc.com,Federal Home Loan Bank of Chicago,Finance
 fhlbny.com,Federal Home Loan Bank OF NY,Finance
 fhlbsf.com,Federal Home Loan Bank of San Francisco,Finance
+fhn.org,FHN,Healthcare
 fhptelecom.com.br,FHP Telecom,ISP
 fhsu.edu,Fort Hays State University,Education
 fi.edu,The Franklin Institute Science Museum,Education
@@ -8977,6 +9291,7 @@ fiber-network.de,Fiber Network,ISP
 fiber-operator.nl,Fiber Operator,ISP
 fiber-sat.net,Fiber-SAT,ISP
 fiber-tech.net,Fiber-Tech Industries,ISP
+fiber-tel.ru,Fibertel,ISP
 fiber-x.com,Fiber-X,ISP
 fiber.bg,Three A Hub EOOD,ISP
 fiber.com.do,Fiber Network,ISP
@@ -8989,6 +9304,7 @@ fiber.net.np,Fiber Net Communication,ISP
 fiber1.bg,Fiber 1,ISP
 fiber23.it,"Colocation, IP Transit e Peering – Fiber23",ISP
 fiber2home.com.ar,Fiber2Ho,ISP
+fiber4.net.bd,Fiber 4,ISP
 fiber4gbroadband.com,Aeertel Fibernet Telecom,ISP
 fiberakses.net,Fiber Akses Nusantara,ISP
 fiberar.ar,Fiber AR,ISP
@@ -9026,6 +9342,7 @@ fiberfed.com,Trinity Network Solutions,ISP
 fiberfed.net,Town of Little Elm,ISP
 fiberfi.net,FIBERFI,ISP
 fiberfix.pe,Fiber FIX S.A.C,ISP
+fiberflash.net,A. N. dos M. P. de Telecomunicações - MICROTEL,ISP
 fiberflow.com.ph,FiberFlow,ISP
 fiberfly.com,fiberfly,ISP
 fibergo.com.ar,Fibergo,ISP
@@ -9097,11 +9414,14 @@ fiberon.az,Fiberon,ISP
 fiberone.de,NYNEX fiberONE,ISP
 fiberone.net.id,Jaringan Fiberone Indonesia,ISP
 fiberopticalnetwork.com,Fiber Optical Network,ISP
+fiberoptics-r-us.com,FiberOptics R US,ISP
 fiberpipe.in,Fiberpipe communications,ISP
 fiberpipe.net,Fiberpipe,ISP
 fiberplay.pl,VIP Agencja Reklamy,ISP
 fiberplus.es,FiberPlus Comunicaciones,ISP
 fiberplus.net.ar,Ferreyra Elio Orlando (Fiber Plus Internet),ISP
+fiberplusinc.com,Fiber Plus,ISP
+fiberpon.net,Fiberpon,ISP
 fiberpro.com.pe,FiberPRO: Internet 100% Fibra Óptica,ISP
 fiberred.pe,Fiberred SAC,ISP
 fiberring.com,LeaseWeb (Fiberring),Web Host
@@ -9127,6 +9447,7 @@ fibertelecom-isp.com.br,Fiber Telecom - Telecomunicação DE Dados,ISP
 fibertelecom.com,Fiber Telecom AS41327,ISP
 fibertelecom.net.br,Fiber Telecom,ISP
 fibertelperu.com,Fibertel Peru,ISP
+fibertic.net,Fibertic,ISP
 fibertown.com,Fibertown,Web Host
 fiberup.com.br,Fiber UP,ISP
 fiberverket.no,Fiberverket,ISP
@@ -9137,6 +9458,7 @@ fiberwave.online,Fiber Wave,ISP
 fiberwaves.com,Fiberwaves S.A.L,ISP
 fiberway.com.ar,Fiberway,ISP
 fiberway.pl,Fiberway,ISP
+fiberwest.net,fiberwest.net,ISP
 fiberwi.com.br,Fiberwi Telecomunicaçoes,ISP
 fiberwide.com,Fiberwide,ISP
 fiberwifi.mx,Fiberwifi SA de CV,ISP
@@ -9147,6 +9469,7 @@ fiberxpress.net,FiberXpress,ISP
 fiberzone.in,Fiberzone,ISP
 fiberzone.pl,Fiberzone,ISP
 fiberztelecom.com,Fiber Z Telecom,ISP
+fibex.do,Fibex Telecom,ISP
 fibextelecom.net,Fibex Telecom,ISP
 fibia.dk,Fibia,ISP
 fibim.com.tr,FibimNET,ISP
@@ -9177,6 +9500,7 @@ fibramax.net,Fibra Amneville,ISP
 fibramax.net.br,Fibramax Internet Banda Larga,ISP
 fibrandes.com.pe,Telecom Bolivia S.A.C,ISP
 fibranet.com.ar,Villeneuve Group,ISP
+fibranet.com.gt,FibraNet,ISP
 fibranet.net.br,Telextra Telecomunicacoes,ISP
 fibranet.tv,Fibranet,ISP
 fibranetbr.com.br,FibranetBR,ISP
@@ -9259,6 +9583,7 @@ fill.ee,Fill,ISP
 fillnet.com.br,"Fillnet | Provedor de Internet, Comércio Serviços de Informática",ISP
 filomeno.eu,Filomeno WiFi,ISP
 fimnet.co.ke,Fimnet Communications,ISP
+finabank.com,Guaranty Trust Bank (Kenya),Finance
 financetrust.co.ug,Finance Trust Bank,Finance
 finanzaworld.it,FinanzaWorld,Finance
 finanzaworld.net,FinanzaWorld,Finance
@@ -9273,6 +9598,7 @@ finet.id,Finet,ISP
 finishlineit.com,Finish Line,ISP
 fink-telecom.com,Andreas Fink trading as Fink Telecom Services,ISP
 fink.org,Andreas Fink trading as Fink Telecom Services,ISP
+fino.co.in,Internet Content Provider,ISP
 finovy.com,Finovy Group,Web Host
 finsb.ru,Bank Finservice,Finance
 finstarbank.ru,PJSC Finstar Bank,Finance
@@ -9303,6 +9629,7 @@ first.gr,First Telecom,ISP
 firstatlanticbank.com.gh,First Atlantic Bank,Finance
 firstbanknigeria.com,First Bank of NG PLC,Finance
 firstcapitalbank.co.mw,First Capital Bank PLC,Finance
+firstcaribbeanbank.com,First Caribbean International Bank,Finance
 firstcitizens.com,First-Citizens Bank & Trust Company,Finance
 firstcityinternet.com,First City Internet,ISP
 firstcloudsecurity.net,CyberCision,Email Security
@@ -9341,6 +9668,7 @@ fishersisland.net,Fishers Island Telephone,ISP
 fisnet.ru,FISNet (Saturn Telecom),ISP
 fisquare.com,Infince,SaaS
 fit.edu,Florida Institute of Technology,Education
+fitchburgstate.edu,Fitchburg State University,Education
 fitelnetwork.com,FITEL Network,ISP
 fitnyc.edu,Fashion Institute of Technology,Education
 fittelecom.com.br,FIT Telecom (Vero),ISP
@@ -9369,6 +9697,7 @@ fjtec.com.br,FJTEC,ISP
 fksecurity.com.br,FK Net.Com,Web Host
 fl.gov,State of Florida,Government
 flagler.edu,Flagler College,Education
+flaglerclerk.gov,Flagler County Clerk of the Circuit Court & Comptroller,Government
 flagman.zp.ua,Flagman Telecom,ISP
 flagstar.com,Flagstar Bank,Finance
 flagtel.com,Flag Telecom,ISP
@@ -9442,6 +9771,7 @@ floridasupremecourt.org,Florida Supreme Court,Government
 floridaurologypartners.com,Florida Urology Partners,Healthcare
 flotek.io,Flotek UK,ISP
 flowfinity.com,Flowfinity,ISP
+flownet.co.uk,Flownet Solutions,MSP
 flowvps.com,Alpha Layer,Web Host
 flroofingcompany.com,Florida Roofing Company,Construction
 flttelecom.com.br,Flt Solutions Telecom,ISP
@@ -9489,6 +9819,8 @@ fmchealth.org,Fairfield Medical Center,Healthcare
 fmcna.com,Fresenius Medical Care,Healthcare
 fmd.ag,FMD,Web Host
 fmitelecom.fr,FMI Telecom,ISP
+fmiweb.com,Franklin Mutual Insurance Company,Finance
+fmkctelecom.com,Fmkc Telecom,ISP
 fmtc.com,Farmers Mutual Telephone Company,ISP
 fmtcnet.com,"The Farmers Mutual Telephone Company of Stanton, Iowa",ISP
 fmu.ac.jp,Fukushima Medical University,Education
@@ -9628,6 +9960,7 @@ foxcell.net,Foxcell Communication,ISP
 foxcloud.net,FOXCLOUD,Web Host
 foxconect.net.br,Fox Conect Provedor de Internet,ISP
 foxconn.com.cn,Foxconn,Manufacturing
+foxelltelecom.com.br,Foxell Telecom Serviços de Telecomunicação,ISP
 foxfiber.com.br,Fox Fiber,ISP
 foxinfo.net.br,FOXINFO Telecom,ISP
 foxinternet.com.br,FOX Internet Banda Larga,ISP
@@ -9681,6 +10014,8 @@ frazmtn.net,Frazier Mountain Internet Service,ISP
 frcbd.net,Md. Raisul Islam,ISP
 freakhosting.com,FreakHosting,Web Host
 freddiemac.com,Freddie Mac,Finance
+frederick.health,"Healthcare Services in Frederick County, MD",Healthcare
+frederickcountymd.gov,Frederick County MD,Government
 fredonia.edu,SUNY Fredonia,Education
 free.fr,Free,ISP
 free.org,Free,ISP
@@ -9724,10 +10059,12 @@ fresno.gov,City of Fresno,Government
 fresnocountyca.gov,County of Fresno,Government
 freynet.com.br,freynet telecom,ISP
 frgp.net,Front Range GigaPoP,Education
+fridayfirm.com,"Friday, Eldredge & Clark, LLP",Healthcare
 friktoria.com,George Sgouridis trading as Friktoria.com - Data Center Services,Web Host
 frinet.com.br,Frinet,ISP
 frinseginternet.com.br,FIG Telecomunicações,ISP
 frionline.com.br,FriOnline,ISP
+friscoisd.org,Frisco Independent School District,Education
 friscotexas.gov,City of Frisco,Government
 froedterthealth.org,Froedtert Health,Healthcare
 froedtertsouth.com,Froedtert South,Healthcare
@@ -9747,6 +10084,7 @@ frozecommunications.com,Froze Communications,ISP
 frsousa.app.br,FR Sousa Telecomunicações,ISP
 frtib.gov,Federal Retirement Thrift Investment Board,Government
 fruits.jp,Yamanashi CATV Co,ISP
+frv.vic.gov.au,Fire Rescue Victoria,Government
 fsbank.com,First Security Bank,Finance
 fscj.edu,Fscj,Education
 fsec.or.kr,Financial Security Institute,Education
@@ -9808,6 +10146,7 @@ fulltelecom.com.py,Full Telecomunicaciones,ISP
 fulltelecom.net,Full Telecom,ISP
 fulltimehosting.net,Full Time Hosting,Web Host
 fulltv.cl,Servicios DE Telecomunicaciones Fulltv Limitada,ISP
+fultonbank.com,Fulton Bank,Finance
 fultoncountyga.gov,Fulton County Government,Government
 fundaments.nl,Fundaments,Web Host
 funeralone.net,funeralOne,SaaS
@@ -9846,6 +10185,7 @@ futuroexito.pl,Futuro Exito Sp. z o.o.,ISP
 futurowireless.com.br,Biasus E Biasus,ISP
 fuz.pl,"Wyszków, Pułtusk | FUZ",ISP
 fv-berlin.de,Forschungsverbund Berlin,Science
+fvcc.edu,Flathead Valley Community College,Education
 fw-t.ru,Forward Telecom,ISP
 fwcs.k12.in.us,Fort Wayne Community Schools,Education
 fwnetworks.co.uk,F and W Networks,ISP
@@ -9892,14 +10232,17 @@ g9.pt,G9 Portugal,ISP
 ga.com,General Atomics,Defense
 ga.gov,State of Georgia,Government
 gabia.com,Gabia,Web Host
+gabix.ga,GABIX,ISP
 gabn.net,Georgia Business Net,ISP
 gabontelecom.ga,Gabon Telecom,ISP
+gabriels.net,Gabriels Technology,Real Estate
 gabrimar.com.br,Gabrimar Telecom,ISP
 gacaradio.com,Georgia-Carolina Radiocasting,Entertainment
 gaertner.de,Gaertner Datensysteme GmbH & Co,Web Host
 gafibra.com.br,GA Telecom,ISP
 gaggle.net,Gaggle,SaaS
 gagratel.ru,"""Gagra Telecom""",ISP
+gaithersburgmd.gov,City of Gaithersburg,Government
 galait.net,Corporación Gala IT,ISP
 galanet.com.ve,Galanet,ISP
 galatea.pl,GALATEA - Dominik Budzowski,ISP
@@ -9917,6 +10260,7 @@ galaxysoft.group,Galaxy Software,ISP
 galaxytelcom.com,HK Galaxy Telecom Holding CO,ISP
 galaxyweb.ch,Galaxyweb,Web Host
 galcom.net.ua,Galichina Telekommunication,ISP
+galileo.edu,Universidad Galileo,Education
 galizanet.com.br,GalizaNET,ISP
 gallagherbassett.com,Arthur J. Gallagher,Finance
 gallaudet.edu,Gallaudet University,Education
@@ -9955,6 +10299,7 @@ gardner-webb.edu,Gardner-Webb University,Education
 garena.com,Garena,Entertainment
 garena.tw,Garena Taiwan,Entertainment
 garena.vn,Garena Vietnam,Entertainment
+garfieldre2.org,Garfield School District No. RE-2,Education
 garlic.com,South Valley Internet,ISP
 garr.it,GARR,Education
 garratelecom.com,Garra Fibra,ISP
@@ -10015,6 +10360,7 @@ gcatelecom.com.sv,GCA TELECOM,Healthcare
 gcb.com.gh,GCB Bank PLC,Finance
 gccbdltd.com,Gardenia Cyber Communication,ISP
 gccitcom.com,GCC IT Communications,ISP
+gcfa.org,GCFA for The United Methodist Church,Religion
 gci.com,GCI,ISP
 gci.net,GCI,ISP
 gci.net.br,GCI Net,ISP
@@ -10045,6 +10391,7 @@ gdmtelecom.com.br,GDM TELECOM,ISP
 gdnetfibra.com.br,GD Net Fibra,ISP
 gds-services.com,GDS,Web Host
 gdstelecom.com.br,susana g de souza,ISP
+gdt.com,GDT,MSP
 gdyunjie.com,YunJie Communication HK,ISP
 ge.ch,Canton of Geneva,Government
 geant.org,GEANT,Education
@@ -10060,6 +10407,7 @@ gehealthcare.com,GE HealthCare (United States),Healthcare
 gehirn.ne.jp,Gehirn,Web Host
 geico.com,GEICO,Finance
 geisinger.org,Geisinger,Healthcare
+gelirler.gov.tr,T.C. Maliye Bakanligi Gelirler Genel Mudurlugu,Government
 gelsen-net.de,GELSEN-NET,ISP
 gemenii.ro,Gemenii Network,ISP
 gemini.net.pl,Gemini,ISP
@@ -10084,6 +10432,7 @@ generixgroup.com,Generix Soft Group Romania,Web Host
 geneseo.com,Geneseo Communications,ISP
 geneseo.edu,SUNY Geneseo,Education
 genesisfibra.com.br,Gênesis COM DE Computadores,ISP
+genesishcs.org,Genesis Healthcare System,Healthcare
 genesishosting.com,Genesis Hosting Solutions,Web Host
 genestelecom.ca,Gene's Telecom,ISP
 genesys.com,Genesys Telecommunications Laboratories,ISP
@@ -10103,11 +10452,14 @@ genoray.com,GENORAY,Healthcare
 genpact.com,Genpact,MSP
 genstarnetcable.com,Gennstar Network Solutions,ISP
 gentetelecom.com.br,Gente Telecom,ISP
+gentex.com,Gentex,Automotive
+genuity.com.au,Genuity,Retail
 genworth.com,Genworth Financial,Finance
 genworx.sg,Genworx,Web Host
 geny.it,Geny Communications SRL,ISP
 genznet.id,GENZNET,ISP
 geo.hosting,GEO.Hosting,Web Host
+geo.tv,"IMC, Karachi",News
 geocity.co.in,Geocity Network,ISP
 geofiber.com.ar,GEOFIBER | INTERNET SIN LIMITES,ISP
 geolinks.com,GeoLinks,ISP
@@ -10179,6 +10531,7 @@ gfourtelecom.com.br,Gfour Telecom,ISP
 gfs.com,Gordon Food Service,Healthcare
 gfsu.edu.in,National Forensic Sciences University,Education
 gftfiber.com,Fiberlink Communication,ISP
+gg.go.kr,Gyeonggi-Do Fire Services,Government
 gga.ch,GGA Maur,ISP
 ggcity.org,City of Garden Grove,Government
 ggdu.net,Al Ard Al Thahabia Phone & Internet Devices Trading L.L.C,ISP
@@ -10205,6 +10558,7 @@ ghttelecom.com.br,GHT Telecom,ISP
 ghx.com,GHX,Healthcare
 gi-comms.com,Telecommunications Company Singapore | GIComms,ISP
 gia.edu,GIA,Education
+giant.net.uk,Giant Communications,ISP
 gianteagle.com,Giant Eagle,Healthcare
 giantpartners.com,Giant Partners,Marketing
 giatechnet.com.br,Giatech Telecomunicações,ISP
@@ -10262,6 +10616,7 @@ giganet.hu,Giganet Internet Szolgaltato,ISP
 giganet.info.pl,"Giganet Internet Mogilany, Kraków",ISP
 giganet.iq,GigaNet Telecom,ISP
 giganet.net.pl,Telewizja | gigaNet,ISP
+giganet.tec.br,Giganet,ISP
 giganetaraxa.com.br,Giganet Telecom,ISP
 giganetbr.com.br,Giga Net,ISP
 giganetco.com,GIGA-NET,ISP
@@ -10275,6 +10630,7 @@ giganetviana.com.br,Giga Net Informática,ISP
 giganineveh.com,Giga Nineveh for internet services,ISP
 gigapacket.net,GigaPacket,Web Host
 gigapop.com.ve,GigaPop Internet,ISP
+gigapop.online,GigaPop Internet Services,ISP
 gigared.com.ar,Gigared,ISP
 gigaredcentro.com,GIGARED,ISP
 gigarede.com.br,Giga Rede Internet,ISP
@@ -10302,6 +10658,8 @@ gilanet.net,Gila River Telecommunications,ISP
 gilat.net,Gilat Telecom,ISP
 gilead.com,Gilead Sciences,Healthcare
 gilesonline.com.ar,Giles Online (Neophone),ISP
+gilhospital.com,Gachon University Gil Hospital,Education
+gillettechildrens.org,Gillette Children's,Healthcare
 gilsonnet.com.br,Gilson NET Fibra,ISP
 gimpa.edu.gh,GIMPA,Education
 ginesia.id,Giga Network Indonesia,ISP
@@ -10317,6 +10675,7 @@ gironet.co.za,Gironet (PTY),ISP
 gironetfibra.com.br,GironetFibra,ISP
 gis.net.br,GIS Internet,ISP
 gis.net.id,GISNET,ISP
+gisd.org,Galveston ISD,Education
 gispl.net,Gigantic Internet Services,ISP
 gissvr.com,gissvr.com,ISP
 gist.ac.kr,GIST Gwangju Institute of Science and Technology,Education
@@ -10332,7 +10691,9 @@ gitlab.com,GitLab,SaaS
 gitlab.io,GitLab,SaaS
 gitn.com.my,GITN Malaysia,ISP
 gitoyen.net,Gitoyen,ISP
+gixa.org.gh,Ghana Internet Exchange Association,ISP
 gj2internet.com,Gj2 Internet,ISP
+gjlabs.com.br,GJ Labs,Consulting
 gk2.net.br,GK2.CLOUD,Web Host
 gkgnetwork.com.br,GKGNET,ISP
 gksvyaz.ru,GK Svyaz,ISP
@@ -10351,9 +10712,11 @@ glccom.com,Great Lakes Communication,ISP
 glcnetcom.it,GLC Netcom,ISP
 glcom.net,Great Lakes Comnet,ISP
 glconect.com.br,GL Telecom,ISP
+gleim.com,Gleim Exam Prep,ISP
 glenbrook225.org,Glenbrook High School District,Education
 glendaleca.gov,Verdugo Fire Communications Center,Government
 gleneira.vic.gov.au,Glen Eira City Council,Government
+glenmede.com,Glenmede,Finance
 glenten.dk,Glenten Odense,ISP
 glercimor.com,Glercimor Network AND Data Solution,ISP
 glesys.com,Glesys,Web Host
@@ -10382,6 +10745,7 @@ global.fujitsu,Fujitsu,Manufacturing
 global.ntt,NTT,ISP
 global63.net,Global Telecom Co,ISP
 globalbandalarga.com.br,Global Banda Larga,ISP
+globalbank.com.pa,"Global Bank, tu banco de confianza",Finance
 globalcitra.id,Global Citra Teknologi,ISP
 globalcloudlink.com,Global Link Communications,ISP
 globalcolocation.net,Global Custom Data,Web Host
@@ -10394,6 +10758,7 @@ globalconnect.dk,GlobalConnect,ISP
 globalconnect.net,GlobalConnect,ISP
 globalconnect.se,GlobalConnect,ISP
 globalconnectgroup.com,GlobalConnect,ISP
+globalcu.org,Global Credit Union,Finance
 globalfiber.com.pe,Satelital Telecomunicaciones S.A.C,ISP
 globalfiberbrasil.com.br,Global Fiber Brasil,ISP
 globalfibertel.com,VI Global Fibertel,ISP
@@ -10424,6 +10789,7 @@ globalnetworkcompany.net,Global Network Point,Web Host
 globalnoc.net,equada network,ISP
 globalnusantara.net.id,Global Nusantara Internet,ISP
 globalonlinebd.com,Global Online BD,ISP
+globalp.com,Global Companies,Logistics
 globalpaymentsinc.com,Global Payments,Finance
 globalrelay.com,Global Relay Communications,ISP
 globalsecurelayer.com,Global Secure Layer,ISP
@@ -10434,6 +10800,7 @@ globaltechtelecom.com.br,Globaltech Telecomunicações e Informatica,ISP
 globaltel-llc.com,Global Telecom,ISP
 globaltelecom-mt.com.br,Global Telecom,ISP
 globaltelecom.com.ar,Global Telecomunicaciones,ISP
+globaltelekomunikasi.net,Global Nusa Telekomunikasi,ISP
 globaltt.com,Global Telephone & Telecommunication S.A. (GT&T),ISP
 globalways.net,Globalways,ISP
 globalwifi.com.ar,Global Wifi,ISP
@@ -10511,6 +10878,7 @@ gnetweb.com.br,G Netweb Telecom,ISP
 gnetworkbd.com,Galaxy Cyber Cafe,ISP
 gnetworkve.com,G-Network,ISP
 gnomen.co.uk,Gnomen,Real Estate
+gnp.com.mx,GNP Seguros,Finance
 gns.co.za,GNS,ISP
 gns.cri.nz,GNS Science New Zealand,Science
 gnsfibra.com.br,GNS Fibra,ISP
@@ -10537,6 +10905,7 @@ gobrolly.com,Brolly Communications,ISP
 gocache.com.br,3L Cloud Internet Services,ISP
 gocloudwave.com,CloudWave,Healthcare
 goco.ca,TELUS,ISP
+gocolumbiamo.com,"City of Columbia, MO",Government
 goconnect.co.za,Go Communications Network (Pty),ISP
 goctc.com,Consolidated Telephone Company,ISP
 godaddy.com,GoDaddy,Web Host
@@ -10550,6 +10919,7 @@ gogoair.com,Gogo,ISP
 gograssroots.ca,Harmonize Networks,ISP
 gogreencloud.com,11:11 Systems (Green Cloud),MSP
 gogvo.com,Global Virtual Opportunities,Web Host
+gohealth.com,GoHealth,Finance
 gohighpoint.com,HighPoint,MSP
 gohost.kz,Fedinyak Sergey Vyacheslavovich,Web Host
 gohosting.com.au,GoHosting,Web Host
@@ -10645,6 +11015,7 @@ goteborg.se,City of Gothenburg,Government
 gotelecom.com.br,VOIPGLOBE SERVICOS DE COM MULTIMIDIA VIA INTERNET,ISP
 goth-project.io,Thales (GoTH Project),Defense
 gotmyhost.com,GOTMYHOST,Web Host
+gotnpayments.com,TransNational Bank Card,Finance
 gotpantheon.com,Pantheon,Web Host
 gotrinity.com,Trinity Network Solutions,ISP
 gotrinity.net,Trinity Communications,ISP
@@ -10691,6 +11062,7 @@ gpinternet.ru,GP Internet,ISP
 gpkgroup.com.au,IT Solutions | GPK Group,MSP
 gplat.co.za,Gplat,ISP
 gpm.co.id,Giga Patra Multimedia,ISP
+gpmlife.com,GPM Life Insurance Company,Finance
 gpnetworks.ca,G.P.N. Wireless Network Solutions,ISP
 gpo.gov,US Government Publishing Office,Government
 gpon.com.ua,PE Romanika Andriy Oleksandrovych,ISP
@@ -10741,6 +11113,7 @@ grayshottgigabit.com,Grayshott Gigabit,ISP
 graysmark.net,Graysmark Business Systems,MSP
 graysoncollin.com,Cutter Communications,MSP
 grcc.edu,Grand Rapids Community College,Education
+greaterregional.org,Greater Regional Health,Healthcare
 greatforti.com,Anpple Tech,Web Host
 greatmail.com,Greatmail,Email Provider
 greatriverenergy.com,Great River Energy,Utilities
@@ -10784,10 +11157,14 @@ greenmountainpower.com,Green Mountain Power,Utilities
 greennetworkbd.com,Green Network,ISP
 greenpacketglobal.com,Green Packet Global,ISP
 greenspruceisp.com,GreenSpruce Internet Services,ISP
+greenstonefcs.com,GreenStone Farm Credit Services,Finance
 greentelecom.co.tz,Green Telecom,ISP
 greentelecom.net.br,Green Telecom,ISP
 greentreefrog.net.au,Green Tree Frog,ISP
 greenviewdata.com,Greenview Data,Email Security
+greenvillecounty.org,Greenville County,Government
+greenvillenc.gov,"Greenville, NC",Government
+greenvillesc.gov,"Greenville, SC",Government
 greenwayhealth.com,Greenway Health,Healthcare
 greenweb.ir,Green Web Samaneh Novin,Web Host
 gremimedia.pl,Gremi Media,News
@@ -10799,6 +11176,8 @@ greyhound.com,Greyhound Lines,ISP
 greystoneconnect.com,GreyStone Connect (GreyStone Power),Utilities
 greywolf.sg,Greywolf Networks,Web Host
 grfastnet.net.br,GR Fast NET Telecomunicacoes,ISP
+grh.org,Grande Ronde Hospital,Healthcare
+grhs.net,Great River Health Systems,Healthcare
 grid-telecom.com,Grid Telecom,ISP
 grid4.com,Grid4 Communications,ISP
 gridcommunications.net,Grid Communications,ISP
@@ -10811,6 +11190,7 @@ grinnell.edu,Grinnell College,Education
 grivanet.com,GRIVANET,ISP
 grm.net,GRM Networks,ISP
 grmc.org,Gila Regional Medical Center,Healthcare
+grmedcenter.com,Guadalupe Regional Medical Center,Healthcare
 grnet.gr,GRNET,Education
 grnettelecom.com.br,Grnet Telecom,ISP
 grobogan.go.id,Dinas Komunikasi dan Informatika Kabupaten Grobogan,Government
@@ -10832,6 +11212,7 @@ grs.net.pl,GRS Net,ISP
 grslink.com.np,GRS Link Internet Service,ISP
 grsolucoestelecom.com.br,GR Soluções Telecom,ISP
 gru.com,Gainesville Regional Utilities,Utilities
+gruma.com,GRUMA,Food
 grund-fibre.uk,Grundfibre,ISP
 grupaping.pl,Grupa PING,ISP
 grupoantares.net,Servicios Technologicos Antares de Costa Rica,Web Host
@@ -10848,6 +11229,7 @@ grupofonelight.com.br,Fonelight Telecomunicações S/A,ISP
 grupog5telecom.com.br,G5 TELECOM,ISP
 grupogmaes.com,AI Brazil Technologies & Datacenter,Web Host
 grupohard.com.br,Hard Web Wireless Comunicações,ISP
+grupohiper.net,Grupo Hiper,ISP
 grupohost.com.br,Grupohost Comunicacao Multimidia,ISP
 grupoi5.com.br,I5 Telecom,ISP
 grupoice.com,ICE,ISP
@@ -10971,6 +11353,7 @@ guabi.com.ar,Internet en Córdoba | Guabi,ISP
 guajiranet.com,GUAJIRANET ISP,ISP
 guamcc.edu,Guam Community College,Education
 guamcell.net,GuamCell,ISP
+guanajuato.gob.mx,Gobierno del Estado de Guanajuato,Government
 guapnet.com.br,Guapnet Telecom,ISP
 guaptel.com.br,Guaptel Telecom,ISP
 guardedhost.com,Omnis Network,Web Host
@@ -10983,7 +11366,9 @@ guilford.edu,Guilford College,Education
 guj.de,Gruner + Jahr (RTL Deutschland),Publishing
 gujarat.gov.in,Gujarat Informatics,Government
 gulbarganet.in,Gulbarga NET Internet Cable Service,ISP
+gulfafricanbank.com,Gulf African Bank,Finance
 gulfbank.com.kw,Gulf Bank,Finance
+gulfcablenetwork.com,Gulf Cable Network (Smc-Pvt.),ISP
 gulfcoast.edu,Gulf Coast State College,Education
 gulfport-ms.gov,City of Gulfport,Government
 gulfstreamaircraft.com,Gulfstream Aerospace,Manufacturing
@@ -10994,11 +11379,13 @@ gunadarma.ac.id,Gunadarma University,Education
 gundersenhealth.org,Gundersen Lutheran Medical Center,Healthcare
 gungchil.net,GUNGCHIL,ISP
 gunma-u.ac.jp,Gunma University,Education
+gunnisonvalleyhealth.org,Gunnison Valley Health,Healthcare
 gunungkidulkab.go.id,Pemerintah Kabupaten Gunungkidul,Government
 gustavus.edu,Gustavus Adolphus College,Education
 gutabank.ru,Guta-Bank,Finance
 guthrie.org,Guthrie Healthcare System,Healthcare
 guthriecounty.gov,Guthrie County,Government
+gutmann.at,Bank Gutmann,Finance
 guzel.net.tr,GNET (Guzel Internet),ISP
 gva.africa,GVA (Canal+),ISP
 gva.es,Generalitat Valenciana,Government
@@ -11036,6 +11423,7 @@ ha-vel.cz,ha-vel internet,ISP
 hab-inc.com,Berkheimer,Finance
 habari.co.tz,Habari Node,ISP
 habiganj.net,Habiganj Net Communications (HNC),ISP
+hacc.edu,Harrisburg Area Community College,Education
 hacettepe.edu.tr,Hacettepe Universitesi,Education
 hachn.am,Hachn ISP,ISP
 hacinet.com,Hacinet,ISP
@@ -11050,10 +11438,12 @@ hai-alive.com.zm,Hai Telecommunications,ISP
 haileybury.vic.edu.au,Haileybury,Education
 haion.net,HAIonNet,ISP
 haitongib.pl,Haitong Bank,Finance
+haj.gov.sa,Ministry of Hajj and Umrah,Government
 hal.ne.jp,"HAL Internet, Internet Service Provider, Tottori, Japan",ISP
 halasat-ftth.iq,Hala Al Rafidain Company for Communications and Internet,ISP
 halasat.net,Hala Al Rafidain Company for Communications and Internet,ISP
 hale-center.k12.tx.us,Region 17 Education Service Center,Education
+halfbat.net,Half Bat Network,Web Host
 halifax.ca,Halifax Regional Municipality,Government
 hallcon.com,Hallcon,Healthcare
 halleytelecom.com,Halley Telecom Comercio & Serviço,ISP
@@ -11067,7 +11457,9 @@ halver.com.br,Halver,Web Host
 halykbank.ge,Halyk,Finance
 halykbank.kz,Halyk Bank,Finance
 hamiltel.com,Hamilton Telecom,ISP
+hamilton.ca,Hamilton Public Library,Government
 hamilton.edu,Hamilton College,Education
+hamiltoncountyohio.gov,"Hamilton County, Ohio",Government
 hamline.edu,Hamline University,Education
 hammacher.com,Hammacher Schlemmer,Retail
 hammerfestenergi.no,Hammerfest Energi,Utilities
@@ -11103,12 +11495,15 @@ hapay.pl,HAPAY,ISP
 hapihhost.in,M/S Harvil Media,Web Host
 haplink.com.cn,Shanghai Telecom Haplink Network,ISP
 hapotele.ru,HAPOTELE,ISP
+happypeering.net,Happy Peering,ISP
 harborcommunications.com,harborcommunications.com,ISP
 harbourit.com.au,Canon Business Services Australia,MSP
 harding.edu,Harding University,Education
 hardliga.com.ua,Khart Liague OF Treyd,ISP
 hardynet.com,Hardy Telecommunications,ISP
 harenet.ad.jp,Harenet,ISP
+harford.edu,Harford Community College,Education
+harfordcountymd.gov,"Harford County, MD",Government
 hargray.com,Hargray,ISP
 harmonika.id,Harmonika ID,ISP
 harmony-hosting.com,Harmony Hosting,Web Host
@@ -11117,6 +11512,7 @@ harmonynetworks.net,Harmony Networks,ISP
 harmonytel.com,Spring Grove Communications,ISP
 harper.cc.il.us,Harper College,Education
 harrisbank.com,Harris Trust & Savings Bank,Finance
+harriscountyesd11.gov,Harris County ESD 11 Mobile Healthcare,Healthcare
 harriscountytx.gov,Harris County,Government
 harrishealth.org,Harris Health System,Healthcare
 hartcom.com,Hart Communications,ISP
@@ -11195,6 +11591,7 @@ hchdfoundation.org,Harris Health System,Healthcare
 hcinet.net,Hanson Communications,ISP
 hcltech.com,HCLTech,MSP
 hcltechnologies.com,HCL Technologies,MSP
+hcm-hitachi.com,Hitachi Cable Manchester,ISP
 hcn.co.kr,Hyundai HCN,ISP
 hcn.com.au,Health Communication Network PTY,ISP
 hcn.gr,HCN Hellenic Cable,ISP
@@ -11241,6 +11638,7 @@ hechoviainternet.com.br,Hecho VIA Internet,ISP
 hedefhosting.com.tr,Hedef Hosting,Web Host
 hehe.si,Hehe,Web Host
 heidelberg-it.de,Heidelberg iT,Web Host
+heidentechnology.com,Heiden Technology Solutions,MSP
 heinlein-support.de,Heinlein Support,Web Host
 hel.fi,City of Helsinki,Government
 helbling-net.ch,Helbling Networks,ISP
@@ -11298,6 +11696,7 @@ hermetek.com,HermeTek,MSP
 herning.dk,Herning Municipality,Government
 hero.co.nz,Blue Reach Services,ISP
 herokuapp.com,Heroku,PaaS
+heron.at,Heron Innovations Factory,Manufacturing
 heros-bg.net,Heros ПОКРИТИЕ,ISP
 herotel.com,Herotel,ISP
 hersheytel.net,Hershey Cooperative Telephone CO,ISP
@@ -11365,6 +11764,7 @@ highmark.com,Highmark,Healthcare
 highnet.com,HighNet (Focus Group),ISP
 highperformancecdn.com,Internet Tubes,ISP
 highpoint.edu,High Point University,Education
+highpointnetworks.com,High Point Networks,MSP
 highradiuscorp.com,HighRadius,Finance
 highrapid.com,High Rapid Networks,ISP
 highspeed-sy.com,High Speed For Internet Services L.L.C,ISP
@@ -11396,6 +11796,7 @@ himawarinet.ne.jp,HimawariTV.,ISP
 himax.com.pl,FiBerHiMax,ISP
 himelinternet.com,Himel Internet Service,ISP
 himelonline.com,Himel Online,ISP
+hindscc.edu,Hinds Community College,Education
 hinet.net,HiNet,ISP
 hinet.net.py,Hinet,ISP
 hinet.net.vn,Hanoi Telecom,ISP
@@ -11406,6 +11807,7 @@ hiperline.ru,Hiperline (Гиперлайн),ISP
 hipernet.com.tr,Hipernet Telekom,ISP
 hiperonline.com.tr,Hiperonline,ISP
 hipointinc.com,HiPoint Technology Services,MSP
+hipotecario.com.ar,Banco Hipotecario Sociedad Anonima,Finance
 hiqdata.net,hiQ Data,MSP
 hiram.edu,Hiram College,Education
 hiranitelcom.co.ke,Hirani Telecommunication,ISP
@@ -11477,6 +11879,7 @@ hmu.gr,Hellenic Mediterranean University,Education
 hn.cl,HN,Web Host
 hnb.net,Hatton National Bank PLC,Finance
 hnet.net.br,Hnet Telecom,ISP
+hneu.edu.ua,Simon Kuznets Kharkiv National University of Economics,Education
 hnhosting.net,HNHosting,Web Host
 hns.com,Hughes Network Systems,ISP
 hns.net.br,HNS Servicos DE Telecomunicacoes,ISP
@@ -11505,8 +11908,10 @@ holistictech.net,Holistic Technologies,MSP
 holkerit.co.uk,Holker Network Solutions,MSP
 hollandbpw.com,Holland Board of Public Works,ISP
 hollandc.pe.ca,Holland College,Education
+hollard.co.za,Hollard,Finance
 holline.com.br,Holline Internet Optic Provider,ISP
 hollywoodconnect.co.za,HOLLYWOOD CONNECT (PTY),ISP
+holmescc.edu,Holmes Community College,Education
 holnet.com.br,holnet internet provider,ISP
 holstonelectric.com,Holston Electric Cooperative,Utilities
 holycross.edu,College of the Holy Cross,Education
@@ -11564,6 +11969,7 @@ honorhealth.com,HonorHealth,Healthcare
 hood.edu,Hood College,Education
 hoodcanal.net,Hood Canal Communications,ISP
 hooplahosting.co.nz,Hoopla Hosting,Web Host
+hoopp.com,Healthcare of Ontario Pension Plan Trust Fund,Healthcare
 hop-electric.com,Hopkinsville Electric (EnergyNet),Utilities
 hope.edu,Hope College,Education
 hopela.fr,HOPELA,Web Host
@@ -11681,6 +12087,7 @@ hosting.com,A2 Hosting,Web Host
 hosting.de,hosting.de,Web Host
 hosting.ie,Irish Domains Limited,Web Host
 hosting.international,Hosting.international,Web Host
+hosting27.com,Hosting-27,Web Host
 hosting2go.nl,Hosting2GO,Web Host
 hostingan.id,Hostingan Awan Indonesia,Web Host
 hostingb2b.com,Hosting B2B,Web Host
@@ -11717,6 +12124,7 @@ hostiran.net,Hostiran,Web Host
 hostireland.com,Elio Networks (HostIreland),ISP
 hostiserver.com,Fully managed hosting services provider ▶️ HOSTISERVER,Web Host
 hostit.host,HostIT,Web Host
+hostixo.com,Hostixo,ISP
 hostkey.com,HOSTKEY,Web Host
 hostkey.ru,HostKey,Web Host
 hostlab.com,HostL,Web Host
@@ -11747,6 +12155,7 @@ hostoff.net,HOSTOFF.NET,Web Host
 hostomega.com,Hostomega,Web Host
 hostone.com.br,Host One,Web Host
 hostonion.com,Hostonion,Web Host
+hostoo.io,Hc4W - Solucoes EM Tecnologia E Hospedagem,Web Host
 hostopia.com,Hostopia,Web Host
 hostoweb.com,"VPS, Serveurs Dédiés, Noms de Domaine & Cloud – HOSTOWEB",Web Host
 hostpacific.com,HostPacific.com,Web Host
@@ -11800,6 +12209,7 @@ hotel-icon.com,Hotel ICON,Travel
 hotelhugony.com,Hotel Hugo New York,Travel
 hotfibre.co.za,HotFibre Pty (Ltd),ISP
 hotlan.net.ua,HotLan,ISP
+hotlingnetwork.net,Hot Ling Network,ISP
 hotlink.com.br,Hotlink Internet,ISP
 hotlinks.co.uk,Hotlinks Internet Services,Web Host
 hotmail.com.br,COM Telecom,ISP
@@ -11833,6 +12243,7 @@ hpe.com,Hewlett Packard Enterprise,Technology
 hpntelecom.com.br,HPN Telecomunicações,ISP
 hps-solutions.nl,SLTN Telecom Professional Services,ISP
 hptelecom.com.br,HP Telecom,ISP
+hpu.edu,Hawaii Pacific University,Education
 hqserv.co.il,Rachamim Aviel Twito,Web Host
 hr-net.com.br,"HR NET – HRNET – Compromisso com a Qualidade, Sempre!",ISP
 hr.de,Hessischer Rundfunk,Government Media
@@ -11860,6 +12271,7 @@ hsl.org.br,Hospital Sírio-Libanês,Healthcare
 hslda.net,Home School Legal Defense Association (HSLDA),Education
 hslda.org,Home School Legal Defense Association (HSLDA),Education
 hslink.com.br,HSLINK Telecom,ISP
+hsmc-ul.com,Home Security AND Management CO,Physical Security
 hspherefilter.com,"DynamicNet, Inc. (DNI)",Web Host
 hss.edu,HSS,Healthcare
 hstele.com,Bilad Al-Rafidain Company for Informatics and Communications Services,ISP
@@ -11900,6 +12312,7 @@ hub-tn.com,Harriman Utility Board,ISP
 hub66.com,Hub66,ISP
 hubara.es,HUBARA hosting solutions,Web Host
 hubelectronics.net,Coastal FiberNet,ISP
+hubgroup.com,Hub Group,Logistics
 hubone.fr,Hub One,ISP
 hubs.net.uk,HUBS,ISP
 hubspotemail.net,HubSpot,Marketing
@@ -11916,10 +12329,12 @@ hufs.ac.kr,Hankuk University of Foreign Studies,Education
 hugel-inc.com,Hugel,Healthcare
 hugeserver.com,HugeServer,Web Host
 hugetns.com,Huge TNS,ISP
+hughchatham.com,Hugh Chatham Memorial Hospital,Healthcare
 hughes.com,Hughes,ISP
 hughes.com.br,Hughes Brasil,ISP
 hughes.in,Hughes Communications India Private,ISP
 hughes.net,Hughes Network Systems,ISP
+hughesbros.com,Hughes Brothers,Utilities
 hughston.com,Hughston Clinic,Healthcare
 hugstelecom.com,Hugs Telecom,ISP
 huicast.com,Huicast Telecom,ISP
@@ -11947,12 +12362,15 @@ huronconsultinggroup.com,Huron,Healthcare
 hurontel.on.ca,HuronTel,ISP
 hurt-orange.pl,Orange Polska (Hurt),ISP
 hushmail.com,Hushmail,Email Provider
+husseycommunications.com,Hussey Communications,ISP
 husson.edu,Husson University,Education
 hust.edu.vn,HaNoi University of science and technology,Education
 hustel.net,Hustel Telecom,ISP
 hut8.com,Hut 8,IaaS
 hut8mining.com,Hut 8,IaaS
 hutch.lk,Hutch,ISP
+hutchcc.edu,Hutchinson Community College,Education
+hutchins.tas.edu.au,"The Hutchins School, Hobart Tasmania",Education
 hutchregional.com,Hutchinson Regional Medical Center,Healthcare
 huxcomm.net,Huxley Communications Cooperative,ISP
 hvacwebsites.com,Online Access,Marketing
@@ -12007,6 +12425,7 @@ i-delta.net,Интернет-провайдер Delta,ISP
 i-evolve.com,I-Evolve Technology Services,ISP
 i-house.ru,Republican Fund 'Mordovia-Internet',ISP
 i-link.net.ua,i-link,ISP
+i-net.am,iNet – Internet + TV provider,ISP
 i-netpartner.net,I-NetPartner GmbH Online Services,Web Host
 i-online.fr,Informatique ON Line,Web Host
 i-system.hk,i-System Technology,ISP
@@ -12119,10 +12538,12 @@ icbcstandardbank.com,ICBC Standard Bank PLC,Finance
 icc-media.co.jp,ICC Corporation,ISP
 icc.com.bd,ICC Communication,ISP
 icc.edu,Illinois Central College,Education
+iccms.edu,Itawamba Community College,Education
 iccsat.com,ICCSAT,ISP
 ice.co.cr,Grupo ICE,Industrial
 ice.go.kr,Inchon Metropolitan Office Of Education,Government
 iceconsulting.com,Ice Consulting,MSP
+icecube.nz,Icecube,Consulting
 icegate.gov.in,Directorate General Of Systems And Data Management,Government
 icehosting.nl,IceHosting,Web Host
 icenet.net.tr,ICENET Telekom Hizmetleri,ISP
@@ -12132,6 +12553,7 @@ icewarpcloud.in,IceWrap,Email Provider
 icewireless.com,Ice Wireless,ISP
 icfre.org,Indian Council of Forestry Research and Education,Government
 icfsystems.de,ICF Systems,Web Host
+ici.org,Investment Company Institute,Education
 ici.ro,ICI București,Government
 icisleri.gov.tr,Turkiye Cumhuriyeti Icisleri Bakanligi,Government
 icknet.co.jp,Imabari Catv,ISP
@@ -12160,6 +12582,7 @@ icomtex.ru,Intercomtex,ISP
 icona.ly,ICONA for IT and Telecom. LTD Co,ISP
 iconecta.com.br,Iconecta,ISP
 iconetelecom.com.br,Icone Serviços,ISP
+iconex.pe,Telcomnetperu S.A.C.-Telcomnet S.A.C,ISP
 iconfiber.co.ke,Icon Fiber Solutions,ISP
 iconicinternet.com,Iconic Internet,ISP
 iconn.net,Iconn,Web Host
@@ -12195,6 +12618,7 @@ ictc.com,Inter-Community Telephone Co,ISP
 ictglobe.com,ICTGlobe,ISP
 ictk.com,ICTK,Technology
 ictshift.com,ICTShift,MSP
+icttech.ca,ictTech,ISP
 ictv.jp,Iruma CATV,ISP
 icuk.net,ICUK,Web Host
 icwa.wa.gov.au,Insurance Commission of Western Australia,Government
@@ -12349,6 +12773,7 @@ iiasa.ac.at,IIASA International Institute for Applied Systems Analysis,Science
 iiat.ru,Institute of Information & Analytical Technologies (IIAT),Science
 iifon.org,IIFON,ISP
 iifrf.ru,Autonomous Non-Profit Organization Institute of Engineering Physics,Education
+iift.edu,Network of Indian Institute of Foreign Trade,Education
 iig.com.au,IIG,ISP
 iiht.com,IIHT,Education
 iiita.ac.in,Indian Institute Of Information Technology Allahabad,Education
@@ -12361,6 +12786,8 @@ iilm.gov.in,Indian Institute OF Legal Metrology,Government
 iinet.co.za,iiNet Connect,ISP
 iinet.net.au,iiNet,ISP
 iiph.com.au,Intelligent IP Hosting,Web Host
+iir.com,IIR,Education
+iiserb.ac.in,IISER Bhopal Campus,Education
 iiserpune.ac.in,Indian Institute Of Science Education And Research,Education
 iit.edu,Illinois Institute of Technology,Education
 iitb.ac.in,Indian Institute of Technology Bombay,Education
@@ -12425,6 +12852,7 @@ ilumi.net.br,Iluminet,ISP
 im3.id,IM3,ISP
 ima.sp.gov.br,IMA Informatica de Municipios Associados,Government
 imageonline.co.in,Image Online,Marketing
+imagestream.com,ImageStream,ISP
 imageworks.com,Sony Pictures Imageworks,Entertainment
 imageworld.fi,Image World,Web Host
 imagine.co.za,Imagine IPS,ISP
@@ -12458,6 +12886,7 @@ imjwanklikics.com,Imjwanklik Internet Communication Services,ISP
 immanuel.sa.edu.au,Immanuel College,Education
 immedion.com,Immedion (Centersquare),Web Host
 immense.net,Immense Networks,MSP
+immofinanz.com,Immofinanz,Real Estate
 immomeister.com,Immomeister,Real Estate
 imnet.com.br,Imnet,ISP
 imnisp.net,IMNisp,ISP
@@ -12471,6 +12900,7 @@ impa.br,IMPA,Education
 impactbusiness.com,Impact Business Solutions,ISP
 impactinternet.com,Impact Internet,ISP
 impactointernet.com.br,Impacto Internet,ISP
+impactonetfibra.com.br,Impacto NET Telecom,ISP
 impactonetwork.com.br,GE Network Provedor de Internet,ISP
 impactotelecom.com,Impacto Telecom,ISP
 imperial.net.ua,Imperial Net Ukraine,ISP
@@ -12511,6 +12941,7 @@ inan.cl,Grupo Inan,Web Host
 inasset.it,Retelit (InAsset),ISP
 inatel.br,Inatel,ISP
 inbroadband.net,inbroadband.net,ISP
+inca.gov.br,INCA,Healthcare
 incableinternet.com,In Cable Internet,ISP
 incapsula.com,Imperva,Email Security
 incas.de,INCAS,MSP
@@ -12531,6 +12962,7 @@ indanet.com.br,Indanet,ISP
 indco.net,Ind. CO. Cable TV,ISP
 indemed.com,Cardinal Health at-home (Formerly Independence Medical),Healthcare
 independence.k12.ia.us,Independence Telecommunications Utility,ISP
+independent-connections.com,Independent Connections,MSP
 indevis.de,indevis,MSSP
 index-education.com,Index Education,SaaS
 indexexchange.com,Index Exchange,Marketing
@@ -12585,6 +13017,7 @@ inet.de,INTERNET AG,Web Host
 inet.net.id,Inet Global Indo,ISP
 inet.us,Internet Connect,ISP
 inet.vn,INET,Web Host
+inet6.jp,Cyber and Internet Association,ISP
 inetc.co.uk,Internet Connections,ISP
 inetcentrum.pl,Inet Centrum,ISP
 inetcom.ru,Inetcom,ISP
@@ -12605,6 +13038,7 @@ inetvdom.ru,Интернет-провайдер inetvdom (УралНет),ISP
 inetvip.com.br,InetVip,ISP
 inetvl.ru,AlianceTelecom,ISP
 inetweb.com.br,Inetweb Informática e Assessoria,Web Host
+inetworks.com.br,Inetworks,Consulting
 inew.com.br,Inew,ISP
 inex.ie,INEX,ISP
 inexa.com.br,Inexa,ISP
@@ -12718,6 +13152,7 @@ infoo.net,Multan Michal trading as INFO-NET,ISP
 infopact.nl,Infopact,ISP
 infopasa.com.br,Infopasa,ISP
 infopointnet.com.br,Infopoint NET,ISP
+infopulse.com,Infopulse Ukraine,Technology
 infoquest.com,InfoQuest,Web Host
 infor.com,Infor,SaaS
 inforang.com,Inforang,SaaS
@@ -12794,6 +13229,7 @@ ing.com,ING,Finance
 ing.com.tr,ING Bank Anonim Sirketi,Finance
 ing.net.br,Ingnet,ISP
 ing.pl,ING Bank Slaski,Finance
+ing.sk,"ING Bank N.V., pobocka zahranicnej banky",Finance
 ingate.de,INGATE,Web Host
 ingate.ru,Ingate Group,Marketing
 ingbank.com,ING Bank N.V. - Sofia Branch,Finance
@@ -12891,6 +13327,7 @@ inricpltd.com,Inri Communications,ISP
 ins.com.ve,INS,ISP
 ins.dn.ua,Private enterprise InformService,ISP
 insead.edu,Insead,Education
+insec.gmbh,in.sec,Technology
 inside-e.co.za,Edgetechit CC,ISP
 insidesign.com.br,Insidesign Tecnologia,ISP
 insidetheinternet.com,Inside The Internet,ISP
@@ -12950,7 +13387,9 @@ intelcom.cl,Intelcom Telecomunicaciones Chile,ISP
 intelcom.net.ni,Servicios DE Internet Y Telecomunicaciones Sociedad Anonima,ISP
 intelcom.online,Intelcom,ISP
 intelekt.net,Buknet,ISP
+intelemedia.com,Intelemedia Communications,ISP
 inteliquent.com,Inteliquent,ISP
+intellica.com.au,Intellica,MSP
 intellicentre.net.au,Macquarie Technology,IaaS
 intelligencehs.co.uk,Intelligence Hosting Services,Web Host
 intelligent-cloud.xyz,Adventureck,Web Host
@@ -13056,6 +13495,7 @@ interleste.com.br,Interleste Internet,ISP
 interlig.com,Interlig,ISP
 interligadointernet.com.br,Interligado Telecom Servicos DE Comunicacao,ISP
 interligadosweblink.com.br,Interligados Weblink,ISP
+interlink.co.th,Interlink,ISP
 interlink.com.ar,Interlink,ISP
 interlink.md,Interlink Comunicatii,ISP
 interlink.net.br,Interlink Telecom,ISP
@@ -13150,6 +13590,7 @@ internetty.uk,InternetTY,ISP
 internetultra.com.br,Ultra Telecomunicacoes,ISP
 internetunion.pl,Internet Union,ISP
 internetvikings.com,Internet Vikings,Web Host
+internetvillaalegre.cl,Telecomunicaciones Wifinet Ruperto Troncoso E.I.R.L,ISP
 internetvivanet.com.br,Internet Vira NET,ISP
 internetwave.com.br,Netwave,ISP
 internetway.com.br,Internet Way,ISP
@@ -13227,6 +13668,7 @@ intouchit.com,In-Touch Computer Services,ISP
 intouchsystems.co.uk,Manage your technology with InTouch Systems,ISP
 intrabit.de,Intrabit,MSP
 intracom-telecom.com,Intracom Telecom,ISP
+intrafi.com,IntraFi®,Finance
 intrahost.tech,Intrahost,Web Host
 intranetbd.net,IBD Communication,ISP
 intranetia.com,Intranet Services,ISP
@@ -13237,11 +13679,13 @@ intratelecom.com.br,Novanet Itanagra Servico de Internet,ISP
 intred.it,Intred,ISP
 intrepidbd.com,Rana Javed Kabir t/a Interpid Broadband Communication Company,ISP
 intrepidfiber.com,BIF IV,ISP
+intrepidtelecom.com,Intrepid Telecom,ISP
 intriguecommunications.com,Intrigue Communications,ISP
 introlan.pl,INTROLAN Marzenna Barbara Bronakowska,ISP
 introserv.com,INTROSERV,Web Host
 introtelecom.in,Intro Telecom,ISP
 intrustbank.com,INTRUST Bank,Finance
+inttelgo.com,Inttelgo,ISP
 inttercom.net.co,Internet Y Telecomunicaciones DE Colombia,ISP
 intune.nz,Smartlinx3,ISP
 intv.com.co,INTV Internet y Televisión,ISP
@@ -13267,6 +13711,7 @@ inwebadriatico.it,Inweb Adriatico,ISP
 inwi.ma,Inwi,ISP
 inwise.com,inwise,Web Host
 inxfiber.com,Imagine Networks,ISP
+inxopen.com,INX Open,MSP
 inxserver.de,Inxmail,Marketing
 inycom.net,Inycom,MSP
 inyonetworks.com,Inyo Networks,ISP
@@ -13283,6 +13728,7 @@ ioh.co.id,IM3,ISP
 ioinc.us,IO Inc,Web Host
 ioit.ac.vn,Institute of Information Technology (IOIT),Education
 ioko.com,Redcentric (ioko),Web Host
+iolani.org,'Iolani School,Education
 iolbd.net,Innovative Online,ISP
 iomart.com,iomart,Web Host
 iomartcloud.com,Iomartcloud,Web Host
@@ -13407,6 +13853,7 @@ ipost.com,iPost,Marketing
 ipp.fi,Lennu (Ikaalisten-Parkanon Puhelin),ISP
 ippathways.com,IP Pathways,MSP
 ippbonline.in,India Post Payments Bank,Finance
+ippe.ru,"Joint Stock Company ""State Scientific Center of the Russian Federation - Physical and Energy Institute named after A.I. Leipunsky""",Education
 ippon.tech,Ippon,Web Host
 ipptr.com,IPPTR DNS Experts,Web Host
 ipr.res.in,Institute for Plasma Research,Education
@@ -13418,8 +13865,10 @@ iproyal.com,IPRoyal,SaaS
 ipserver.su,IpServer.su,Web Host
 ipserverone.com,IP ServerOne,Web Host
 ipservice.in.ua,IP Service Ukraine,ISP
+ipservices.net.co,IP Services Redes E Internet,ISP
 ipsism.co.jp,Philippine Telegraph and Telephone,ISP
 ipsla.fr,IP SLA Internet Protocole Service Leval Agreement,ISP
+ipst.ac.th,The Institute for the Promotion of Teaching Science,Education
 ipstar.com.au,IPSTAR Australia,ISP
 ipswich.qld.gov.au,Ipswich City Council,Government
 ipsys-bf.com,Ipsystem,ISP
@@ -13512,6 +13961,7 @@ irondata.com,MicroPact Global,Government
 ironhosting.net,Ironhosting,Web Host
 ironmountain.com,Iron Mountain,Technology
 irontec.com,Irontec,ISP
+ironton.com,Ironton Telephone Company,ISP
 irontree.co.za,IronTree Internet Services,ISP
 ironwoodcrc.com,Ironwood Cancer & Research Centers,Healthcare
 irpinianetcom.it,Irpinia Net-Com,ISP
@@ -13535,10 +13985,12 @@ isabellabank.com,Isabella Bank,Finance
 isahaya-media.com,Isahaya Cable Media,ISP
 isat.net.id,Insan Sarana Telematika (ISAT),ISP
 isatafrica.com,iSAT Africa Zambia,ISP
+isb.edu,"Indian School of Business, a world class business school, India",Education
 isc.id,ISC.ID,Web Host
 isc.org,Internet Systems Consortium,Nonprofit
 iscgroup.com,ISC Group,MSP
 ischiawifi.com,Ischia WiFi,ISP
+iseas.edu.sg,ISE,Education
 iseclayer.com,ISECLAYER,Web Host
 iseek.com.au,iseek Communications,ISP
 isenterprise.com,KPN,ISP
@@ -13574,6 +14026,7 @@ isn.ng,ISN Nigeria,ISP
 isncom.net,ISN Communications,ISP
 isnet.net.tr,Is Net,ISP
 isnic.is,Internet a Islandi hf,ISP
+isoc.bj,Chapitre Beninois DE L'Internet Society,ISP
 isoc.go.th,Internal Security Operations Command,Government
 isoc.org.il,Israel Internet Association,ISP
 isoc.sd,Sudanese Internet Association,ISP
@@ -13699,6 +14152,7 @@ itaon.net.br,ITAON,ISP
 itatelecom.com.br,ITA Telecom,ISP
 itatiaianet.com,Itatiaia Informatica E Telecomunicacoes,ISP
 itau.cl,Banco Itau Chile,Finance
+itau.com.py,Banco Itau Paraguay,Finance
 itb.ac.id,Institut Teknologi Bandung,Education
 itbasebd.com,IT Base,ISP
 itbasecamp.com.au,itbasecamp,MSP
@@ -13884,12 +14338,14 @@ iwn.bz,Infinite Wireless & Networking,ISP
 iworx-host.com,iWorx Host,Web Host
 iws.co,IWS Networks,Web Host
 iwsnet.id,Ilham Wifi Solution,ISP
+iwu.edu,Illinois Wesleyan University,Education
 iwv.works,Iconz-Webvisions,Web Host
 iwvisp.com,Indian Wells Valley ISP,ISP
 ix.net.ua,"DE ""Ukrainian Internet Exchange"" (UA-IX)",ISP
 ix.ro,IX.RO,ISP
 ix.ru,Join-stock company Internet ExchangeMSK-IX,ISP
 ixcitanet.com.br,Itanet Telecom,ISP
+ixica.com,IXICA Communications,ISP
 ixirhost.com,Iksir Internet Hizmetleri A.S,Web Host
 ixnet.com.br,iXnet Fibra,ISP
 ixp.ge,IXP,ISP
@@ -13961,6 +14417,7 @@ janatabank-bd.com,Janata Bank,Finance
 janex-net.pl,Janex-Net Marek Jasinski,ISP
 janis.jp,JANIS,ISP
 jannatmirinternetservice.com,Jannat Mir Internet Service,ISP
+janusresearch.com,JANUS Research Group,Government
 japan-wirecable.com,Bell Denki,Industrial
 japneetfiber.in,Japneet Fiber,ISP
 japnet.com.br,Japnet Telecom,ISP
@@ -13996,6 +14453,7 @@ jaztel.in,Jaztel,ISP
 jazz.com.pk,Jazz,ISP
 jazztel.com,Jazztel,ISP
 jazztel.es,Jazztel,ISP
+jbbank.co.kr,Jeonbuk Bank,Finance
 jbcpbd.com,Md. Moniruzzaman (Rocky) trading as Jhenaidah Broadband & Cyber Point,ISP
 jbedu.kr,Jeonbuk State office of Education Future Education Research Institute,Education
 jbinternet.com.br,JB Internet,ISP
@@ -14055,6 +14513,7 @@ jemberkab.go.id,Dinas Komunikasi Dan Informatika Kabupaten Jember,Government
 jembranakab.go.id,Dinas Komunikasi dan Informatika Pemerintah Kabupaten Jembrana,Government
 jencospeed.net,Jenco Wireless,ISP
 jenny.africa,Jenny Internet,ISP
+jenzabar.com,Jenzabar,Web Host
 jepara.go.id,Pemerintah Kabupaten Jepara,Government
 jequietelecom.com,Jequie Telecom Servicos,ISP
 jerenet.com.br,Jerenet,ISP
@@ -14153,9 +14612,11 @@ jnisystem.com,JNI System,MSP
 jnj.com,Johnson & Johnson,Healthcare
 jnt.fi,JNT Jakobstadsnejdens Telefon,ISP
 jnu.ac.bd,Jagannath University,Education
+jnu.ac.in,Jawaharlal Nehru University,Education
 jnu.ac.kr,Chonnam National University,Education
 joanneum.at,Joanneum Research,Science
 jocarroll.com,Jo-Carroll Energy,Utilities
+joeys.org,Marist Brothers ST Josephs College,Education
 jogjakota.go.id,Badan Teknologi Informasi Dan Telematika Sekretariat Daerah Kota Yogyakarta,Government
 jogjaprov.go.id,Diskominfo DIY,Government
 johnshopkins.edu,Johns Hopkins University,Education
@@ -14171,6 +14632,7 @@ jollybroadband.net,Jolly Broadband,ISP
 jombangkab.go.id,Pemerintah Kabupaten Jombang,Government
 jon.cz,JON.CZ,ISP
 jonebroadband.com,Jone Broadband,ISP
+jones.edu,Jones College,Education
 jonesday.com,Jones Day,Legal
 jonkoping.se,City of Jonkoping,Government
 joomlawired.com,Joomla Wired,Web Host
@@ -14229,17 +14691,21 @@ jsums.edu,Jackson State University,Education
 jsvoy.fi,Järvi-Suomen Valokuitu,ISP
 jsvtelecom.com.br,JSV Telecom,ISP
 jt.iq,Al-Jazeera Al-Arabiya Communication,ISP
+jtchinae-bank.co.kr,JT Chinae Savings Bank,Finance
 jtcinet.com,Johnson Telephone Company,ISP
 jtel.net.id,Media Jaringan Telekomunikasi,ISP
 jtglobal.com,JT,ISP
 jtminternet.com,JTM Internet,ISP
 jtncommunications.com,JTN Communications,ISP
 jtsa.edu,Jewish Theological Seminary,Education
+jtsmith.com,Smith & Associates,Event Planning
 jtti.cc,JT Telecom International,ISP
 ju.se,Hogskolan i Jonkoping,Education
 juce.ca,JUCE Communications,ISP
+juceconnect.com,Juce Connect,ISP
 juice-broadband.com,Juice Broadband,ISP
 juicemagazine.com,Juice Magazine,Publishing
+juilliard.edu,The Juilliard School,Education
 jujuy.gob.ar,Gobierno de la Provincia de Jujuy,Government
 jujuyinternet.com.ar,Jujuy Internet,ISP
 juliusbaer.com,Julius Baer,Finance
@@ -14253,6 +14719,7 @@ jumpwireless.net,Jump Wireless,ISP
 junct.com,The Junction Internet,ISP
 jundfibra.com.br,Magofy Telecomunicacoes,ISP
 junet.se,Junet,ISP
+junin.gob.ar,Municipalidad DE Junin,Government
 juniper.net,Juniper Networks,Manufacturing
 junisat.com,Junisat,ISP
 juniv.edu,Jahangirnagar University,Education
@@ -14262,6 +14729,7 @@ jupiter.com.br,Jupiter Telecomunicacoes,ISP
 jupitermed.com,Jupiter Medical Center,Healthcare
 jupiterprovedor.com.br,Jupiter Provedor,ISP
 juquianet.com.br,Juquianet,ISP
+jus.gov.ar,Ministerio de Justicia,Government
 jusan.kz,First Heartland Jysan Bank,Finance
 jusbaires.gob.ar,Consejo DE LA Magistratura,Government
 just-size.net,Just-Size Networks,Web Host
@@ -14422,6 +14890,7 @@ katelecom.com.br,KA Telecom,ISP
 kater.com.br,Kater Telecom,ISP
 katnip.it,Fiberland Srls,ISP
 kattare.com,Kattare,Web Host
+kattenlaw.com,Katten Muchin Rosenman LLP,Legal
 katv1.az,AG Telekom,ISP
 katv1.net,AG Telekom,ISP
 kau.ac.kr,Korea Aerospace University,Education
@@ -14430,6 +14899,7 @@ kaunogrudai.lt,Kauno Grūdai,Food
 kaust.edu.sa,KAUST King Abdullah University,Education
 kawanua.net.id,Kawanua Internet Indonesia,ISP
 kaweahdelta.org,Kaweah Health,Healthcare
+kaweb.co.uk,Kaweb,Marketing
 kayanat.af,Kayanat Technology Internet Services CO,ISP
 kayenta.net,Kayenta Technologies,ISP
 kazintercom.kz,Kaz InterCom,ISP
@@ -14441,6 +14911,7 @@ kband.no,Hardanger Breiband,ISP
 kbbsl.net,Khulna Broadband Service,ISP
 kbc.com,KBC Group,Finance
 kbcnet.rs,TRUF,ISP
+kbi.or.kr,Korea Banking Institute,Education
 kbleu.net,Regie du reseau cable du haut sundgau,ISP
 kblextelecom.com,KBLEX TELECOM,ISP
 kbmf.org,KBMF,ISP
@@ -14467,6 +14938,7 @@ kcn.ne.jp,KCN,ISP
 kcn.tv,Keumgang Cable Network,ISP
 kcnet.ne.jp,Kyoutou Cable Net,ISP
 kcom.com,KCOM,ISP
+kcore.net,kCore Cloud,Web Host
 kcp.co.kr,NHN KCP,Finance
 kcs.co.jp,Sakura KCS,MSP
 kct.co.jp,Kurashiki Cable TV,ISP
@@ -14499,10 +14971,14 @@ keepit.com,Keepit,SaaS
 keepnettelecom.net.br,Keepnet Telecomunicações,ISP
 keio.ac.jp,Keio University,Education
 keio.jp,Keio University,Education
+keiti.re.kr,Korea Environmental Technology Industry Institute,Education
+keizer.ca,Pegboard Hosting,Web Host
 kek.jp,KEK,Education
 kelag.at,Kelag,Utilities
 keliweb.com,Keliweb,Web Host
 kellin.net,Kellin Communications,ISP
+kellogg.edu,Kellogg Community College,Education
+kellogghansen.com,"Kellogg, Huber, Hansen, Todd & Evans",Legal
 kelnet.in,Kelnet Communication Services (P),ISP
 kelvyn.net.br,Kelvyn Net,ISP
 kemdiknas.go.id,Pustekkom,Government
@@ -14514,6 +14990,7 @@ kemenkopmk.go.id,Kemenko PMK RI,Government
 kemenkumham.go.id,Kementerian Hukum DAN HAK Asasi Manusia,Government
 kemenpar.go.id,Kementerian Pariwisata DAN Ekonomi Kreatif,Government
 kemenpora.go.id,Kementerian Pemuda dan Olahraga,Government
+kemenpppa.go.id,Kementerian Pemberdayaan Perempuan Dan Perlindungan Anak,Government
 kemhan.go.id,Pusdatin Kemhan RI,Government
 keminet.net,Keminet,ISP
 kemkes.go.id,Departemen Kesehatan,Government
@@ -14545,6 +15022,7 @@ keremetbank.kg,"OJSC ""Keremet Bank""",Finance
 keris.or.kr,KERIS (Korea Education and Research Information Service),Education
 kern.org,Kern County Superintendent of Schools,Education
 kernet.ie,KerNet Broadband,ISP
+kernhigh.org,Kern High School District,Education
 kernwifi.com.au,KernWi-Fi,ISP
 kerrybroadband.ie,Kerry Broadband,ISP
 kerv.com,Kerv,MSP
@@ -14552,12 +15030,14 @@ ketertech.co.za,Keter Technologies,ISP
 ketis.ru,KETIS,ISP
 keuka.edu,Keuka College,Education
 kevag-telekom.de,KEVAG Telekom,ISP
+kexp.org,KEXP,Nonprofit
 key-systems.net,Key-Systems,Web Host
 keybank.com,KeyBank,Finance
 keycorpgroup.com,KeyCorp Financial,Finance
 keyinfo.com,Key Information Systems (Converge),MSP
 keymachine.de,Keyweb,Web Host
 keymail.com,KeyMail,Email Provider
+keysourceusa.com,KeySource Acquisition,Healthcare
 keystonescloudtech.com,Key Stones Cloud Tech,Web Host
 keytele.com,KeyTele,ISP
 keytelsystems.com,Keytel Systems,MSP
@@ -14639,6 +15119,7 @@ king-online.ru,KING-ONLINE,ISP
 king-servers.com,King Servers,Web Host
 king.host,KingHost (LWSA),Web Host
 kingcounty.gov,King County,Government
+kingdon.com,Kingdon Capital Management,Finance
 kinghost.net,KingHost,Web Host
 kingnet.net.br,Kingnet Telecomunicacoes,ISP
 kingpolahnetwork.co.id,Kingpolah Network Solutions,ISP
@@ -14658,6 +15139,7 @@ kins.re.kr,Korea Institute of Nuclear Safety,Education
 kinx.net,KINX,ISP
 kio.tech,KIO Networks,Web Host
 kiom.re.kr,Korea Institute of Oriental Medicine,Education
+kirams.re.kr,KIRAMS (Korea Institute of Radiological Medical Sciences),Healthcare
 kirchmann-hurry.co.za,Kirchmann-Hurry Construction,Construction
 kirkbrothers.com,Kirk Brothers Supercenter,Automotive
 kirkland.com,Kirkland & Ellis,Legal
@@ -14680,6 +15162,7 @@ kit.ac.kr,KyungNam College of Information Technology,Education
 kit.edu,Karlsruhe Institute of Technology,Education
 kitano-hp.or.jp,Kitano Hospital,Healthcare
 kitcarson.com,Kit Carson Electric Cooperative,Utilities
+kitchell.com,Kitchell,Real Estate
 kitech.re.kr,KITECH,Education
 kitsapwifi.com,Kitsap WiFi,ISP
 kitsune.tr,Kitsune Bilisim Sistemleri Bilgi Teknolojileri Yazilim ve Danismanlik Ticaret Limited Sirketi,Web Host
@@ -14717,6 +15200,7 @@ kmd.dk,KMD,Consulting
 kmex.com,Estacion KMEX | Univision,ISP
 kmitl.ac.th,King Mongkut's Institute of Technology Ladkrabang,Education
 kmitnb.ac.th,King Mongkut's Institute of Technology North Bangkok,Education
+kmklaw.com,Keating Muething & Klekamp PLL,Legal
 kmnbd.net,KM Network,ISP
 kmnet.com.ve,KM Net | Internet Fibra Ãptica en Acarigua y Araure,ISP
 kmou.ac.kr,Korea Maritime and Ocean University,Education
@@ -14836,6 +15320,7 @@ kotabogor.go.id,Kantor Komunikasi Dan Informatika Kota Bogor,Government
 kotawaringinbaratkab.go.id,"Dinas Komunikasi, Informatika, Statistik dan Persandian Kabupaten Kotawaringin Barat",Government
 kotimkab.go.id,Dinas Komunikasi dan Informatika Kabupaten Kotawaringin Timur,Government
 kotovsk.net.ua,Santosha,ISP
+kotovsk.od.ua,"PP ""TV Cable Center""",ISP
 koumbit.net,Koumbit.org,MSP
 kovacmed.com,KOVAC-MED,Healthcare
 kovaifibernet.com,Kovai Fibernet,ISP
@@ -14872,8 +15357,10 @@ krishcom.in,Krish Communication,ISP
 krishiinet.com,Krishiinet Infocom,ISP
 krishnabb.in,Krishna Broadband,ISP
 kristallcom.ru,MTU Kristall,ISP
+krka.biz,Krka,Healthcare
 krksistemi.hr,AIRNET d.o.o. za telekomunikacije,ISP
 kroger.com,The Kroger Co,Retail
+krohne.com,Krohne,Manufacturing
 krones.com,Krones,MSP
 kronline.net,KR Online,ISP
 kronoz.co.jp,kronos,MSP
@@ -14894,6 +15381,7 @@ ksfiber.net,Kansas Fiber Network,ISP
 ksiezyc.pl,Aves,ISP
 kskc.net,KanOkla Communications,ISP
 ksmship.com,Korea Eco Management,Logistics
+ksnet.net.id,KSNET,ISP
 ksol.com.au,Kritikos Solutions,MSP
 ksp.ca,KSP Technology,MSP
 kstu.kz,"Non-profit joint-stock company ""Karaganda technical University""",Education
@@ -14982,6 +15470,7 @@ kwater.or.kr,K-water (Korea Water Resources),Utilities
 kwds.net.ua,PP Iv-Com,ISP
 kwikbit.com,Kwikbit Internet,ISP
 kwikom.com,KwiKom Communications (Gateway Fiber),ISP
+kwiktrip.com,Kwik Trip,Retail
 kwikzo.co.in,Kwikzo Telecomm,ISP
 kws.nsw.edu.au,Kinross Wolaroi School,Education
 ky.gov,Kentucky Communications Network Authority (KCNA),Government
@@ -14999,6 +15488,7 @@ kyoto-u.ac.jp,Kyoto University,Education
 kysu.edu,Kentucky State University,Education
 kyun.host,Aokigahara,Web Host
 kyungmin.ac.kr,kyungmin university,Education
+kyushutele.com,Kyushu Telecom Global,ISP
 kywimax.com,Kentucky Wimax,ISP
 kyxar.fr,Kyxar,Web Host
 kztelecom.com.br,KzNet Telecom,ISP
@@ -15017,6 +15507,7 @@ labcorp.com,Labcorp,Healthcare
 labelsistemi.net,Label sistemi Tecnologici,ISP
 laboratoires-thea.fr,Laboratoires Théa,Healthcare
 laca.org,Licking Area Computer Association,Nonprofit
+lacaja.com.ar,La Caja,Finance
 laceibanetsociety.com,Laceibanetsociety,ISP
 lachollanet.com,La Cholla Net,ISP
 lacity.gov,City of Los Angeles,Government
@@ -15029,6 +15520,7 @@ lacoste.com,Lacoste,Retail
 lacounty.gov,Los Angeles County,Government
 ladwp.com,LADWP Los Angeles Department of Water and Power,Utilities
 lafayette.edu,Lafayette College,Education
+lafise.com,Banco LAFISE,Finance
 lagoon.nc,Lagoon New Caledonia,ISP
 lagosnetminas.com.br,LagosNet Internet Banda Larga,ISP
 lagrange.cloud,Lagrange Cloud Technologies,Web Host
@@ -15053,6 +15545,7 @@ lakenetmi.com,LakeNet,ISP
 lakeplacidfiber.com,Lake Placid Fiber,ISP
 lakeregionfiber.com,Lake Region Technology,ISP
 lakeshorefiber.com,High‑Speed Internet from Lakeshore Fiber,ISP
+laketrust.org,Lake Trust Credit Union,Finance
 lakotanetwork.com,CRST Telephone Authority (Lakota Network),ISP
 lakshmipuronline.com,Lakshmipur Online,ISP
 lakshnetworks.com,Laksh Networks,Web Host
@@ -15069,15 +15562,18 @@ lamrc.com,Lam Research,Manufacturing
 lan-telecom.net,PP Lan-Telecom,ISP
 lan.go.id,Lembaga Administrasi Negara Republik Indonesia,Government
 lan.ua,LocalNet Obolon (Aslanua),ISP
+lanacion.com.ar,LA NACION,News
 lanairgroup.com,LANAIR Group,MSP
 lancashire.gov.uk,Lancashire County Council,Government
 lancastergeneralhealth.org,Penn Medicine Lancaster General Health,Healthcare
 lancelot-telecom.nl,Lancelot,ISP
+lancet.co.za,Lancet Laboratories,Government
 lancom.gr,Lancom Greece,ISP
 lancraft.pro,LanCraft,ISP
 lancronix.ru,Lancronix,ISP
 landakannorty.id,Landak Annorty Net,MSP
 landcareresearch.co.nz,New Zealand Institute for Bioeconomy Science,Education
+landmark.edu,Landmark College,Education
 landsbanki.is,Landsbankinn,Finance
 landvps.ru,New Hosting Technologies,Web Host
 landynamix.co.za,LanDynamix,MSP
@@ -15116,6 +15612,7 @@ laovietbank.com.la,"Lao-Viet Bank, CO",Finance
 lapariah.com,E-Lapariah Technologies,ISP
 laptech.com,LapTech Precision,Manufacturing
 larabida.org,La Rabida Children's Hospital,Healthcare
+laramiecountywy.gov,Laramie County Government,Government
 laranet.com.br,LaraNet Telecomunicações e Serviços EIRALI,ISP
 laredwifi.com.ar,LA RED Wifi Sociedad DE Hecho,ISP
 largabanda.it,Largabanda (Alfanews),ISP
@@ -15140,6 +15637,7 @@ lastnet.com.br,Lastnet Telecom,ISP
 lasvegas.net,LasVegas.Net,ISP
 lasvegasnevada.gov,City of Las Veg,Government
 latansa.net,Latansanet,ISP
+latcomm.net,Latino Communications,ISP
 latech.edu,Louisiana Tech University,Education
 lateralplains.com,Lateral Plains,ISP
 latigo.net,Latigo,ISP
@@ -15223,6 +15721,7 @@ ld4unity.com,LD4Unity,Web Host
 ldexconnect.co.uk,Iomart LDeX (LDexConnect),Web Host
 ldp.net.id,Lintas Data Prima,ISP
 lds.online,Luganskie Domashnie Seti,ISP
+ldschurch.org,LDS Church of Jesus Christ,Religion
 ldtelecom.com,LD Telecommunications,ISP
 ldtelecomrn.com.br,LD Telecom,ISP
 ldw.com,Last Day of Work,Entertainment
@@ -15250,7 +15749,9 @@ ledl.net,Ledl.net,Web Host
 lee.edu,Lee College,Education
 lee.net,Lee Enterprises,News
 leecommunicationisp.com,Lee Communication,ISP
+leeprocess.com,LEE & Associates,Government
 leeschools.net,Lee County Schools Florida,Education
+leeuniversity.edu,Lee University,Education
 leewireless.net,"Lee Wireless – Internet for El Paso, TX",ISP
 leftor.ba,Leftor,Web Host
 leftor.com,Leftor,Web Host
@@ -15259,6 +15760,7 @@ legacyinternet.com,Legacy ISP,ISP
 legalaid.qld.gov.au,Legal Aid Queensland,Government
 legenditsolutions.com,Legend IT Solutions,Web Host
 legendsconnect.co.za,Legends Connect,ISP
+leggett.com,Leggett & Platt,Manufacturing
 legiontelecom.com.au,Legion Telecom,ISP
 legontelecomunicaciones.com,Legon Telecomunicaciones,ISP
 legroupeforget.com,Le Groupe Forget,Healthcare
@@ -15282,7 +15784,9 @@ lentel.ru,Lentel,ISP
 lenz.net.ua,LENZ,ISP
 lenzing.com,Lenzing,ISP
 leo.co.ls,Leo (PTY),MSP
+leo.com.hk,Leo Paper Group,Print
 leogrid.com,Leogrid,Web Host
+leomax.ru,Телемагазин LEOMAX,ISP
 leomaxtelecom.com.br,LeoMax Telecom,ISP
 leon.k12.fl.us,Leon County Schools Florida,Education
 leon.pl,Leon Polish ISP,ISP
@@ -15298,6 +15802,7 @@ lestari.net.id,Lestari Exellika Barokah,ISP
 lestetelecom.com.br,Leste,ISP
 lesunco.com,"Lesun communication furtherance engineers Co, (Ltd.)",ISP
 letaba.net,Letaba Networks,ISP
+lethbridge.ca,City of Lethbridge,Government
 lethbridgecollege.ca,Formerly Lethbridge College,Education
 letobank.ru,"""Post Bank""",Finance
 letsgointernet.com.br,LetsGo Internet | Fibra Ótica de Alta Velocidade,ISP
@@ -15326,8 +15831,10 @@ lexi.net,Lexicom,MSP
 lexico-voip.com,SIA Lexico Telecom,ISP
 lexicom.ca,Lexicom,MSP
 lexiconbusiness.com,Lexicon International,Web Host
+lexingtonky.gov,Lexington-Fayette Urban County Government,Government
 lexingtonmo.com,City OF Lexington,Government
 lexisnexis.com,ChoicePoint,Government
+lexmed.com,Lexington Medical Center,Healthcare
 lextelecom.com.br,Lex Telecom,ISP
 lexxion.com.br,Lexxion Provedor de Serviços de Internet,ISP
 lf.net,LF.net Stuttgart,ISP
@@ -15384,6 +15891,7 @@ libertymutual.com,Liberty Mutual,Finance
 libertynet.com,Liberty Networks,ISP
 libertynetworks.com,Liberty Networks,ISP
 libertypr.com,Liberty,ISP
+libertypumps.com,Liberty Pumps,Manufacturing
 librabank.ro,Libra Internet Bank,ISP
 libradsl.it,LIBRA,ISP
 libraesva.com,Libraesva,Email Security
@@ -15403,6 +15911,7 @@ lidertelecommg.com.br,Lider Internet,ISP
 lietpark.com,Lietpark Communications,ISP
 life-link.ru,Life-Link,ISP
 life.by,Life Belarus (BeST),ISP
+life.church,Life Covenant Church,Religion
 life.edu,Life University,Education
 lifecell.ua,lifecell,ISP
 lifecelldigital.com,LIFECELL DIGITAL,ISP
@@ -15410,6 +15919,7 @@ lifeconnectionsbr.com.br,Life Connections,ISP
 lifein.com.br,LIFE.IN TELECOM,ISP
 lifeinternet.com.br,Real Life Comercio E Servicos,ISP
 lifelink.ru,KB Rubin,ISP
+lifenethealth.org,12-182-8156,Healthcare
 lifenetworks.com.br,Lifenetworks,ISP
 lifepointhealth.net,Legacy Lifepoint Health,Healthcare
 lifetech.com,Life Technologies,Healthcare
@@ -15441,6 +15951,7 @@ lightspeedhosting.com,LightSpeed Hosting,ISP
 lightstorm.net,Lightstorm,ISP
 lightstormtelecom.com,Lightstorm,ISP
 lightstream.coop,Monon Telephone Company,ISP
+lightstream.io,Lightstream.io,ISP
 lightstreamfiber.net,Lone Star ISP,ISP
 lightwaveb.net,Lightwave Broadband,ISP
 lightwavenetworks.com,LightWave Networks,Web Host
@@ -15475,6 +15986,7 @@ limitrack.com,LIMITRACK,Web Host
 limonhost.net,The easiest way to be on the Internet | LimonHost | en,Web Host
 limops.net,LimOps,ISP
 limpo.co.za,Limpo Wifi,ISP
+limra.com,LIMRA,Finance
 linax.net.br,Linax Internet,ISP
 linca.net.br,Linca Fibra e TV,ISP
 linceris.com,Linceris International Cloud Solutions,Web Host
@@ -15494,6 +16006,7 @@ linenet.cl,Linenet,ISP
 liner.pro,Excellent Signalman,ISP
 linevast.de,Linevast Hosting,Web Host
 linevps.com,LineVPS,Web Host
+linfield.edu,Linfield University,Education
 linfortel.com.br,Linfortel,ISP
 lingo.com,Lingo,ISP
 linivo.net,Linivo,SaaS
@@ -15586,6 +16099,7 @@ linkuniao.com.br,linkuniao,ISP
 linkuniverse.net,Linkuniverse Communication,ISP
 linkup.ar,Linkup Internet,ISP
 linkup.net.br,Linkup,ISP
+linkupcommunications.com,Linkup Communications,ISP
 linkupctg.com,Link Up Communication,ISP
 linkupnetworks.in,Linkup Networks,ISP
 linkvale.com.br,LinkVale,ISP
@@ -15633,6 +16147,7 @@ lisco.com,LISCO,ISP
 lisimsits.com,Lisims Internet AND Technology Services,ISP
 lismoretel.com,Lismore Cooperative Telephone Company,ISP
 listrak.com,Listrak,Marketing
+lit.edu,Lamar Institute of Technology,Education
 litc.ly,Libyan International Telecommunication Company,ISP
 lite-telecom.ru,Lite-Telecom,ISP
 litecloudhosting.com,Lite Cloud,ISP
@@ -15651,6 +16166,7 @@ litoralconect.com.br,Litoral Conect - SAO Sebastiao - SP,ISP
 litorallink.com.br,Silva E Silva telecom,ISP
 litoraltelecom.com.br,Litoral Telecom Provedor DE Internet E Servicos LT,ISP
 litoraltelecom.net,Litoral Telecom | Provedor de Internet,ISP
+littencommunications.media,Litten Communications,ISP
 littleappletech.com,Little Apple Technologies,ISP
 littletongov.org,City of Littleton,Government
 liu.edu,Long Island University,Education
@@ -15686,6 +16202,7 @@ liviate.com,Liviate Hosting ApS,Web Host
 livihosting.com,LIVI HOSTING,Web Host
 livrewifi.net.br,Livre WiFi Telecom,ISP
 liwest.at,LIWEST,ISP
+lixpa.org.lr,Liberia Internet Exchange Point Association,ISP
 lizaonlinebd.com,LIZA ONLINE BD,ISP
 ljbroadbandnetwork.com,L.J Broadband Network,ISP
 lji.org,La Jolla Institute for Immunology,Education
@@ -15717,6 +16234,7 @@ ln.edu.hk,Lingnan University,Education
 lnc.com,Lincoln Financial,Finance
 lncc.br,LNCC Brazilian National Laboratory for Scientific Computing,Science
 lnet.pl,LNET,ISP
+lnfcu.com,L & N Federal Credit Union,Finance
 lnktelecom.com.br,LNK Telecom,ISP
 lns.com.my,LNS,MSP
 lntelecom.net,LN Telecom,ISP
@@ -15750,12 +16268,14 @@ locontewifi.it,Lo Conte WiFi,ISP
 loctelecom.ru,Loctelecom,ISP
 locus-t.com.my,LOCUS-T,Marketing
 locustwalk.cc,Locust Walk,Finance
+lod.com,LOD Communications,Web Host
 lodestonegroup.com,Loadstone Insurance,Finance
 lodz.pl,Lodz University of Technology,Education
 lofisnet.ru,PE Filimonov Boris Yurievich,ISP
 loftsinc.com,"Lofts, Inc.",Retail
 log.inf.br,LOG Informatica,ISP
 loga.net.br,Loga,ISP
+logan-aluminum.com,Logan Aluminum,Manufacturing
 loganet.com.ar,Loganet,ISP
 logfi.net.br,log.fi,ISP
 logi-tech.net,Logi Tech,ISP
@@ -15799,6 +16319,7 @@ lombardodier.com,Lombard Odier,Finance
 lomboktengahkab.go.id,Dinas Komunikasi dan Informatika Kabupaten Lombok Tengah,Government
 loncomillatv.cl,TV Cable Loncomilla,ISP
 lonconnect.co.uk,LonConnect,ISP
+london.ca,City of London,Government
 london.on.ca,St. Joseph's Health Care London,Healthcare
 londrina.pr.gov.br,Portal da Prefeitura de Londrina,Government
 londrinet.net.br,Londrinet,ISP
@@ -15810,12 +16331,14 @@ longlines.com,Long Lines Broadband,ISP
 longmontcolorado.gov,City of Longmont,Government
 longvan.net,Long Van Soft Solution,Web Host
 loni.org,LONI,Education
+lonsys.co.uk,London Systems UK,MSP
 loomnet.com.pk,Loomnet Fiber Internet,ISP
 loophost.com.br,LoopHost,Web Host
 loopia.se,Loopia,Web Host
 loras.edu,Loras College,Education
 lorensat.com.br,Lorensat Telecom,ISP
 loretonh.nsw.edu.au,Loreto Normanhurst,Education
+loretotoorak.vic.edu.au,Loreto Mandeville Hall Toorak,Education
 lorettotel.com,Loretto Communication Services,ISP
 losalamosnm.us,Incorporated County of Los Alamos,Government
 losnettos.net,Los Nettos,Education
@@ -15824,6 +16347,7 @@ lotic.com.br,L.Lotic Servicos DE Tecnologia,Web Host
 lotte.net,Lotte Data Communication Indonesia (LDCI),ISP
 lottedata.id,LOTTE Data Communication Indonesia,ISP
 lotteinnovate.com,Lotte Innovate,MSP
+lotterywest.wa.gov.au,Lotteries Commission of Western Australia,Government
 lotuswireless.com,Lotus Wireless Technologies India,ISP
 loudnclear.co.nz,Ayone Computers,ISP
 loudoun.gov,"Loudoun County, VA",Government
@@ -15842,6 +16366,7 @@ loyalty.com,LoyaltyOne,SaaS
 loyno.edu,Loyola University New Orleans,Education
 loyola.edu,Loyola University Maryland,Education
 loyolahs.edu,Loyola High School of Los Angeles,Education
+lozier.com,Retail Store Fixtures & Shelving Manufacturer | Lozier,Manufacturing
 lpages.co,Leadpages,Marketing
 lpb.lv,Joint Stock Company LPB Bank,Finance
 lpbank.com.vn,LPBank,Finance
@@ -15885,14 +16410,17 @@ ltc.net.ly,Abraj Libya Co For Communications & information Technology,ISP
 ltcconnect.com,LTC Connect,MSP
 ltdalarna.se,Region Dalarna,Government
 ltechsolutions.com,LTech Solutions,MSP
+ltk32.ru,Lifetelecom,ISP
 ltnglobal.com,LTN,ISP
 lts.org.ua,Link Telecom Service,ISP
+ltsi-fiber.com,Lukban Telephone System,ISP
 ltsi.ph,Limitless-Tech Solutions,ISP
 ltsolucoes.com,LT Solucoes,ISP
 ltt.ly,Libya Telecom & Technology,ISP
 ltu.se,Luleå University of Technology,Education
 lu.lv,University of Latvia,Education
 lu.se,Lund University,Education
+lubbockcounty.gov,Lubbock County,Government
 lubonet.net.pl,LUBONET,ISP
 luc.edu,Loyola University Chicago,Education
 lucasinternet.com.br,Lucas Internet,ISP
@@ -15909,6 +16437,7 @@ lugacom.com,Telematika,ISP
 luganet.ru,Luganet,ISP
 lugtel.com,Lugansk Telephone Company,ISP
 luke-it.de,Luke IT,Web Host
+luki.ec,Lukinet,ISP
 lukman.pl,ABM Uslugi Instalatorskie BOGDAN MUCHARSKI,ISP
 lukoil-inform.ru,Lukoil-Inform,Industrial
 luksus.net.pl,LUKSus,ISP
@@ -15946,6 +16475,7 @@ luolakallio.fi,Luolakallio,Web Host
 lupin.com,Lupin,Healthcare
 lurahosting.net,LuraHosting,Web Host
 luriechildrens.org,Lurie Children's Hospital of Chicago,Healthcare
+lusakaixp.co.zm,Lusaka Internet Exchange point,ISP
 lusfiber.net,LUS Fiber,ISP
 lusovps.com,LusoVPS,Web Host
 luther.edu,Luther College,Education
@@ -15973,9 +16503,11 @@ lwsonline.net,Ladysmith Wireless Solutions,ISP
 lxcluster.at,LXCluster,Web Host
 lycap.com,Lightyear Capital,Healthcare
 lycatel.com,Lyca Group,ISP
+lycoming.edu,Lycoming College,Education
 lycorp.co.jp,LY Corporation,SaaS
 lylab.net,"Lebanon, Lancaster, Harrisburg | LYLAB Technology Solutions",MSP
 lymefiber.net,LymeFiber,ISP
+lynchburg.edu,University of Lynchburg,Education
 lynchburgva.gov,"Lynchburg, VA",Government
 lynchesriver.com,Lynches River Communications,Utilities
 lyncross.llc,Lyncross,Web Host
@@ -16026,6 +16558,7 @@ m9network.com,Volico Data Centers,Web Host
 ma.edu,Westfield State University,Education
 maainternet.com,Maa Internet Service Provider,ISP
 maastricht.nl,Gemeente Maastricht,Education
+maax.com,MAAX Bathware,Manufacturing
 mabasafenet.com,Maba Safenet Broadband Services,ISP
 mabeltel.coop,Mabel Cooperative Telephone Company,ISP
 mable.jp,San-in Cable Vision,ISP
@@ -16066,6 +16599,7 @@ madenetwork.it,Made Network Srl,Web Host
 madfoat.com,Madfoo3atkom for electronic payment co PJ,ISP
 madgenius.com,Madgenius,Web Host
 madisoncounty.net,Madison County Telephone Company,ISP
+madisoncountyal.gov,Madison County Commission,Government
 madisonhealth.com,Madison Co Memorial Hospital,Healthcare
 madisontelco.com,Madison Telephone Company,ISP
 madiunkab.go.id,Pemerintah Kabupaten Madiun,Government
@@ -16113,6 +16647,7 @@ mahamayainternet.com,Mahamaya Internet Services,ISP
 mahaonline.gov.in,MahaOnline,Government
 maharashtra.gov.in,Maharashtra Government – Official Website,Government
 maharashtrabank.com,Bank Of Maharashtra,Finance
+maharlikaix.ph,Maharlika Internet Exchange,ISP
 mahaska.org,Mahaska Communication Group MCG,ISP
 mahawiranusantaragroup.id,Mahawira Nusantara Grup,ISP
 mahdiinternet.com,Mahdi Internet,ISP
@@ -16160,6 +16695,8 @@ mailspamprotection.com,SiteGround,Web Host
 mailwip.com,Mailwip,Email Provider
 maimonidesmed.org,Maimonides Medical Center,Healthcare
 maine.edu,University of Maine System,Education
+maine.gov,State of Maine,Government
+maine207.org,Maine Township High School District 207,Education
 mainehealth.org,MaineHealth,Healthcare
 mainlandtelecom.com,Mainland Telecom,ISP
 mainline.com,Mainline Information Systems,MSP
@@ -16193,6 +16730,7 @@ majordomo.ru,Hosting,Web Host
 mak.ac.ug,Makerere University,Education
 makassar.go.id,LPSE Kota Makassar,Government
 makassarkota.go.id,Dinas Komunikasi dan Informatika Kota Makassar,Government
+makcm.ru,Maks-M,Finance
 makeevka.com,Makeevka Online,ISP
 makenewmedia.com,MakeNewMedia Communications,ISP
 makeshop.jp,makeshop,SaaS
@@ -16241,6 +16779,7 @@ mangonet.com.ve,"Mango Network, C. A. Mangonet",ISP
 mangotele.com,Mango Telecom,ISP
 manh.com,Manhattan,SaaS
 manhattan.edu,Manhattan University,Education
+manhattanassociates.com,Manhattan Associates,Logistics
 manifone.com,Manifone,ISP
 maniranet.id,Maniranet,ISP
 manitu.de,manitu,Web Host
@@ -16259,6 +16798,7 @@ manulife.com,Manulife,Finance
 manux.net.nz,Manux Solutions,Web Host
 manxtelecom.com,Manx Telecom,ISP
 maocablevision.com,MAO Cable Vision,ISP
+mapfre.cl,MAPFRE Chile,Finance
 mapheadstart.org,Mississippi Action for Progress,Nonprofit
 mapit.gov.in,Madhya Pradesh Agency For Promotion Of Information Technology,Government
 maplebank.com,Maple Bank,Finance
@@ -16276,6 +16816,7 @@ maraveca.com,Maraveca Telecomunicaciones,ISP
 marbell.com,Marbell,Finance
 marcant.net,MARCANT,MSP
 marcatel.com,Marcatel,ISP
+marchnetworks.com,March Networks,Healthcare
 marconet.com,Marco Technologies,MSP
 marconi.solutions,Marconi Solutions,ISP
 maren.ac.mw,MAREN Malawi Research and Education Network,Education
@@ -16291,6 +16832,7 @@ mariettaga.gov,"Marietta, GA",Government
 mariix.net,Mariana Islands Internet Exchange,ISP
 mariluznet.com.br,MariluzNet Telecomunicações,ISP
 marin.ca.us,County of Marin,Government
+maringeneral.org,Marin General Hospital,Healthcare
 marinter.com.br,Marinter Telecom,ISP
 marion.sa.gov.au,City of Marion,Government
 marioncs.com,Computer Solutions,MSP
@@ -16329,6 +16871,7 @@ marsu.ru,"Federal State Budgetary Educational Institution of Higher Education ""
 mart.ru,KVS,ISP
 martekwireless.com,Martek Wireless,ISP
 martinborough.net.nz,Martinborough internet,ISP
+martingale.com,Martingale Asset Management Limited Partnership,Finance
 martinsnet.com.br,Martins.Net,ISP
 martinstelecom.com.br,Martins & Martins Telecom,ISP
 martinstelecom.net.br,Martins Telecom,ISP
@@ -16426,6 +16969,7 @@ matrixtelecoms.com,Matrix Telecoms,ISP
 matrixwifi.com.br,Toledo Fibra Telecomunicaçao,ISP
 matrox.com,Matrox Video,Manufacturing
 matruchhayanetwork.com,Matruchhaya Cable Network,ISP
+matson.com,Matson,Logistics
 mauleebroadband.com,Maulee Broadband,ISP
 maulinetwork.com,Mauli Network,ISP
 mauriziano.it,Ordine Mauriziano,Healthcare
@@ -16471,6 +17015,7 @@ maxisat.fi,Maxisat (Maxivision),ISP
 maxistelecom.com.br,Impactnet Telecomunicacoes,Web Host
 maxitel.nl,MaxiTEL Telecom,ISP
 maxko-hosting.com,MAXKO Hosting,Web Host
+maxline.net.br,Maxline Telecom,ISP
 maxlink.net.id,MAXLINK,ISP
 maxmaton.nl,Max Maton,Education
 maxmedia.com.sa,Maximum Solutions for Communications and Information Technology,ISP
@@ -16484,6 +17029,7 @@ maxnetisp.com.br,Maxnet Provedor DE Internet,ISP
 maxnetonlinebd.com,maxnetonline,ISP
 maxnoc.com,MaxNOC Communications,ISP
 maxo.com.au,Maxo Telecommunications,ISP
+maxsip.com,Maxsip,ISP
 maxtelekom.sk,MaxTelekom,ISP
 maxwebtelecom.com.br,MaxWeb Telecom,ISP
 maxwelltele.com,Maxwell Telecom,ISP
@@ -16515,6 +17061,7 @@ mbharch.com,MBH Architects,Healthcare
 mbhbank.hu,MBH Bank Nyrt,Finance
 mbibd.net,Matuail Broadband Internet,ISP
 mbit.pl,mBit.pl,ISP
+mbix.ca,Manitoba Internet Exchange,ISP
 mbl.edu,MBL,Education
 mblbd.com,Mercantile Bank,Finance
 mbn-glasfaser.de,Mobile Breitbandnetze,ISP
@@ -16534,6 +17081,7 @@ mc.net.co,Media Commerce Partners,ISP
 mc3.edu,Montgomery County Community College,Education
 mcad.edu,Minneapolis College of Art and Design,Education
 mcat.co.jp,MCAT,ISP
+mcb-bank.com,Maduro & Curiels Bank,Finance
 mcb.com.mm,Myanmar Citizens Bank Public,Finance
 mcb.com.pk,MCB Bank Pakistan,Finance
 mcbankny.com,Metropolitan Commercial Bank,Finance
@@ -16541,11 +17089,13 @@ mcbislamicbank.com,MCB Islamic Bank,Finance
 mcbroad.com,Mcbroad,ISP
 mcbroadbandbd.com,M.C. Broadband,ISP
 mcc.edu,Mott Community College,Education
+mccb.edu,MIssissippi Community College Board,Education
 mccneb.edu,Metropolitan Community College,Education
 mccooknet.com,McCookNet,Web Host
 mccormickplace.com,McCormick Place,Event Planning
 mccsc.edu,Monroe County Community School,Education
 mcdaniel.edu,McDaniel College,Education
+mcdermottlaw.com,"McDermott, Will, and Emery",Legal
 mcdir.me,McHost,Web Host
 mcdir.ru,McHost,Web Host
 mcdlv.net,Intuit Mailchimp,Marketing
@@ -16560,6 +17110,7 @@ mcgm.gov.in,Brihanmumbai Muncipal,Government
 mch.com,Miami Children's Hospital,Healthcare
 mchd-tx.org,Montgomery County Hospital District,Healthcare
 mchenry.edu,McHenry County College District 528,Education
+mchest.com,MChest Pharmacy,Healthcare
 mchsi.com,MediacomCable,ISP
 mci.ir,MCI Iran,ISP
 mcinfor.com.br,MC Telecom,ISP
@@ -16571,6 +17122,7 @@ mcl.edu.ph,Pulo Diezmo Rd,Education
 mcla.edu,Mass College of Liberal Arts,Education
 mclaren.org,McLaren Health Care,Healthcare
 mclaut.com,McLaut,ISP
+mclennan.edu,McLennan Community College,Education
 mcloud.rs,mCloud,Web Host
 mcm-id.net,Badan Kependudukan dan Keluarga Berencana Nasional,ISP
 mcm.ru,Telekom Servis,ISP
@@ -16592,6 +17144,7 @@ mcperu.pe,Media Commerce Perú S.A.C,ISP
 mcpinc.com,Marchese Computer Products,MSP
 mcpre.ru,McHost,Web Host
 mcpsmd.org,Montgomery County Public Schools (Maryland),Education
+mcru.ac.th,Muban Chombueng Rajabhat University,Education
 mcservices.com,MC Services,MSP
 mcsnet.ca,MCSnet,ISP
 mcsv.net,Intuit Mailchimp,Marketing
@@ -16628,7 +17181,9 @@ mdu.com,MDU Resources,Utilities
 me.com,Apple iCloud,Email Provider
 mea.gov.in,"CPV Division , Ministry of External Affairs",Government
 mea.sa,Middle East Advanced IT Systems Establishment,Web Host
+meadewillis.com,Meade Willis,Logistics
 measat.com,Measat Satellite Systems,ISP
+mebank.com.au,ME Bank,Finance
 mec.pt,Portuguese Ministry of Education,Government
 mechanicsb.com,Mechanics Bank,Finance
 mechanicsvilletel.net,Mechanicsville Telephone,ISP
@@ -16640,6 +17195,7 @@ meconecte.com.br,Meconecte COM BR,ISP
 medallia.com,Medllia,SaaS
 medallioncom.com,Medallion Communications,Web Host
 medcity.net,HCA Healthcare,Healthcare
+medcoenergi.com,MedcoEnergi,Utilities
 medeniyet.edu.tr,Istanbul Medeniyet Universitesi,Education
 medhahosting.com,Medha Hosting,Web Host
 medi-take.jp,Medi-Take,Healthcare
@@ -16688,6 +17244,7 @@ medinacounty.gov,Medina County Ohio,Government
 medis.com,"Medis, Medical Marketing Company",Healthcare
 medisyshealth.org,Medisys Health Network,Healthcare
 meditake.jp,Medi-Take,Healthcare
+meditech.com,MEDITECH EHR Software,Healthcare
 meditel.cat,Meditel Network,ISP
 mediweightloss.com,Medi-Wegihtloss,Healthcare
 mediweightlossclinics.com,Medi-Wegihtloss,Healthcare
@@ -16699,12 +17256,14 @@ medrozoitsolutions.com,Medrozo IT Solutions,MSP
 medstar911.org,MedStar Mobile Healthcare,Healthcare
 medstarhealth.org,MedStar Health,Healthcare
 medtronic.com,Medtronic,Healthcare
+meduca.gob.pa,Ministerio de Educacion - MEDUCA,Government
 medunet.com.sa,Sultan Bin Abdulaziz Foundation (Medunet),Healthcare
 meduniwien.ac.at,Medical University of Vienna,Education
 medusind.com,Medusind,Healthcare
 medway.gov.uk,Medway Towns Council,Government
 medweb.net,Medweb,Healthcare
 medyabim.com.tr,Emre Erim trading as Medyabim Datacenter,Web Host
+meemic.com,Meemic Insurance Company,Finance
 meeq.com,MEEQ,SaaS
 meerfarbig.net,meerfarbig,Web Host
 meezanbank.com,Meezan Bank,Finance
@@ -16856,13 +17415,16 @@ mercury.net,Mercury Network,ISP
 mercurybroadband.com,Mercury Broadband,ISP
 mercurygate.net,MercuryGate,SaaS
 mercuryit.com.au,Mtspl,MSP
+mercy.edu,Mercy University,Education
 mercy.net,Sisters of Mercy Health System,Healthcare
 merdeka.net.id,Merdeka,ISP
 merezha.in.ua,Merezha,ISP
 meric.net.tr,Meriç Hosting,Web Host
+meridiancc.edu,Meridian Community College,Education
 meridianfiberblaze.com,Meridian Cable TV,ISP
 meridianhealth.com,Hackensack Meridian Health,Healthcare
 merinosa.com,Merino,ISP
+merinoservices.com,"70, KLJ Complex",Finance
 meriplex.com,Meriplex Communications,MSP
 merit.edu,Merit Network,Education
 merl.com,Mitsubishi Electric Research Labs,Education
@@ -16887,11 +17449,14 @@ messagelabs.com,Broadcom Enterprise Messaging Security,Email Security
 messagenet.com,Messagenet,ISP
 messagexchange.com,MessageeXchange,SaaS
 messagingengine.com,Fastmail,Email Provider
+messiah.edu,Messiah,Education
 mestelecom.com.br,Mirante Network Comunicacao,ISP
 mesvr.com,ReadNotify,Email Provider
 met.pl,PC Serwis Athletic Studio,ISP
+meta-akses.com,Meta Akses Indonesia,ISP
 meta-cti.com.br,META-CTi Tecnologia da Informacao,MSP
 meta10.com,META10,IaaS
+metacamp.com.br,Transkompa,Consulting
 metadatanetwork.com,Meta Data Network (MDN),ISP
 metadosis.gr,Metadosis,ISP
 metaliance.net,Metaliance Datacenter GRA,Web Host
@@ -16915,12 +17480,14 @@ meteoric.net,Meteoric,ISP
 meteversecloud.com,Meteverse,IaaS
 metfone.com.kh,Metfone,ISP
 metfy.cl,Metfy,ISP
+methodisthealth.org,Methodist Hospital of Memphis,Healthcare
 methodisthealthsystem.org,Methodist Health System,Healthcare
 methodisthospital.org,Methodist Hospital of Southern California,Healthcare
 metoo72.ru,Mitu Telecom,ISP
 metpro.co,MetPro,SaaS
 metrabyte.cloud,453 Ladplacout Jorakhaebua,Web Host
 metranet.co.uk,Metranet Communications,ISP
+metrex.net,Metrex Systems,Nonprofit
 metricsthatmatter.com,Metrics That Matter,SaaS
 metro-cit.ac.jp,Tokyo Metropolitan College of Industrial Technology Infomation System Engineering Course,Education
 metro-set.ru,Metroset Tyumen,ISP
@@ -16981,7 +17548,9 @@ mfu.ac.th,Mae Fah Luang University,Education
 mfwireless.com,MFWireless,ISP
 mgb.org,Mass General Brigham,Healthcare
 mgbsys.com,MGB Systems,Web Host
+mgccc.edu,Mississippi Gulf Coast Community College,Education
 mgconecta.com.br,Conecta,ISP
+mggs.vic.edu.au,Melbourne Girls Grammar School,Education
 mgimo.ru,"Federal state autonomous institution of higher education ""Moscow State Institute of International Relations (University)""",Education
 mgk.pl,MGK Internet i Telewizja,ISP
 mgmresorts.com,MGM Resorts,Travel
@@ -16991,6 +17560,7 @@ mgnett.com.br,Mgnett Telecomunicações,ISP
 mgnettelecom.com.br,MG NET Telecom,ISP
 mgnfibra.com.br,MGN FIBRA,ISP
 mgp.net.br,MGP Telecom,ISP
+mgs.vic.edu.au,Melbourne Grammar School,Education
 mgsm.ru,Aviasales,Travel
 mgtelecom.com.br,MG Telecom,ISP
 mgtelecom.ru,Magellan Telecom Kuzbass,ISP
@@ -17000,6 +17570,7 @@ mha.gov.in,Indian Cybercrime Coordination Centre,Government
 mhcc.edu,Mount Hood Community College,Education
 mhchealthcare.org,Marana Health Center,Healthcare
 mhcs.us,Memorial Health Care Systems,Healthcare
+mhdcommunications.com,MHD,ISP
 mhnet.com.br,Mhnet Telecom,ISP
 mho.de,Marienhospital Osnabrück,Healthcare
 mhonlinebd.com,MH Online,ISP
@@ -17012,6 +17583,7 @@ mia.co.za,MIA Telecoms,ISP
 mia.net,HostDrive,Web Host
 miami.edu,University of Miami,Education
 miamidade.gov,Miami-Dade County,Government
+miamigov.com,City of Miami,Government
 miamioh.edu,Miami University,Education
 miatel.ru,MiaTel,ISP
 mibroadband.com,MiBroadband,ISP
@@ -17075,10 +17647,14 @@ midiko.pl,Livenet,ISP
 midix.com.br,midix.com.br,ISP
 midland.edu,Midland College,Education
 midlandbankbd.net,Midland Bank,Finance
+midlandhealth.org,Midland County Hospital District,Healthcare
+midlandtexas.gov,City of Midland,Government
+midpac.edu,"Mid-Pacific Oahu, Honolulu, Hawaii",Education
 midplains.coop,Mid-Plains Rural Telephone,ISP
 midrivers.com,Mid-Rivers Communications,ISP
 midsouthfiber.com,MidSouth Fiber,ISP
 midwaynet.net,MidwayNet,ISP
+midwestern.edu,Midwestern University,Healthcare
 midwestfibernetworks.com,Midwest Fiber Networks,ISP
 midwestwirecable.com,Midwest Cable,ISP
 mie-u.ac.jp,Mie University,Education
@@ -17099,6 +17675,7 @@ mihandns.com,Netmihan Communication,Web Host
 mihs.org,Maricopa Integrated Health System,Healthcare
 miinternet.cl,Mi Internet,ISP
 miit.co.nz,MiIT,MSP
+miit.ru,"Federalnoe gosudarstvennoe avtonomnoe obrazovatelnoe uchrezhdenie vysshego obrazovaniya ""Rossiyskiy Universitet Transporta""",Education
 miit.ua,MIIT,ISP
 mik.ua,MIK Telecom,ISP
 mikipro.co.nz,MikiPro,ISP
@@ -17158,6 +17735,7 @@ mines.edu,Colorado School of Mines,Education
 minet-telecom.com.br,MI NET Telecom,ISP
 minet.sk,Minet Slovakia,ISP
 minetinc.net,MiNet,ISP
+minetworks.net,MINetworks,ISP
 mingonet.com.br,Mingo NET Comunicacao,ISP
 minhabloom.com.br,Minha BLOOM,ISP
 minhaconnect.com.br,Connect Telecomunicacoes,ISP
@@ -17204,6 +17782,7 @@ mirtelecom.pro,MIR Telecom,ISP
 mirzuno.com,Mirzuno Global Solution Provider,Web Host
 misaka.io,Misaka Network,IaaS
 misamiscable.tv,Misamis Cable Management and Development,ISP
+mischoice.com,MIS Choice,MSP
 misd.net,Macomb Intermediate School District,Education
 misen.org,Middle Michigan Network for Educational Telecommunications,ISP
 misericordia.edu,Misericordia University,Education
@@ -17261,6 +17840,7 @@ mix-it.net,MIX,ISP
 mixconect.com.br,Mixconect,ISP
 mixheberg.fr,MixHeberg,Web Host
 mixnet.net.br,MixNet,ISP
+mixp.org,Mauritius Internet Exchange Point,ISP
 mixtrio.net,Mixtrio,Web Host
 mixvoip.com,Mixvoip,ISP
 miyatelecom.com,Miya Telecom,ISP
@@ -17268,6 +17848,7 @@ miyazaki-catv.ne.jp,Miyazaki Cable Television,ISP
 mizban.com,Mizban,Web Host
 mizuho-sc.com,Mizuho Bank,Finance
 mjhs.org,MJHS Health System,Healthcare
+mjjbrilliant.com,MJJ Brilliant,Manufacturing
 mk-net.ru,Buko,ISP
 mk.de,MK Netzdienste,MSP
 mkb.ru,Credit bank of Moscow,Finance
@@ -17278,6 +17859,7 @@ mkpnet.ru,Orgtechservice (MKP-Net),ISP
 mkq.de,Webhosting-Angebote | MKQ Internetservice,Web Host
 mks-net.ru,Elektranet,ISP
 mksnet.com.br,RazaoInfo,ISP
+mksnetsolucoes.com.br,mks net solucoes em internet,ISP
 mkstelecom.ru,MKS Telecom,ISP
 mkt2527.com,Acoustic,Marketing
 mktdns.com,Marketo,Marketing
@@ -17299,6 +17881,7 @@ mlps.ca,Middlesex-London Paramedic Service,Healthcare
 mls-communications.com,MLS Communications spécialiste Télécom,ISP
 mls.com.br,MLS Wireless,ISP
 mls.nc,MLS New Caledonia,ISP
+mlslistings.com,MLSListings.com,Real Estate
 mltfibra.net.br,MLT Fibra,ISP
 mma.com.br,MMA Fibra,ISP
 mma.gov.br,Ministerio DO Meio Ambiente,Government
@@ -17306,6 +17889,7 @@ mmc.at,MMC,ISP
 mmc.edu,Meharry Medical College,Education
 mmchs.org,Meadville Medical Center,Healthcare
 mmd.net.id,Mitra Media Data,ISP
+mme.gov.br,Ministerio DE Minas E Energia,Government
 mmeherabinternet.net,M Meherab Internet,ISP
 mminternet.com,MM Internet,ISP
 mmix.net.mm,MMIX,ISP
@@ -17318,6 +17902,7 @@ mmsdigi.id,Mms Digital Communication,ISP
 mmtelecom.ru,"""Mir Mitino Telecom""",ISP
 mmu.ac.kr,Mokpo National Maritime University,Education
 mmumo.net,Marshall Municipal Utilities,ISP
+mnat.com,"Morris, Nichols, Arsht and Tunnel",Legal
 mnb.hu,National Bank of Hungary,Finance
 mnc303.id,Muba Network Connection,ISP
 mncable.net,Sjoberg's,ISP
@@ -17371,6 +17956,7 @@ moc.edu,University of Mount Olive,Education
 moc.gov.kw,Ministry Of Communication,Government
 mocinternet.net.br,MOC Internet,ISP
 mod.go.th,"Ministry Of Defence, Thailand",Government
+modahealth.com,Moda Health,Healthcare
 modares.ac.ir,Tarbiat Modares University,Education
 modee.gov.jo,National Information Technology Center,Government
 modeldrug.com,Model Health Care,Healthcare
@@ -17378,6 +17964,7 @@ modeltele.com,Model Telecom,ISP
 modenesegastone.com,Modenese Gastone,Retail
 moderncolo.com,ModernColo LP,Web Host
 moderncommunication.net,Modern Communication,ISP
+modernops.com,ModernOps Solutions,MSP
 modexi.com.tr,Modexi Veri Hizmetleri,ISP
 modhumotibankltd.com,Modhumoti Bank,Finance
 modhumotinet.com,Modhumoti Internet Service,ISP
@@ -17394,7 +17981,9 @@ moffitt.org,H. Lee Moffitt Cancer Center & Research Institute,Education
 mofiber.se,Mjoback Overlida Fiber Ekonomisk forening,ISP
 mogilev.by,Mogilev.by,ISP
 moha.gov.vn,Information Technology Center - Ministry of Home Affairs,Government
+mohave.gov,Mohave County AZ,Government
 mohawkcollege.ca,Mohawk College,Education
+mohegansunpocono.com,Mohegan Sun Pocono Downs,Travel
 moi.go.th,Ministry of Interior,Government
 moi.gov.qa,Ministry of Interior - Telecommunication Department,ISP
 moiprovaider.ua,Telekompaniya Region,ISP
@@ -17457,6 +18046,7 @@ montgomerycountymd.gov,"Montgomery County Government, Maryland",Government
 montgomerycountypa.gov,"Montgomery County, PA",Government
 montreal.ca,City of Montreal,Government
 montrosehospital.com,Montrose Memorial Hospital,Healthcare
+monument.health,Monument Health,Healthcare
 monzoon.net,Monzoon Networks,ISP
 moody.edu,The Moody Bible Institute of Chicago,Education
 moodycenteratx.com,Moody Center,Education
@@ -17483,14 +18073,17 @@ more-telecom.ru,"MUE ""Sea Telecom"" VGA Melitopol Zaporizhie Region",ISP
 more.net,MOREnet,Education
 moreheadstate.edu,Morehead State University,Education
 morehouse.edu,Morehouse College,Education
+morelos.gob.mx,Gobierno del Estado de Morelos,Government
 morenet.ac.mz,MoRENet,Education
 moreno.gob.ar,Municipalidad DE Moreno,Government
 moresi.com,Moresi.com,MSP
 morespeed.com.br,More Speed Fibra,ISP
+moretonbay.qld.gov.au,Moreton Bay Regional Council - Pine Rivers Office,Government
 morewave.com,Morewave,ISP
 morewifi.in,More wifi Internet,ISP
 morfeutelecom.com.br,Morfeu Telecom,ISP
 morgan.edu,Morgan State University,Education
+morgans.com.au,Morgans,ISP
 morganstanley.com,Morgan Stanley,Finance
 morganstanleysmithbarney.com,Morgan Stanley Smith Barney,Finance
 moriah.nsw.edu.au,Moriah War Memorial College Association,Education
@@ -17514,6 +18107,7 @@ mosline.ru,OOO Gruppa MosLine,ISP
 mosnet.ru,Informational-measuring systems,ISP
 mosoblbank.ru,Joint Stock Company Moscovskiy Oblastnoi Bank,Finance
 mospolytech.ru,Moscow Polytechnic University,Education
+mossadams.com,"Moss Adams, LLP",Finance
 mostele.ru,Moskovia Telecom,ISP
 mostobene.com,Mostobene,Healthcare
 mot.go.th,"The Permanent Secretary, Ministry of Transport of Thailand",Government
@@ -17570,6 +18164,7 @@ mpsaz.org,Mesa Public Schools,Education
 mpschools.org,Minneapolis Public Schools,Education
 mpsnet.net.mx,"Internet Engine, S.A. de C.V",ISP
 mptc.gov.kh,Ministry of Posts and Telecommunication,ISP
+mptt.gov.so,"Ministry of Posts, Telecommunications and Technology",ISP
 mpucomms.co.za,Mpu Communications (Pty),ISP
 mpulsefiber.com,M-Pulse Fiber,ISP
 mpw.org,Muscatine Power and Water,Utilities
@@ -17578,6 +18173,7 @@ mr-daten.de,MR Datentechnik,MSP
 mr7telecom.com.br,MR7 Telecom,ISP
 mrc.gov.in,Karnataka Municipal Data Society,Government
 mrdigital.net.br,MR Digital Servicos e Comunicacoes,Web Host
+mrdoors.ru,Кухни и мебель на заказ от производителя Mr.Doors в Москве,Manufacturing
 mrgdigital.com,MRG Digital,Marketing
 mrhc.org,Magnolia Regional Health Center,Healthcare
 mrhost.biz,MrHost,Web Host
@@ -17598,6 +18194,7 @@ mscc.edu,Motlow State Community College,Education
 msctv.ca,Mitchell Seaforth Cable TV,ISP
 msd-consulting.co.za,MSD Consulting,Finance
 msd.govt.nz,MSD,Government
+msdelta.edu,Mississippi Delta Community College,Education
 msen.com,Msen,ISP
 mserwis.pl,MSERWIS,Web Host
 msfiber.net,Mainstream Fiber Networks,ISP
@@ -17681,10 +18278,12 @@ mtn.ng,MTN,ISP
 mtn.sd,MTN,ISP
 mtn.zm,MTN Zambia,ISP
 mtnbeam.com,Almendras Communications,ISP
+mtnbusiness.co.ke,NIC Bank,Finance
 mtncongo.net,MTN Congo,ISP
 mtnet.hr,Magic Net,ISP
 mtnirancell.ir,MTN Irancell,ISP
 mtnl.net.in,MTNL,ISP
+mtnlinkd.com,Mtnlinkd,ISP
 mtnonline.com,MTN,ISP
 mtnpcl.com,Myanmar Telecommunication Network Public,ISP
 mtnsat.com,MTNSat,ISP
@@ -17800,6 +18399,7 @@ muona.fr,MUONA,ISP
 murfreesborodata.com,Murfreesboro Data,Web Host
 murphysboro-il.gov,Murphysboro Community Unit School District No. 186,Government
 murray-ky.net,Murray Electric System,ISP
+murraybridge.sa.gov.au,The Rural City of Murray Bridge,Government
 murrayhospital.org,Murray-Calloway County Hospital,Healthcare
 murraystate.edu,Murray State University,Education
 musashi-eng.co.jp,Musashi Engineering,Manufacturing
@@ -17875,9 +18475,11 @@ myanmaposts.net.mm,Myanma Posts and Telecommunications,ISP
 myanmar-link.com,Myanmar Link Telecommunication,ISP
 myanmarskycitynetworkcommunication.com,MYANMAR SKY CITY NETWORK COMMUNICATION Co,ISP
 myarsyilaindonesia.co.id,Myarsyila Indonesia Interkoneksi,ISP
+mybbs.id,Baraya Bareng Sadulur,Physical Security
 mybec.com.tr,Mybec Telekom,ISP
 mybluehost.me,Bluehost,Web Host
 mybluepeak.com,Bluepeak,ISP
+mybrb.com,Blue Ridge Bankshares,Finance
 mybtc.com,BTC Broadband,ISP
 mycallis.com,Callis Communications,ISP
 mycentra.ru,MyCentra,ISP
@@ -17974,6 +18576,7 @@ myspreadshop.nl,Spreadshop,SaaS
 myspreadshop.no,Spreadshop,SaaS
 myspreadshop.pl,Spreadshop,SaaS
 myspreadshop.se,Spreadshop,SaaS
+mysticlake.com,Mystic Lake Casino Hotel,Travel
 mytel.com.mm,Mytel Myanmar,ISP
 mytelco.com.cy,MyTel,ISP
 mytelnet.co.za,Broadband Innovations,ISP
@@ -18062,10 +18665,12 @@ nap.com.ve,Servicios NAP VEN,ISP
 nap.net.tw,Taiwan Network Access Point,ISP
 napapiirinkuituverkot.fi,Napapiirin Kuituverkot,ISP
 naperville.il.us,City of Naperville,Healthcare
+naphcare.com,NaphCare,Healthcare
 napinfo.co.id,NAP Info Indonesia,ISP
 naquadria.it,Naquadria,ISP
 naracom.hu,Naracom,ISP
 narayana.com.br,Narayana,ISP
+naropa.edu,Naropa University,Education
 narxoz.edu.kz,Narxoz University,Education
 nasa.gov,NASA,Government
 nasatel.id,Nusantara Akses Telekomunikasi,ISP
@@ -18091,6 +18696,7 @@ natalfibra.com.br,Natal Fibra,ISP
 natanet.ru,Service Terminal Media,ISP
 natanetwork.co.id,NATANETWORK,Web Host
 natbank.co.mw,National Bank of Malawi,Finance
+natc.co.nz,NATC,MSP
 natcom.com.ht,Natcom Haiti,ISP
 natconet.com,Northern Arkansas Telephone,ISP
 natcoweb.com,NatCoWeb,Web Host
@@ -18100,6 +18706,7 @@ nationalbank.co.ke,National Bank of Kenya,Finance
 nationalbank.kz,National Bank of the Republic of Kazakhstan,Finance
 nationalgeneral.com,National General (Allstate),Finance
 nationalhha.com,National Home Health,Healthcare
+nationallife.com,National Life Group,Finance
 nationalwi-fi.com,National Wi-Fi,ISP
 nationbd.com,Nation Communication,ISP
 nationlanka.com,Nation Lanka Finance,Finance
@@ -18111,6 +18718,7 @@ nationwidechildrens.org,Nationwide Children's Hospital,Healthcare
 nativenetwork.com,Native Network,ISP
 natkraftboras.se,Natkraft Boras,Utilities
 nato.int,NATO,Defense
+natomasunified.org,Natomas Unified School District,Education
 natunakab.go.id,Diskominfo Kab. Natuna,Government
 naturalwireless.com,Natural Wireless,ISP
 natwestmarkets.com,NatWest Markets,Finance
@@ -18158,6 +18766,7 @@ navpoint.com,Navpoint Internet,ISP
 navy.mil,U.S. Navy,Defense
 naxostelecom.com.br,Naxos Telecom,ISP
 nayatel.com,Nayatel,ISP
+naz.edu,Nazareth University,Education
 nazanet.com.br,Nazanet,ISP
 nazaseg.com.br,Nazaseg Telecom,ISP
 nazimhost.com.bd,Nazim Host,Web Host
@@ -18174,6 +18783,7 @@ nbcuni.com,NBCUniversal,Entertainment
 nbg.gov.ge,National Bank of Georgia,Finance
 nbg.gr,National Bank OF Greece,Finance
 nbhbank.com,NBH Bank,Finance
+nbi.ie,NBI,ISP
 nbi.kyiv.ua,NBI INTERNET,ISP
 nbi.lv,NBI,ISP
 nbis.bg,NBI Systems,ISP
@@ -18231,6 +18841,7 @@ ncsl.ca,Northern Computer Solutions,MSP
 ncst.com,NCS Technologies,MSP
 ncsu.edu,NC State University,Education
 nct9.co.jp,NCT,ISP
+ncta.com,NCTA - The Internet & Television Association,ISP
 nctaiwan.com,NC Taiwan,ISP
 nctc.com,NCTC,ISP
 ncts.com.eg,National Company for Telecommunication Services,ISP
@@ -18263,6 +18874,7 @@ neareastbank.com,Near East Bank,Finance
 nearlyfreespeech.net,NearlyFreeSpeach.NET,Web Host
 nearoute.io,Nearoute (Ikuuu Network),Web Host
 neas.mr.no,Neas,ISP
+nebh.org,NEBH Orthopedic Care in Boston,Healthcare
 nebius.com,Nebius,IaaS
 nebraska.edu,University of Nebraska,Education
 nebraska.gov,State of Nebraska,Government
@@ -18296,6 +18908,7 @@ neitel.net,NEIT Services,ISP
 nelsoncable.com,Nelson Cable,ISP
 nelsonvilletv.com,Nelsonville TV,ISP
 nema.fo,Nema,SaaS
+nemcc.edu,Nemcc,Education
 nemicom.ua,NEMIcom,ISP
 nemont.com,Nemont,ISP
 nemours.org,The Nemours Foundation,Healthcare
@@ -18377,6 +18990,7 @@ net-max.com,CR Internet Apucarana,ISP
 net-minders.com,Netminders Server Hosting,IaaS
 net-partner.pl,Net-Partner,ISP
 net-pro.com.pl,Lukasz Zaremba trading AS NET-PRO,ISP
+net-ray.com,NetRay VPS,Web Host
 net-rosas.com.br,Net Rosas,ISP
 net-sky.ru,Korolev-Telecom,ISP
 net-uno.net,Net Uno,ISP
@@ -18440,6 +19054,7 @@ netbudur.com,Netbudur,ISP
 netbull.it,Net Bull,ISP
 netcablecnd.com,Net Cable CND,ISP
 netcabo.pt,NOS,ISP
+netcalibre.uk,Netcalibre,ISP
 netcan.es,Netcan,ISP
 netcanes.com.br,NetCanes Fibra,ISP
 netcarrier.com,NetCarrier,ISP
@@ -18447,6 +19062,7 @@ netcartelecom.com.br,Netcar Telecom,ISP
 netcasa.cl,Netenmica,Healthcare
 netcaster.com.br,NETCASTER,ISP
 netcelltelecom.com.br,Netcell Telecom,ISP
+netcenter.net,Network Center,MSP
 netcentersp.com.br,Netcenter,ISP
 netcentertelecom.com.br,Netcenter Telecom,ISP
 netcetera.co.uk,Netcetera,Web Host
@@ -18517,6 +19133,7 @@ netesta.com,Hosting Hizmeti | Netesta.com,ISP
 netexpand.com.br,NetExpand,ISP
 netexpressbd.com,NetExpress Online,ISP
 netexpressbrasil.com,Net Express Brasil,ISP
+netfabric.com,NetFabric,MSP
 netfacilbandalarga.com.br,S.Barros DE Souza,ISP
 netfactor.com.tr,Netfactor Telekominikasyon ve Teknoloji Hizmetleri San. ve Tic,MSP
 netfala.pl,NETFALA,ISP
@@ -18552,6 +19169,7 @@ netfort.com.br,NET FORT Telecom,ISP
 netfree.it,Netfree Internet Service Provider,ISP
 netfront.net,Netfront (2012 Limited),Web Host
 netfsa.com.br,Netfsa Banda Larga,ISP
+netfullfibra.cl,Netfull Fibra,ISP
 netfulltelecomunicacoes.com.br,Netfull Telecomunicações,ISP
 netfusion.com.br,Netfusion Internet,ISP
 netfy.com.br,Netfy Telecomunicacoes,ISP
@@ -18564,6 +19182,7 @@ netgloriainternet.com.br,Netglória Serviços de Internet,ISP
 netgo.psi.br,NetGo Telecomunicações do Brasil,ISP
 netgoias.com.br,Netgoias Telecom,ISP
 netgool.com.br,Netgool Telecomunicação,ISP
+netgotelecom.com.br,NetGO Telecom,ISP
 netgrid.host,Netgrid Host,Web Host
 netgrid.nl,NetGrid,ISP
 netgroot.com,Netgroot,ISP
@@ -18709,6 +19328,7 @@ netrexo.com,Netrexo Communications,ISP
 netribas.net.br,Net Rib,ISP
 netrics.ch,Netrics,MSP
 netrixllc.com,Netrix,MSP
+netro.com.au,Netro: Web Hosting,Web Host
 netroad.ru,Mobile TeleSystems,ISP
 netrouting.com,Netrouting,Web Host
 netrun.in,Netrun Fibernet,ISP
@@ -18915,6 +19535,7 @@ newlifechurchoffaith.org,New Life Church of Faith,Nonprofit
 newlime.ru,Newli,ISP
 newline.com.br,Newline Telecom,ISP
 newlinkrio.com.br,Work 349 Internet Provedores,ISP
+newlondonhospital.org,The New London Hospital Association,Healthcare
 newmanu.edu,Newman University,Education
 newmarket.com,Newmarket,Travel
 newmediaexpress.com,NewMedia Express,Web Host
@@ -18960,6 +19581,7 @@ newvisionsfiber.com,New Visions,ISP
 newvm.nl,NewVM.nl,Web Host
 newwavecom.net,New Wave Communications,ISP
 newwavenet.com.br,NEW WAVE NET,ISP
+newwestcity.ca,New Westminster Public Library,Government
 newworld.ph,NewWorld+,ISP
 newworldcomm.com,World Communications,ISP
 newworldpresenter.com,New World Presenter,News
@@ -19049,6 +19671,7 @@ nexusairfiber.com,Nexus Air Fiber,ISP
 nexusdatacenter.com.br,Alfacom telecomunições e multimidia,Web Host
 nexusds.com,NEXUSDS,ISP
 nexusguard.com,Nexusguard,Email Security
+nexushosting.io,Nexuscore Hosting,Web Host
 nexusis.com,Nexus IS,Healthcare
 nexusone.com.au,Nexus One,ISP
 nexustek.com,Nexus Technologies,Web Host
@@ -19060,6 +19683,7 @@ nexxlink.net.br,W B DE Andrade Telecomunicações E Informática,ISP
 nexy.com.br,Nexy,Web Host
 neyrial.com,Neyrial informatique,Web Host
 neysanetworks.com,Neysa Networks,Web Host
+nfenterprises.com,VA Broadband,ISP
 nfinitybroadband.com,NFinity,ISP
 nfl.com,National Football League,Sports
 nforce.com,NForce Entertainment,Web Host
@@ -19068,14 +19692,17 @@ nfshost.com,NearlyFreeSpeech.NET,Web Host
 nftctelecom.com,NFTC North Frontenac Telephone,ISP
 nfx.cz,NFX czFree eXchange,ISP
 nga.gov,National Gallery of Art,Government
+nga.gov.au,National Gallery of Australia,Government
 ngawikab.go.id,Ngawi,Government
 ngblunetworks.nl,NGBLU Networks,ISP
 ngcbroadband.com,NGC Broadband,ISP
 ngcommunications.com,NG Communications,ISP
 ngcomworld.com,Ngcom,ISP
 ngenix.net,NGENIX,SaaS
+nghs.com,Northeast Georgia Medical Center,Healthcare
 ngloba.com,Ngloba Devices,MSP
 ngn.coop,North Georgia Network,ISP
+ngnsys.com,NGNSYS,Technology
 ngpweb.com,Bonterra,Marketing
 ngren.edu.ng,NgREN Nigerian Research and Education Network,Education
 ngs.net.br,NGS NET Comunicacoes Multimidia,ISP
@@ -19101,6 +19728,7 @@ nhncloud.com,NHN Cloud,IaaS
 nhs.net,NHSmail,MSP
 nhso.go.th,National Health Security Office (NHSO),Government
 nhtc.coop,New Hope Telephone Cooperative,ISP
+nhvweb.net,North Hunterdon-Voorhees Regional High School District,Education
 ni.ac.rs,University of Nis,Education
 ni.iq,Domain Earth for Communication and Banking Solutions with Limited Liability,ISP
 nia.or.kr,NIA Korea,Government
@@ -19109,6 +19737,7 @@ niagaracollege.ca,Niagara College of Applied Arts and Technology,Education
 nianet.com.br,Nianet Fibra,ISP
 nibble.it,Nibble,ISP
 nibl.com.np,Nepal Investment Bank,Finance
+nibr.com,Genomics Institute of the Novartis Research Foundation,Education
 nibss-plc.com.ng,Nigeria Inter-Bank Settlement System Plc,Finance
 nibtv.co.kr,Namincheon Broadcasting,ISP
 nic-net.co.jp,Nippon Information and Communication,ISP
@@ -19147,6 +19776,7 @@ nigcomsat.gov.ng,NIGCOMSAT,Government
 nightowl.pro,Night Owl Wireless,ISP
 nigsun.net,Nigsun Telecom,ISP
 nih.gov,National Institutes of Health,Government
+nihilent.com,Nihilent,Consulting
 nihon-u.ac.jp,Nihon University,Education
 nii.ac.jp,National Institute of Informatics,Education
 niigata-u.ac.jp,Niigata University,Education
@@ -19177,6 +19807,7 @@ niosh.com.my,Malaysian National Institute of Occupational Safety and Health,Gove
 nip.io,nip.io,SaaS
 nipbr.com,NipBr Telecom,ISP
 nipbr.com.br,NipBr (NipCable),ISP
+nipfp.org.in,NIPFP,Education
 nipissingu.ca,Nipissing University,Education
 nippontec.net,Nippontec Telecomunicacoes,ISP
 niqturbo.com.br,Optica Telecom,ISP
@@ -19219,9 +19850,11 @@ nj-ix.net,NJ IX,ISP
 nj.gov,State of New Jersey,Government
 njedge.net,Edge,Nonprofit
 njit.edu,New Jersey Institute of Technology,Education
+njmasonic.org,Masonic Charity Foundation OF NEW Jersey,Healthcare
 njstatelib.org,New Jersey State Library,Education
 njtelecom.com.br,J. R. DOS Santos Serviços DE Comunicaçao,ISP
 nk-net.ru,NK-NET,ISP
+nkcschools.org,North Kansas City Schools,Education
 nkfiber.com.br,N.K. Fiber Link,ISP
 nkh.com.tw,New Kaohsiung Broadband,ISP
 nkn.gov.in,National Knowledge Network,Education
@@ -19235,6 +19868,7 @@ nl.edu,National-Louis University,Education
 nla.gov.au,National Library of Australia,Government
 nlighten.com,nLighten,Web Host
 nlighten.eu,nLighten,Web Host
+nline.ru,Enline,ISP
 nlink.com.br,Nlink Servicos E Tecnologia DE Internet,ISP
 nls.kz,NLS Kazakhstan,ISP
 nltc.net,New Lisbon Telephone,ISP
@@ -19246,6 +19880,7 @@ nmcourts.gov,State of NM Administrative Office of the Courts,Government
 nmfibernetwork.com,NM Fiber Network,ISP
 nmit.edu.au,Northern Melbourne Institute OF Tafe,Education
 nmlegis.gov,Legislative Council Service,Government
+nmmi.edu,The New Mexico Military Institute,Education
 nmmn.com,NMMN,ISP
 nmsolution.net,Nusantara Multimedia Solution Gorontalo,ISP
 nmsu.edu,New Mexico State University,Education
@@ -19257,6 +19892,7 @@ nn.dp.ua,Anastasiia Kamyshan,ISP
 nnetrj.com.br,Iago NET TEL Servicos DE Internet,ISP
 nnettelecom.com.br,Nnet Telecomunicação,ISP
 nnix.cn,Zhejiang Province New-Type Internet Exchange Point CO,ISP
+nnpcgroup.com,NNPC,Utilities
 nns.ne.jp,Nihon Network Service,ISP
 nnt.lt,NNT (Barbamia),ISP
 nnvhs.net,nnvhs.net,ISP
@@ -19389,6 +20025,8 @@ northtelecom.com,Northtelecom,ISP
 northwell.edu,North Shore Long Island Jewish Health System,Healthcare
 northwestbroadband.ie,Northwest Broadband,ISP
 northwestern.edu,Northwestern University,Education
+northwesternmedicalcenter.org,NorthWestern Medical Center,Healthcare
+northwestms.edu,Northwest Mississippi Community College,Education
 northwestu.edu,Northwest University,Education
 northwood.edu,Northwood University,Education
 northwoodsconnect.com,Northwoods Connect,ISP
@@ -19396,6 +20034,7 @@ nortonhealthcare.com,Norton Healthcare,Healthcare
 norttelecom.com.br,Nort Telecom,ISP
 norvado.com,Norvado,ISP
 norvoz.es,Norvoz Telecom,ISP
+norwoodbank.com,Norwood Cooperative Bank,Finance
 norwoodlight.com,Norwood Light Broadband,ISP
 nos.com,NOS Communications,ISP
 nos.pt,NOS,ISP
@@ -19493,6 +20132,7 @@ now-corp.com,NOW,ISP
 now-dns.net,Now-DNS,Web Host
 now-dns.org,Now-DNS,Web Host
 now.sh,Vercel,PaaS
+nowa.games,Nowa Games Teknoloji Anonim Sirketi,Entertainment
 nowanet.pl,NOWANET.PL,ISP
 nowasucha.pl,Urząd Gminy Nowa Sucha,Government
 nowecom.ru,Severo-Zapadnye telekommunikacii,ISP
@@ -19517,6 +20157,7 @@ npru.ac.th,Nakhon Pathom Rajabhat University,Education
 npsin.com,NP Foods Singapore,Food
 nque.com,Nedelco (Adams Industries),ISP
 nr.no,Norsk Regnesentral,Science
+nrao.edu,National Radio Astronomy Observatory,Education
 nrb.be,NRB (KEYES),MSP
 nrb.org.np,Nepal Rastra Bank (NRB),Finance
 nrbglobalbank.com,NRB Global Bank,Finance
@@ -19534,6 +20175,7 @@ nri-secure.co.jp,NRI SecureTechnologies,MSP
 nri.com,Nomura Research Institute,Education
 nrk.no,NRK,Government Media
 nrlink.net,NR Link,ISP
+nrru.ac.th,Nakorn Ratchasima Rajabhat University,Education
 nrsenterprise.com,NRS Enterprise,ISP
 nrtco.net,NRTC Communications,ISP
 nrtmexico.mx,Corporativo Núcleo Radio Televisión,News
@@ -19544,6 +20186,7 @@ nscc.ca,NSCC,Education
 nscglobal.com,NSC Global,MSP
 nscorp.com,Norfolk Southern,Logistics
 nsf.gov,National Science Foundation,Government
+nsgdv.com,Network Services Group,MSP
 nshost.ro,nshost.ro,Web Host
 nsighttel.com,Nsight,ISP
 nsix.pl,NSIX Data Center Polska,Web Host
@@ -19683,6 +20326,7 @@ nust.na,Namibia University of Science and Technology,Education
 nustream.com,Nustream Communications,ISP
 nutritionclub.ca,Nutrition Club Canada,Retail
 nuuday.dk,Nuuday,ISP
+nuukcommunications.com,Nuuk Communications,ISP
 nuvancehealth.org,Nuvance Health,Healthcare
 nuvdatacenter.com.br,NUV Datacenter,Web Host
 nuvera.net,Nuvera Communications,ISP
@@ -19699,6 +20343,7 @@ nvhcloud.com,"NVHCloud SAS – VPS, Anti-DDoS & Serveurs Dédiés en France",Web
 nvidia.com,Nvidia,Manufacturing
 nvnetinfo.com.br,Nvnet Provedor DE Internet E Servicos,ISP
 nvnetwork.com.br,NV Network,ISP
+nvp.com,Norwest Venture Partners,Healthcare
 nvrh.org,Northeastern Vermont Regional Hospital,Healthcare
 nvrsk.ru,TelecomService,ISP
 nvtc.ru,Novokuznetsk Telecom,ISP
@@ -19716,6 +20361,7 @@ nwire.net.br,Nwire Telecom,ISP
 nwisp.co.za,N W Internet Service,ISP
 nwohiobb.com,Northwest Ohio Broadband,ISP
 nwt.net.br,NWT,ISP
+nwtechnology.com,NW Technology,MSP
 nwtel.ca,Northwestel,ISP
 nwtelephone.com,NEW Windsor Telephone CO,ISP
 nwu.ac.za,North-West University,Education
@@ -19758,6 +20404,7 @@ nysenate.gov,New York State Senate,Government
 nysernet.com,NYSERNet,Education
 nysif.com,New York State Insurance Fund,Government
 nyspta.org,New York State PTA,Nonprofit
+nysut.org,New York State United Teachers,Healthcare
 nysyswireless.com,Nysys Wireless,ISP
 nyu.edu,New York University,Education
 nyx.net,Nyx.net,ISP
@@ -19778,6 +20425,7 @@ oai.com.br,OAI,ISP
 oakfordis.com,Oakford Internet Services,ISP
 oakhost.com,OakHost,Web Host
 oakland.k12.mi.us,Oakland Schools,Education
+oaklandca.gov,City of Oakland,Government
 oaklandcatholic.org,Oakland Catholic High School,Education
 oakton.edu,Discover Oakton College,Education
 oakwood.org,Oakwood Healthcare,Healthcare
@@ -19824,6 +20472,7 @@ oceanviewfunding.com,Ocean View Funding,Finance
 ocec.coop,Okanogan County Electric Cooperative,ISP
 ocesb.com.my,OCE Sdn Bhd ISP,ISP
 ocgfiber.com,Optical Communications Group,ISP
+ocharleys.com,O'Charleys,Food
 ochin.org,OCHIN.org,Healthcare
 ocic.co.kr,OCI Information Communication,ISP
 ociris.com,Ociris (G-Portal),Web Host
@@ -19836,9 +20485,11 @@ ocnk.net,Ochanoko,SaaS
 ocosa.com,OCOSA Communications,Web Host
 ocsc.go.th,Ocsc,Government
 oct-net.ne.jp,Oita Cable Telecom,ISP
+oct.ca,The Ontario College of Teachers,Education
 octacom.ca,Octacom,MSP
 octanet.id,OCTAnet,ISP
 octantis.ca,Octantis,Marketing
+octapharma.com,Octapharma Plasma,Manufacturing
 octaplus.co.uk,Octaplus Networks,ISP
 octatelecom.com.br,Octa Telecom,ISP
 octopuce.fr,Octopuce,Web Host
@@ -19863,6 +20514,7 @@ oeaw.ac.at,Austrian Academy of Sciences,Education
 oecfiber.com,OEC Fiber,ISP
 oekb.at,Oesterreichische Kontrollbank,Government
 oenb.at,Oesterreichische Nationalbank,Finance
+oeste-rede.com.br,Oeste-rede Prestação de Serviço de Internet,ISP
 oeste.digital,Oeste Digital,ISP
 oeste.net.br,Oeste Telecom,ISP
 oestetelecom.net.br,Oeste Servicos DE Internet,ISP
@@ -19870,7 +20522,9 @@ ofb.uz,Orient Finance Bank,Finance
 off-site.com,Offsite,Web Host
 offgridcom.net,Off-Grid Communications,ISP
 officeit.ie,Office IT,Healthcare
+officeworks.com.au,Officeworks,Retail
 offshoreracks.com,OffshoreRacks,Web Host
+oficial7.net.br,Oficial 7,ISP
 ofnl.co.uk,Open Fibre Networks,ISP
 ofsoptics.com,OFS Fitel,ISP
 ogaki-tv.co.jp,Ogaki Cable Television,ISP
@@ -19923,6 +20577,7 @@ olafibra.com.br,Ola Fibra Telecomunicacoes,ISP
 olahconnect.com.br,Olah Connect,ISP
 olamam.com,Tomorrow World Communication Solutions,ISP
 olanet.com.br,OnLine Assis Telecomunicações,ISP
+oldscollege.ca,Olds College of Agriculture & Technology,Education
 ole.net.br,Ole Fibra,ISP
 oleane.fr,Oleane,ISP
 oleanwebhosting.com,Olean Web Hosting,Web Host
@@ -19959,6 +20614,7 @@ omegatech.cz,Nordic Telecom,ISP
 omegatechinternet.com.br,Omega Tech Internet,ISP
 omegatelecom.ua,Omega Telecom,ISP
 omegatelecomunicacao.com.br,Omega Telecomunicacao,ISP
+omegatv.com.ua,Цифрове телебачення OmegaTV. Сучасна IPTV мережа в Україні!,ISP
 ometanet.com,Ometa Net,ISP
 ometria.com,Ometria,Marketing
 ometria.email,Ometria,Marketing
@@ -19983,6 +20639,8 @@ omniscient.com,Omniscient Technologies,Technology
 omnispring.com,Omnispring,ISP
 omnistep.com,OmniStep Incorporated,ISP
 omnitel.biz,OmniTel,ISP
+omnitracs.com.mx,Omnitracs de México,Logistics
+omnom.net,omnom ITS,ISP
 omonia.com,Omonia,ISP
 omsai.network,Omsai Cable Systems India,ISP
 omshivsai.com,OM Shiv SAI Internet Service OPC,ISP
@@ -20000,6 +20658,7 @@ onatel.bf,ONATEL Burkina Faso,ISP
 onati.pf,Onati,ISP
 onbahia.com.br,Onbahia Telecom,ISP
 oncabo.com.br,ONCABO Internet,ISP
+oncb.go.th,C/o Cs Loxinfo Public,Government
 onda.net.br,Onda Internet,ISP
 ondal.com,Ondal Medical Systems,Healthcare
 ondalivre.net.br,Onda Livre Fibra,ISP
@@ -20035,7 +20694,10 @@ onefibraoptica.com.br,ONE Fibra Optica,ISP
 onefone.pl,Onefone,ISP
 onega.net,Onega,MSP
 oneheberge.fr,"VPS, Serveurs de Jeux, Hébergement Web – OneHeberge",Web Host
+oneidacountyny.gov,Oneida County,Government
+oneidaschools.org,Oneida Special School District,Education
 oneinternetamerica.com,One Internet America,ISP
+onelink.id,OneLink,ISP
 onemax.com,Onemax,ISP
 onemindservices.com,OneMind Services,MSP
 onenationuk.org,One Nation,Nonprofit
@@ -20058,6 +20720,7 @@ oneshome.top,Oneshome Communications,ISP
 onesky.com.bd,One Sky Communications,ISP
 onestop.online,One-Stop Communications of PA,ISP
 onet.pl,Onet (Ringier Axel Springer),News
+oneteamit.com.au,OneTeam IT,MSP
 onetechtelecom.net.br,Onetech Telecom,ISP
 onetelecom.net.br,One Telecom,ISP
 onetelecom.od.ua,ONE Telecom,ISP
@@ -20113,6 +20776,7 @@ onred.com.co,ONRED INTERNET,ISP
 onremote.in,Onremote Telecom,ISP
 onrender.com,Render,PaaS
 ons24.ru,Obyedinennye Nakhabinskie seti,ISP
+onsavii.com,Onsavii Partners,Consulting
 onshore.com,Onshore,SaaS
 onsip.com,OnSIP Business VoIP Services Provider,ISP
 onsitecomputers.com.au,Onsite Computers,MSP
@@ -20188,6 +20852,7 @@ opiquad.com,Opiquad (Southern Broadband),ISP
 oplink.net,Optimal Link Corporation,ISP
 opnet.it,OpNet (WindTre),ISP
 oportunasul.com.br,Blasternet Telecom,ISP
+opp.vic.gov.au,Office Of Public Prosecutions (VIC),Government
 oppd.com,Omaha Public Power District,Utilities
 opq.co.bw,OPQ Botswana Internet,ISP
 opstelecom.com.br,Ops Telecom,ISP
@@ -20224,6 +20889,7 @@ optimaitalia.com,Optima Italia,ISP
 optimantra.com,OptiMantra,SaaS
 optimaset.ru,Optimaset,ISP
 optimatelecom.es,Internet Mantenimientos,ISP
+optimation.co.nz,Optimation Group,Consulting
 optimaxbd.net,OptiMax Communication,ISP
 optimisedsolutions.com.au,Optimised Solutions,MSP
 optimotelecom.com.br,Optimo Telecom,ISP
@@ -20265,6 +20931,7 @@ optyma.com,"OPTYMA, Hospedaje & Desarrollo",ISP
 optyxbroadband.com,Optyx Broadband,ISP
 opu.ua,Odessa National Polytechnic University,Education
 opusinteractive.com,Opus Interactive,IaaS
+opusonewinery.com,Opus One Winery,Food
 opyt.net.br,Opyt,ISP
 oquei.net.br,Oquei Telecom,ISP
 oracle.com,Oracle,Technology
@@ -20367,6 +21034,7 @@ osage.net,Osage Municipal Communications Utility,ISP
 osaka-sandai.ac.jp,Osaka Sangyo University,Education
 osaka-u.ac.jp,Osaka University,Education
 osawi.com.tr,Osawi Telekomunikasyon Teknoloji Bilisim Hizmetleri VE Ticaret Ltd.Sti,ISP
+osb.co.uk,OSB Group,Finance
 osbnet.in,Osbnet Broadband Pvt Ltd | High Speed Internet Connection & Broadband Plans,ISP
 osc.edu,OARnet,Education
 oschadbank.ua,Joint Stock Company State Savings Bank of Ukraine,Finance
@@ -20382,6 +21050,7 @@ osiedlowa.net,Osiedlowa,ISP
 osifaonline.com,Osifa Online,ISP
 osir.net.br,Osirnet,ISP
 osirnet.com.br,Osirnet,ISP
+osis.gov,Joint Intelligence Center Pacific,Government
 osism.tech,OSISM,Web Host
 ositelecom.com.br,OSI Connect Telecomunicacoes E Servicos,ISP
 oskolnet.ru,Osknolnet,ISP
@@ -20426,6 +21095,7 @@ otitelecom.com,Omnium des Telecom et de l'Internet,ISP
 otktel.ru,United Telecommunications,ISP
 otnet.co.jp,OTNet,ISP
 otpbank.al,OTP Bank Albania Sh.A,Finance
+otpbank.com.ua,PJSC OTP Bank,Finance
 otpbank.hu,OTP Bank,Finance
 otpbank.ru,OTP Bank,Finance
 ots-net.ru,OTS,ISP
@@ -20450,6 +21120,7 @@ ouriran.com,"Ravand Tazeh Co,.PJS",Web Host
 ourspace.com,Urban Communications,ISP
 ourtrust.org,Columbia Basin Broadband,ISP
 ous.ac.jp,Okayama University of Science,Education
+out.ac.tz,The Open University of Tanzania,Education
 outbackinternet.com,Outback Internet,ISP
 outboundrelay.com,ForwardMX,SaaS
 outcomex.com.au,Outcomex,MSP
@@ -20463,6 +21134,7 @@ outscale.com,Outscale,IaaS
 outtelecom.com.br,Out Service Telecom Serviços,ISP
 ovabil.com,Ovabil Internet VE Bilisim Hizmetleri Limited Sirketi,ISP
 ovea.com,Ovea,ISP
+overlakehospital.org,Overlake Hospital Medical Center,Healthcare
 overlinkinternet.com,overlink internet e S em telecomunicações,ISP
 overon.es,Overon,ISP
 oversight.com,Oversight,SaaS
@@ -20477,6 +21149,7 @@ ovhcloud.com,OVH,Web Host
 ovintiv.com,Ovintiv,Industrial
 ovni.com,Galaxy Communications,ISP
 ow.ua,Openway Ukraine,ISP
+owasa.org,Orange Water and Sewer Authority,Nonprofit
 owensborohealth.org,Owensboro Health,Healthcare
 own.pm,OwnProvider,Web Host
 owncloud-dav-hamburg.de,ownCloud,SaaS
@@ -20598,6 +21271,7 @@ palette-up.jp,Palette UP,Web Host
 palmasnet.inf.br,Palmasnet Informática,ISP
 palmbeachschools.org,The School District of Palm Beach County,Education
 palmbeachstate.edu,Palm Beach State College,Education
+palmcoastgov.com,City of Palm Coast,Government
 palmerone.com,Palmer Mutual Telephone Company,ISP
 paloaltonetworks.com,Palo Alto Networks,MSSP
 palomar.edu,palomar.edu,Education
@@ -20607,6 +21281,7 @@ palukota.go.id,Pemerintah Kota Palu,Government
 pamekasankab.go.id,Dinas Komunikasi Dan Informatika Kab. Pamekasan,Government
 pamico-czech.cz,"PAMICO CZECH, s.r.o",ISP
 panafricatelecom.co.za,Pan Africa Telecom,ISP
+panagora.com,PanAgora Asset Management,Finance
 panamaserver.com,Panamaserver.com,Web Host
 panasonic.com,Panasonic,Technology
 panaybroadband.com.ph,Panay Broadband / Buenavista Cable TV,ISP
@@ -20657,6 +21332,7 @@ paraopebanet.com.br,Paraopebanet Provedor,ISP
 parasat.tv,Parasat Cable,ISP
 paratus.africa,Paratus Telecom,ISP
 paraty.com,Visualphone-Scm,ISP
+parauapebas.pa.gov.br,Prefeitura Municipal de Parauapeb,Government
 parhealth.com,Par Health,Healthcare
 pariamankota.go.id,Pemerintah Kota Pariaman,Government
 paribasco.com,Paribas Communications,ISP
@@ -20665,10 +21341,12 @@ parisat.hu,PARISAT,ISP
 parishbroadband.com,Parish Broadband,ISP
 paritel.fr,Paritel,ISP
 parkcenter.org,Indiana Data Center,Healthcare
+parkcommunity.com,Park Community Credit Union,Finance
 parker.edu,Parker University,Healthcare
 parkerbroadband.net,Parker Broadband,ISP
 parkerinstitute.org,Parker Jewish Institute for Healthcare & Rehabilitation,Healthcare
 parkersystems.net,Parker FiberNet,ISP
+parkhotel-vitznau.ch,Park Hotel Vitznau,Travel
 parking.ru,Garant Park Internet,Web Host
 parkregion.com,Park Region Telephone,ISP
 parktele.com,Park Telecom,ISP
@@ -20728,6 +21406,7 @@ patrimonialfibra.com.br,Patrimônio Monitoramento Eletrônico,ISP
 patriot-bd.com,Patriot Technologies,ISP
 patriotbroadband.com,Patriot Broadband,ISP
 patxkj.com,Shenzhen Ping An Communication,ISP
+pau.edu.ng,Pan-Atlantic University,Education
 pau.edu.tr,Pamukkale University,Education
 paubox.com,Paubox,Email Security
 paulbunyan.net,Paul Bunyan Communications,ISP
@@ -20746,6 +21425,7 @@ paylodegrowth.com,Paylode,SaaS
 paylodeperk.com,Paylode,SaaS
 paypal.com,PayPal,Finance
 payplug.com,Payplug,Finance
+pba.edu,PBA: Palm Beach Atlantic University,Education
 pbb.net.pk,Play Broadband (Private),ISP
 pbcgov.com,Palm Beach County,Government
 pbgc.gov,Pension Benefit Guaranty,Government
@@ -20772,6 +21452,7 @@ pccwglobalinc.com,PCCW Global,ISP
 pcepa.com,Prentiss County Electric Power Association,Utilities
 pch.net,Packet Clearing House,Nonprofit
 pchosp.org,Putnam County Hospital,Healthcare
+pci-nsn.gov,Poarch Band of Creek Indians,Government
 pci.com,PCI Pharma Services,Healthcare
 pcibroadband.in,Parvez Cable Internet Broadband,ISP
 pcibuf.com,PCI,MSP
@@ -20783,6 +21464,7 @@ pcmaniacs.co.za,PC Maniacs,ISP
 pcmcindia.gov.in,Municipal Pimpri Chinchwad,Government
 pcn.co.za,PCN,ISP
 pcnet-catv.ro,PCNET-CATV Internet si televiziune prin fibra optica,ISP
+pcnet.com,Paradigm Communications,ISP
 pcnetbrasil.com.br,G G Bruzarrosco Serviços DE Telecomunicacoes,ISP
 pcnettelecom.com.br,PCNET Telecom,ISP
 pcom.edu,PCOM,Healthcare
@@ -20798,6 +21480,7 @@ pd25.com,Salesforce Marketing Cloud (Formerly Pardot),Marketing
 pdam-sby.go.id,Pdam Surya Sembada Kota Surabaya,Government
 pdctelco.com.my,PDC Telecommunication Services,ISP
 pdfiber.com,PD Fiber,ISP
+pdpgroupinc.com,PDP Group,Automotive
 pdx.edu,Portland State University,Education
 pdx.net,PORTLAND INTERNETWORKS,MSP
 pdxhosting.net,Portland Internet Hosting,ISP
@@ -20817,6 +21500,7 @@ pearlandtx.gov,City of Pearland,Government
 pearson.com,Pearson,Education
 peasoup.net,Pea Soup Hosting,Web Host
 pebblehost.com,PebbleHost,IaaS
+pechanga-nsn.gov,Pechanga Band of Indians,Government
 pecoraricloud.com.br,Pecorari Cloud,Web Host
 pedranet.com.br,Wellington Paiva Damascena,ISP
 pedreratelecom.es,Fibrasur Operadores,ISP
@@ -20843,7 +21527,9 @@ pendc.com,PenDC,IaaS
 penguincomputing.com,Penguin Computing,Web Host
 penguinwebhosting.com,Penguin Webhosting,Web Host
 penki.lt,Penki,ISP
+pennhighlands.edu,Pennsylvania Highlands Community College,Education
 pennwest.edu,Pennsylvania Western University,Education
+penrith.city,Penrith City Council,Government
 penta-six.com,Penta-Six Communication,ISP
 penta.ch,Switzerland & UAE | Penta IT Services,Web Host
 pentanet.com.au,Pentanet,ISP
@@ -20944,6 +21630,7 @@ philander.edu,Philander Smith University,Education
 philasd.org,School District of Philadelphia,Education
 philcom.com,Philcom,ISP
 philips.com,Philips,Healthcare
+phillong.com,Phil Long Dealerships,Automotive
 phillyix.net,Philadelphia Internet Exchange,ISP
 philsat.com,WIT Phils,ISP
 phinfortelecom.com.br,PH Telecom,ISP
@@ -20966,6 +21653,7 @@ phpoy.fi,Elmonet (PHP Oy),ISP
 phpwebhosting.com,PHPWebHosting,Web Host
 phs.org,Presbyterian Healthcare Services,Healthcare
 phsa.ca,Provincial Health Services Authority,Healthcare
+phsc.edu,PHSC,Education
 phsnet.com.br,PHS Internet E Suprimentos,ISP
 phxnet.com.br,Phxnet Provedor DE Internet,ISP
 phxtel.com.br,PHX Telecom,ISP
@@ -20984,6 +21672,7 @@ piercecountywa.gov,"Pierce County, Washington",Government
 piercepepin.com,Pierce Pepin,Utilities
 pif.co.uk,Pinnacle Freight,Logistics
 pig.com.br,Kinema da Ilha Informática e Tecnologia,ISP
+pih-uk.com,Prima Internet Holdings,ISP
 pikevillehospital.org,Pikeville Medical Center,Healthcare
 pikhtabank.ru,Pikhta Bank,Finance
 pillsburylaw.com,Pillsbury Madison & Sutro,Healthcare
@@ -21000,6 +21689,7 @@ pinehosting.com,Pine Hosting,Web Host
 pineland.net,Pineland Telephone Cooperative,ISP
 pinellascounty.org,Pinellas County,Government
 pinemedia.net,Pine Media,ISP
+pinerichland.org,Pine-Richland School District,Education
 pinetel.com,Pine Telephone System,ISP
 pingday.se,Pingday,ISP
 pingprime.com.br,Prime Connect Telecomunicacoes,ISP
@@ -21064,6 +21754,7 @@ pixeltelecom.com.br,Pixel Telecomunicação,ISP
 pixelx.net,Pixel X,Web Host
 pixwifi.com.br,Pix Wifi,ISP
 pj24.ir,Pishgaman Jonoub,ISP
+pjdick.com,PJ Dick,Construction
 pjm.net.br,PJM Net,ISP
 pjnet.com.cn,Shanghai pujv Communication Technology,ISP
 pjnhk.go.id,Pusat Jantung Nasional Harapan Kita,Government
@@ -21134,6 +21825,7 @@ playstation.com,Sony PlayStation,Entertainment
 playtech.ee,Playtech,Entertainment
 playtelecom.ru,INKO-Telecom,ISP
 plb.net.id,Putra Lebak Banten,ISP
+plc.nsw.edu.au,PLC Sydney,Education
 pldi.net,Pioneer Cellular,ISP
 pldt.com,PLDT,ISP
 pldt.com.ph,PLDT Home,ISP
@@ -21154,6 +21846,7 @@ plis.com.br,Plis Telecom,ISP
 plis.net.br,Plis Telecom,ISP
 pljtelecom.pl,PLJ Telecom,ISP
 plniconplus.co.id,PLN Icon Plus,MSP
+plow.net,Plow Networks,MSP
 pltpro.com,CX2 (PLTPro),ISP
 plu.edu,Pacific Lutheran University,Education
 plug-telecom.com,Oliveira Telecom,ISP
@@ -21174,6 +21867,7 @@ plus.net,plusnet,ISP
 plus.pl,Plus,ISP
 plusbank.pl,Plus Bank,Finance
 plusitma.com.br,PLUS MEGA,ISP
+plusline.de,Plus.line,Web Host
 plusline.net,Plus.line,Web Host
 plusmultiplayer.com.br,Plus Multiplayer TV,ISP
 plusnet.co.in,Plusnet Communication,ISP
@@ -21207,6 +21901,7 @@ pno.solutions,PNO Solutions,MSP
 pnpopularnet.com.br,PopularNET,ISP
 pnpt.com,Pinpoint Fiber,ISP
 pnru.ac.th,PNRU,Education
+pnu.ac.th,Princess of Naradhiwas University,Education
 pnu.edu.ua,State Higher Educational Institution 'Precarpathian National University of Vasyl Stefanyk',Education
 pnwu.edu,Pacific Northwest University of Health Sciences,Education
 poa.co.ke,POA Internet Kenya,ISP
@@ -21243,6 +21938,7 @@ pol-online.com,Bangladesh Online,ISP
 pol.ir,ParsOnline,ISP
 pol.net.in,Dvr Broadband Services,ISP
 polans.si,"POLANS, telekomunikacijske storitve",ISP
+polarbearsinternational.org,Polar Bears International,Nonprofit
 polarcomm.com,Polar Communications,ISP
 polarisbanklimited.com,Skye Bank PLC,Finance
 polariscablevision.com,Polaris Cable Vision,ISP
@@ -21271,6 +21967,7 @@ polyclinique-limoges.com,Polyclinique de Limoges,Healthcare
 polyclinique-limoges.fr,Polyclinique de Limoges,Healthcare
 polyesterday.com.mk,Polyesterday,Marketing
 polyesterday.mk,Polyesterday,Marketing
+polyone.com,PolyOne,Manufacturing
 polyu.edu.hk,Hong Kong Polytechnic University,Education
 pom.go.id,Badan Pengawas Obat dan Makanan,Government
 pombonet.com.br,Pombonet,ISP
@@ -21351,6 +22048,8 @@ posluh.hr,"POSLuH d.o.o, za informaticke usluge i trgovinu",Web Host
 post.ch,Swiss Post,Logistics
 post.lu,POST Luxembourg,ISP
 posta.rs,Pošta Srbije (Serbian Post),Logistics
+postalbank.co.tz,Tanzania Postal Bank,Finance
+postbank.co.ke,Kenya Post Office Savings Bank,Finance
 postbank.co.ug,Post Bank (Uganda),Finance
 postcodesoftware.co.uk,Postcode Software,SaaS
 postdanmark.dk,Post Danmark,Logistics
@@ -21392,6 +22091,7 @@ powertecprovider.com.br,Powertec Telecomunicacoes,ISP
 powertel.co.id,Power Telecom Indonesia,ISP
 powertel.co.zw,Powertel Communications,ISP
 powertelecom.net.br,Power Telecom,ISP
+powertelecom.ru,Power Telecom,ISP
 powervisionisp.com,Power Vision ISP,ISP
 powerweb.de,Frank Gadegast trading as PHADE Software,Web Host
 pox.com.br,Pox Network Telecomunicações,ISP
@@ -21426,9 +22126,11 @@ pratt.edu,Pratt Institute,Education
 pratt.lib.md.us,Enoch Pratt Free Library,Government
 pravex.ua,Pjsccb Pravex-Bank,Finance
 prayagbroadband.com,Prayag Broadband â Fiber Internet,ISP
+prcc.edu,Pearl River Community College,Education
 prchost.com,PRC Hosting,Web Host
 prcomputer.net,PR Computer Services,ISP
 prebits.de,PREBITS,MSP
+precicom.com,Precicom,MSSP
 preciousnetcom.in,Precious Netcom,ISP
 precisehotels.com,Precise Hotels and Resorts,Travel
 predialnet.com.br,Predialnet,ISP
@@ -21449,6 +22151,7 @@ premium-datacenter.de,Hofmeir Media,Web Host
 premiumchoicebroadband.com,Premium Choice Broadband,ISP
 premiumhosting.net,Premium Hosting,Web Host
 prempub.com,Premier Publishing,Marketing
+prensa.com,La Prensa Panamá,News
 presbyuniversity.edu.gh,"Presbyterian University College, Ghana",Education
 presconnect.co.za,PresConnect,ISP
 prescott-az.gov,City OF Prescott,Government
@@ -21482,6 +22185,7 @@ primed-halberstadt.de,Primed Halberstadt,Healthcare
 primefiber.net,Prime Fibernet,ISP
 primefocusworld.com,PrimeFocus House Opp Citi Bank,Finance
 primehealthcare.com,Prime Healthcare,Healthcare
+primeis.com,Prime Holdings Insurance Services,Finance
 primeisp.pl,Prime ISP,ISP
 primelink.net.id,PrimeLink Communication,ISP
 primenet.in,Primesoftex,Web Host
@@ -21504,7 +22208,9 @@ princeton.edu,Princeton University,Education
 principal-it.com,Principal IT,MSP
 prinetime.net,Prinetime Internet Solutions,ISP
 print.com.br,Printi,Print
+printingforless.com,Printingforless.com,Print
 prioritycolo.com,Priority Colo,IaaS
+pris.ca,PRiS,ISP
 prisma.net.bd,"Bengal Group Ltd. Nationwide Internet Service Provider, Bangladesh",ISP
 prismahealth.org,Prisma Health,Healthcare
 prismarede.com.br,Prismarede Telecomunicações,ISP
@@ -21609,6 +22315,7 @@ pronet.al,ProNet Albania,ISP
 pronet.bg,Pronet Telekom,ISP
 pronet.id,Profesional Internet Indonesia,ISP
 pronet.net.ua,Інтернет-провайдер Pro&Net м. Косів,ISP
+pronetinc.ca,Orillia Pronet,MSP
 pronetinformatica.com.br,Info Net Telecomunicações,ISP
 pronetlapa.com.br,Pronet Construções,ISP
 pronetprovedor.com.br,JND - Provedor,ISP
@@ -21622,6 +22329,7 @@ proofpoint.com,Proofpoint,Email Security
 proomnis.ca,Pro Omnis Telecommunication,ISP
 propelcloud.co,Propel Cloud,Web Host
 propersupportmedia.com,Proper Support Media,Web Host
+propertysolutions.com,Entrata,Real Estate
 prophase.es,Prophase Telecom,ISP
 prophecy.net.nz,Securecom,MSP
 proquest.com,ProQuest,SaaS
@@ -21705,6 +22413,7 @@ provernet.net,ISP Provernet Informatica,ISP
 provex.net.br,Provex Telecomunicacoes,ISP
 providence.edu,Providence College,Education
 providence.org,Providence Hospital,Healthcare
+providentcu.org,Provident Credit Union,Finance
 providerdienste.de,Bradler and Krantz Providerdienste,Web Host
 providers.com.ar,Experon (Providers),ISP
 providersnet.com.br,Providers Serviços em Telecomunicações,ISP
@@ -21817,6 +22526,7 @@ pucpr.br,PUCPR,Education
 pucrs.br,PONTIFICIA UNIVERSID CATOLICA DO RIO GRANDE DO SUL,Education
 pucsp.br,PUC-SP,Education
 pucv.cl,Pontificia Universidad Catolica de Valparaiso,Education
+pufs.ac.kr,Pusan University of Foreign Studies,Education
 pugetsound.edu,University of Puget Sound,Education
 puhoi.net.nz,puhoi.net.nz,ISP
 pulkco.com,Pulk & Co,ISP
@@ -21828,6 +22538,7 @@ pulsetv.com,Pulse TV,Retail
 pulstv.pl,Telewizja Puls,ISP
 pumo.com.tw,PUMO,IaaS
 pumori.ru,Pumori-Telecom,ISP
+punahou.edu,Punahou School,Education
 punedigitalization.com,Pune Digitalization,ISP
 punjab.gov.in,Department of Governance Reforms,Government
 puntocallrd.com,Puntocall Lora Communications Dominicana,ISP
@@ -21843,6 +22554,7 @@ purepeak.com,Purepeak,IaaS
 purevoltage.com,PureVoltage Hosting,Web Host
 purplecomputing.com,Purple Computing,MSP
 purplecowinternet.com,Purple Cow Internet,ISP
+purpleguys.com,The Purple Guys,MSP
 purtel.com,PURtel,ISP
 purvaco.com,Purvaco Technology,Web Host
 purworejokab.go.id,Pemerintah Kabupaten Purworejo,Government
@@ -21872,6 +22584,7 @@ pwsz.nysa.pl,Panstwowa Akademia Nauk Stosowanych w Nysie,Education
 pwtinternet.com.br,PWT Internet,ISP
 pwuhui.com.tw,Perfect Medical,Healthcare
 pxc.co.uk,TalkTalk,ISP
+pymblelc.nsw.edu.au,Pymble Ladies' College,Education
 pyranah.com,Pyranah Communications,ISP
 pyro.institute,Institute for pyrotechnical cleaning,Education
 pythonanywhere.com,PythonAnywhere,SaaS
@@ -21892,6 +22605,7 @@ qbix.ch,Qbix,MSP
 qcell.gm,Qcell Gambia,ISP
 qcell.sl,QCell Sierra Leone,ISP
 qcn.com.au,QCN,ISP
+qcnetwork.net,Qalby Cahaya Network,ISP
 qcol.net,QCOL,ISP
 qcpl.in,Quest Consultancy,ISP
 qcsgroup.com.au,QCS Group,MSP
@@ -21916,6 +22630,7 @@ qline.by,Flynet,ISP
 qlix.com.br,Qlix,Web Host
 qmul.ac.uk,Queen Mary University of London,Education
 qnax.sh,QNAX,Web Host
+qnb.com.eg,Qatar National Bank Al Ahli (QNB AA),Finance
 qnet.vn.ua,QNET,ISP
 qnetfacil.com.br,Netfacil Internet VIA Radio E Informatica,ISP
 qnsal.cn,Qn-Solar,Manufacturing
@@ -21932,6 +22647,7 @@ qsp.nl,Quality Service Provider,Web Host
 qsr-group.com,QSR GROUP,ISP
 qsrsystems.net,QSR Systems,ISP
 qsttelecom.com.br,QST Telecom,ISP
+qsuper.qld.gov.au,ART Group Services,Government
 qtc404.com,Operadora Gredos,ISP
 qth.com,QTH.com,Web Host
 qti.com,Quick Technologies,Event Planning
@@ -21995,6 +22711,7 @@ quicknet.ch,Kabelfernsehen Bodeli,ISP
 quicknet.co.in,QuickNet,ISP
 quickpacket.com,QuickPacket,Web Host
 quickservers.net,QuickServers: Buy High-Performance VPS and Dedicated Servers,Web Host
+quiknt.com,Quik Net,ISP
 quinnipiac.edu,Quinnipiac University,Education
 quintillionglobal.com,Quintillion Subsea Operations,ISP
 quitmancountyms.org,"Quitman County, Mississippi",Government
@@ -22032,6 +22749,8 @@ rabbitinternetbd.com,Rabbit Internet,ISP
 racc.edu,Racc,Education
 race.com,Race Communications,ISP
 race.net.bd,Race Online,ISP
+racetrac.com,RaceTrac,Retail
+racgp.org.au,RACGP,Education
 rack400.com,Rack400,Web Host
 rack59.com,RACK 59,Web Host
 rack66.com,RACK66,Web Host
@@ -22049,6 +22768,7 @@ rackhosting.com,Rackhosting,Web Host
 racklodge.com,Rack Lodge,Web Host
 rackmaze.com,Rackmaze,Web Host
 rackmaze.net,Rackmaze,Web Host
+rackmill.au,Rackmill,Web Host
 rackmonk.com,Rackmonk Datacenters,Web Host
 racknation.cr,RsckNation,Web Host
 rackscentral.com,Rackscentral Data Center,Web Host
@@ -22065,6 +22785,7 @@ radarconnect.com.br,Radar Connect,ISP
 radarinternet.com.br,Radar Internet,ISP
 rade.com.tr,RADE Bilisim Anonim Sirketi,Web Host
 radford.edu,Radford University,Education
+radian.biz,Radian Group,Finance
 radiant.net,TELUS,ISP
 radiantbd.com,Radiant Communications Bangladesh,ISP
 radiantbd.net,Radiant Communications LTD IIG,ISP
@@ -22211,6 +22932,7 @@ ratiokontakt.de,Ratiokontakt,ISP
 ratpconnect.com,"RATP Connect, opérateur d’infrastructure fibre optique noire",ISP
 rau.ro,Universitatea Romano-Americana,Healthcare
 raul.no,Raul Ghita trading as 'Ghita Telekom',ISP
+rauland.com,Rauland,Healthcare
 ravand.ca,Urano Internet Uranet,ISP
 ravgonet.in,Ravgonet,ISP
 ravnix.gg,RAVNIX,Web Host
@@ -22256,6 +22978,7 @@ rcanet.com.br,RCANET,ISP
 rcatelecom.com.br,RCA Telecom,ISP
 rcbbank.com,RCB Bank,Finance
 rccbi.com,Rural Computer Consultants,SaaS
+rccc.edu,Rowan-Cabarrus Community College,Education
 rccd.edu,Riverside Community College District,Education
 rcell.me,RCell,ISP
 rcgim.qc.ca,RCGIM,ISP
@@ -22266,6 +22989,7 @@ rcnbroadband.com,Romance Cable Network,ISP
 rcnetbd.com,Relation Cable Network,ISP
 rcoe.us,Riverside County Office of Education,Education
 rcom.co.in,Reliance Communications,ISP
+rcpa.edu.au,Royal College of Pathologists of Australasia,Education
 rcs-southsudan.com,RCS-Communication,ISP
 rcsnet.com.br,RCS Net,ISP
 rctelecomnet.com.br,RC Telecomunicaçoes,ISP
@@ -22336,6 +23060,7 @@ rechnungshof.gv.at,Rechnungshof Oesterreich,Government
 recife.pe.gov.br,Emprel - Empresa Municipal DE Informatica,Government
 reconn.ru,Reconn,ISP
 red-7.net,Red 7 Telecomunicaciones,ISP
+red-inal.com,Red-Inalsoluciónes,ISP
 red-planet.com.co,RED Planet Telecomunicaciones,ISP
 red-spectrum.com,Red-Spectrum Communications,ISP
 redbendcc.nsw.edu.au,Red Bend Catholic College,Education
@@ -22348,9 +23073,11 @@ redcreektelecom.ca,Red Creek Telecom,ISP
 redcross.org,American Red Cross,Nonprofit
 redd.com.au,Redd digital services,MSP
 reddata.com.bd,Red Data,ISP
+reddeer.ca,City of Red Deer,Government
 redder.it,REDDER,ISP
 reddotdigitalit.com,RedDot Digital,Government
 reddotnet.us,Reddot Networks,ISP
+reddyice.com,Reddy Ice,Manufacturing
 redea2telecom.com.br,A2 Telecom Provedor DE Internet,ISP
 redeapui.com.br,Inter.Net Servicos em Telecom,ISP
 redeatel.com.br,Natel Telecom,ISP
@@ -22430,13 +23157,16 @@ rediris.es,RedIRIS,Education
 redit.com,IP Matrix (Redit),ISP
 reditel.com.ar,Reditel ISP,ISP
 redlands.edu,University of Redlands,Education
+redlands.nsw.edu.au,Redlands,Education
 redlandshospital.org,Redlands Community Hospital,Healthcare
 redlily.org,Red Lily Internet,ISP
 redlimtech.com,Redlimtech,ISP
 redline.net.ua,RedLine,ISP
 redlineisp.com,Red Line Internet Services,ISP
 redlinkfibra.com.br,RedLink Fibra,ISP
+redlion-controls.com,Red Lion Controls,Manufacturing
 redmond.gov,"Redmond, WA",Government
+redmond.host,Redmond Hosting,Web Host
 redmovil.eu,Redmovil,ISP
 rednesp.br,rednesp,Education
 rednettelecom.com.br,Rednet Telecom,ISP
@@ -22498,6 +23228,7 @@ regusnet.com,Regus,Real Estate
 regxa.com,Regxa Cloud,Web Host
 rehedmas.com,Rehedmas Internet Para Todos S.A. DE C.V,ISP
 reinbeck.net,Reinbeck Telecommunications Utility,ISP
+reinhardt.edu,Reinhardt University,Education
 reinos.net,ReinOS,Web Host
 reis.rio.br,RJ NET Brasil Telecom,ISP
 reisinformatica.com,Reis Informatica,MSP
@@ -22509,6 +23240,7 @@ relabs.id,Relabs Net DayaCipta,ISP
 relaix.net,RelAix Networks,ISP
 relativity.one,RelativityOne,SaaS
 relax8.in,Relax8,ISP
+releasepoint.com,Release Point,Healthcare
 reliablecom.com,Reliable Communications s.r.o,ISP
 reliablehosting.com,Reliable Hosting,Web Host
 reliablehostingservices.net,Reliable Hosting Services,Web Host
@@ -22589,6 +23321,7 @@ reytel.hn,Reytel Honduras,ISP
 reytel.net,Reynolds Cable,ISP
 reyvi.com.br,Reyvi Internet,ISP
 rezocean.fr,REZOCEAN,ISP
+rezzo-telecom.com,Rezzo,ISP
 rfa.com,RFA,MSP
 rfc.pl,RFC Internet Poland,ISP
 rfchost.net,Ju Link Tech,Web Host
@@ -22598,6 +23331,7 @@ rferl.org,Radio Free Europe/Radio Liberty,News
 rfisolutions.com.ph,RFi Fiber,ISP
 rfnfiber.com,Reach Fiber Network,ISP
 rfnow.com,RF Now,ISP
+rfsuny.org,The Research Foundation for the State University of New York,Education
 rftelecom.net.br,RF Telecom,ISP
 rftkabel.de,RFT Kabel,ISP
 rgcommunications.in,RG Communications India,ISP
@@ -22632,12 +23366,14 @@ riber.net.br,Ribernet Conecta Você ao Mundo,ISP
 riberasaludmail.com,Ribera Salud,Healthcare
 rice.edu,Rice University,Education
 ricebelt.net,Rice Belt Telephone CO,ISP
+richardson.ca,Richardson International,Agriculture
 richlandcountysc.gov,Richland County,Government
 richmond-telephone.com,Richmond Telephone Company,ISP
 richmond.ca,"City of Richmond, British Columbia, Canada",Government
 richmond.edu,University of Richmond,Education
 richmondfed.org,Federal Reserve Bank of Richmond,Government
 ricoh-usa.com,Ricoh USA,Manufacturing
+ricta.org.rw,Rwanda Internet Exchange Point (RINEX) c/o RICTA,ISP
 ridaonline.com,Wifi | Ridaonline,ISP
 rideriverwave.com,Riverwave,ISP
 riderz.pk,Riderz Network Broadband (Private),ISP
@@ -22719,6 +23455,7 @@ river.net.br,RiverNET ISP,ISP
 rivercanyonwireless.com,River Canyon Wireless,ISP
 rivercity.net.au,Rivercity Solutions,MSP
 rivercitytower.com,River City Wireless,ISP
+riverdale.edu,Riverdale Country School,Education
 rivernetwifi.com,RiverNet,ISP
 riversideca.gov,"Riverside, California",Government
 riversidehealth.org,St. John's Riverside Hospital,Healthcare
@@ -22733,6 +23470,7 @@ riyazinternet.com,Riyaz Internet Service,ISP
 rizwanwifi.com,Rizwan Cable Network,ISP
 rizzi.net.br,Rizzinet,ISP
 rizzitelecom.com.br,Rizzi Servicos EM Telecom E Tecnologia,ISP
+rjet.com,Republic Airways Holdings,Travel
 rjf.com,Raymond James Financial,Finance
 rjktelecom.com,RJK Telecom,ISP
 rjtelecom.net.br,RJNET Telecomunicacoes,ISP
@@ -22767,6 +23505,7 @@ rmutl.ac.th,Rajamangala University of Technology Lanna,Education
 rmutr.ac.th,Rajamangala University of Technology Rattanakosin,Education
 rmutsv.ac.th,Rajamangala University of Technology Srivijaya,Education
 rmx.de,Retarus GmbH,SaaS
+rncommunications.net,RN Communications,ISP
 rnet.ph,R-NET Wired Internet Services,ISP
 rnetfibra.com.br,Internet Fibra Óptica,ISP
 rnetservicos.com.br,Rnet Servicos DE Internet,ISP
@@ -22814,12 +23553,15 @@ rocketnetnam.com,Rocketnet,ISP
 rocketnetworks.com.au,Rocket Networks,ISP
 rocketsoftware.com,Attachmate (Rocket Software),Technology
 rockfalls61071.net,City of Rock Falls,Government
+rockford.edu,Rockford University,Education
 rockfordil.gov,"Rockford, IL",Government
 rockhamptonregion.qld.gov.au,Rockhampton City Council,Government
 rockhoster.com,RockHoster,Web Host
 rockingconnect.com,Rocking Connect PTY (LTD),ISP
 rockingham.wa.gov.au,City of Rockingham Official Website,Government
 rockisland.com,Rock Island Communications,ISP
+rocklin.ca.us,City of Rocklin,Government
+rockvillemd.gov,Mayor and Council of Rockville,Government
 rockwellcollins.com,Collins Aerospace,Defense
 rockynordic.com,RockyNordic,Web Host
 rockyridge.net,Rocky Ridge Wireless,ISP
@@ -22900,6 +23642,7 @@ royalnetbd.net,Royalnet,ISP
 royalroads.ca,Royal Roads University,Education
 royell.net,Royell Communications,ISP
 rp.edu.sg,Republic Polytechnic. Multihoming AS Singapore,Education
+rpa.com,Rubin Postaer AND Associates,Marketing
 rpa.net.br,R.P.A Telecom,ISP
 rpi.edu,Rensselaer Polytechnic Institute,Education
 rpm-net.id,RPM.NET,ISP
@@ -23008,6 +23751,7 @@ ruraltelecom.es,Rural Telecom,ISP
 ruraltelephone.com,Nex-Tech (Rural Telephone Service),ISP
 ruralwave.ca,Rural Wave,ISP
 ruralwebtelecom.com.br,RuralWeb,ISP
+rus-telecom.ru,Rus-Telecom,ISP
 rusanovka-net.kiev.ua,Rusanovka-Net (UkrDataKom),ISP
 rusety.ru,Russet,ISP
 rush.edu,Rush University,Education
@@ -23019,6 +23763,7 @@ rutgers.edu,Rutgers University,Education
 ruukki.com,Ruukki SSAB,Manufacturing
 ruvds.com,RU VDS,Web Host
 ruweb-nn.ru,Ruweb-Nn,Web Host
+ruyat.tech,Ruyat Tech,ISP
 rvatelecom.com.br,RVA Telecom,ISP
 rvba.online,Roanoke Valley Broadband Authority,ISP
 rvc.net.vn,RVC – Hạ tầng viễn thông,ISP
@@ -23095,6 +23840,8 @@ safaricom.et,Safaricom Ethiopia,ISP
 safaricombusiness.co.ke,Safaricom,ISP
 safe-lock.net,Safe-Lock.NET,ISP
 safeconnect.com.br,Safe Connect Telecomunicacoes,ISP
+safecu.org,Safe Credit Union,Finance
+safeguardproperties.com,Safeguard Properties,Real Estate
 safenames.net,Safenames,Web Host
 safeport.com,Safeport Network Services,Web Host
 safescreening.co.uk,The Access Group,SaaS
@@ -23104,6 +23851,7 @@ safetycomputing.com,Safety Computing,MSP
 safeway.com,Safeway,Retail
 safewebservices.com,NMI,SaaS
 safhomefibre.com,SAFHO,ISP
+safib.ru,Safib,Technology
 safindo.net.id,Safindo,ISP
 safitelchad.com,Safitel Chad,ISP
 saforwifi.es,SAFOR WIFI,ISP
@@ -23123,6 +23871,7 @@ saha.ac.in,Saha Institute of Nuclear Physics,Education
 sahaltel.com,Sahal Telecom Somalia,ISP
 sahara.com,Sahara Net,ISP
 saheltelecom.com,Sahel Telecom Liberia,ISP
+sahilnet.com.tr,SahilNET Telekomunikasyon Hizmetleri Ltd. Sti,ISP
 sahmri.com,SAHMRI,Education
 saibababroadband.com,Saibaba Broadband,ISP
 saibabd.net,Sharmin Akter Shilpi t/a M/S. Saiba International,ISP
@@ -23160,11 +23909,13 @@ salamonline.com.bd,Salam Online,ISP
 salary.com,Salary.com,SaaS
 salauddincybernet.com,Salauddin Cybernet,ISP
 salem.edu,Salem Academy and College,Education
+salemhospital.org,Salem Hospital,Healthcare
 saleminternetinc.com,Salem Internet,ISP
 salemstate.edu,Salem State University,Education
 salesforce.com,Salesforce,SaaS
 salestelecom.net.br,Sales Telecom,ISP
 salihliwifi.com.tr,Salihli WiFi,ISP
+salinasvalleyhealth.com,Salinas Valley Memorial Hospital,Healthcare
 salingka.net,Salingka Telekomunikasi Nusantara,ISP
 salisburync.gov,"City of Salisbury, North Carolina",Government
 salishnetworks.com,Salish Networks,ISP
@@ -23174,6 +23925,7 @@ salnet.net,El Salvador Network (SALNET),ISP
 salom.uz,Salom Telecom,ISP
 salomon.com,Salomon,Retail
 salonlofts.com,Salon Lofts,Retail
+sals.edu,Southern Adirondack Library System,Education
 salsanet.id,SalsaNet Media,ISP
 salt.ch,Salt,ISP
 salta.gob.ar,Servicio Administrativo Financiero DE LA Gobernacion,Government
@@ -23192,12 +23944,14 @@ sama.gov.sa,Saudi Central Bank (SAMA),Finance
 samanage.com,SolarWinds Service Desk,SaaS
 samaralan.ru,SamaraLan,ISP
 samarindakota.go.id,Dinas Komunikasi dan Informatika Kota Samarinda,Government
+samaritanhealthcare.com,Samaritan Healthcare,Healthcare
 samart.co.th,Samart Infonet,ISP
 samarts.com,SAMART Corp (Excise-Direct Coding Data Center),Web Host
 samba.com.pk,Samba Bank,Finance
 sambanova.ai,SambaNova,Web Host
 sambatel.es,Sambatel Consulting,ISP
 sambd.com,SAM Online,ISP
+samc.org,Southeast Alabama Medical Center,Healthcare
 sameswireless.fr,Sames Wireless,ISP
 samhouston.net,Sam Houston Electric Cooperative,Education
 samil-pharm.com,Samil,Healthcare
@@ -23250,13 +24004,19 @@ sanmanuel-nsn.gov,San Manuel Band of Mission Indians,Government
 sanmina.com,Sanmina,Manufacturing
 sanofi.com,Sanofi,Healthcare
 sanofi.fr,Sanofi,Healthcare
+sanpedro.gob.mx,San Pedro,Government
 sans.org,SANS Institute,Education
 sansalvadordejujuy.gob.ar,Municipalidad DE SAN Salvador DE Jujuy,Government
 sansar.mn,Shine Sansar Cable,ISP
+sansumclinic.org,Sansum Santa Barbara Medical Foundation Clinic,Healthcare
 santa-barbara.ca.us,Santa Barbara County,Government
+santa-clarita.com,City Of Santa Clarita,Government
+santabarbaraca.gov,City of Santa Barbara,Government
+santaclaraca.gov,"City of Santa Clara, Ca",Government
 santaclaracounty.gov,Santa Clara County,Government
 santacruz.k12.ca.us,Santa Cruz County Office of Education,Education
 santafe.edu,The Santa Fe Institute,Education
+santafe.gov.ar,Gobierno de Santa Fe,Government
 santamonica.gov,santamonica.gov,Government
 santander.cl,Banco Santander,Finance
 santander.com.br,Banco Santander (Brasil),Finance
@@ -23288,6 +24048,7 @@ saraguros.net,Saraguros Net,ISP
 sarahbush.org,Sarah Bush Lincoln Health Center,Healthcare
 saranaindo.com,Saranaindo,Web Host
 sarasotacountyschools.net,Sarasota County Schools,Education
+sarasotafl.gov,"City of Sarasota, FL",Government
 saratogahospital.org,Saratoga Hospital,Healthcare
 sardegnawifi.com,Sardegna Wifi,ISP
 saremail.com,SAREnet,ISP
@@ -23388,12 +24149,14 @@ sbcglobal.net,AT&T,ISP
 sbcounty.gov,County of San Bernardino,Government
 sbcss.net,San Bernardino County Superintendent of Schools,Education
 sberbank-tele.com,Sberbank-Telecom,ISP
+sbfiber.com,SBFiber,ISP
 sbfiberlink.com,Fiber Link,ISP
 sbibankllc.ru,SBI Bank,Finance
 sbin.bj,Celtiis (SBIN Benin),ISP
 sbisb.co.kr,SBI Savings Bank,Finance
 sbjnet.id,Sugi Bintang Jaya,ISP
 sbktelecom.com,SBK Telecom | Business VoIP,ISP
+sbmbank.co.ke,SBM Bank Kenya,Finance
 sbn.co.th,Super Broadband Network,ISP
 sbnetcity.com,SBNetCity,ISP
 sbnettelecom.com.br,SBNET Telecom,ISP
@@ -23405,6 +24168,7 @@ sbsbroadband.com,Sbs Broadband And Cable,ISP
 sbsconnect.in,Sunrise Broadband Services,ISP
 sbu.ac.ir,Shahid Beheshti university,Education
 sbu.edu,Saint Bonaventure University,Education
+sbv.gov.vn,Department of Infomatic - The State Bank of Viet Nam,Finance
 sby-telecom.info,SBY-TELECOM.INFO,ISP
 sc.ac.kr,Suseong College,Education
 sc.com,Standard Chartered,Finance
@@ -23426,6 +24190,7 @@ scandinavianhosting.se,Scandinavian Hosting,Web Host
 scania.com,Scania,Manufacturing
 scansat-network.net,Scan Sat Network,ISP
 scansource.com,ScanSource,ISP
+scarletpearlcasino.com,Scarlet Pearl Casino Resort,Travel
 scarnet.eu,"SCARNET- Internet, Telewizja, Usługi dla biznesu",ISP
 scasd.org,State College Area School District,Education
 scatair.com,Scatair,Manufacturing
@@ -23435,12 +24200,17 @@ scb.co.th,Siam Commercial Bank,Finance
 scb.com.vn,Sai Gon Join stock commercial Bank,Finance
 scbroadband.com,SC Broadband,ISP
 scc.com,SCC,MSP
+scc.k12.wi.us,St. Croix Central School District,Education
 sccbroadband.ie,SCC Broadband,ISP
+sccc.edu,Seward County Community College (SCCC),Education
 sccoast.net,Horry Telephone Cooperative,ISP
 sccoe.org,Santa Clara County Office of Education,Education
 scdatacenter.com,Data Center,Web Host
 sce.com,Southern California Edison,Utilities
+scefcu.org,SCE Federal Credit Union,Finance
+scentsy.com,Scentsy,Beauty
 scf.edu,"SCF Home | State College of Florida, Manatee",Education
+scgcorp.com,THE Scientific Consulting Group,Consulting
 sch.ac.kr,Soon Chun Hyang University,Education
 sch.gr,Greek School Network,Education
 schaeffler.de,Schaeffler,Manufacturing
@@ -23454,6 +24224,7 @@ schneider.com,Schneider National,Logistics
 schoolcraft.edu,Schoolcraft College,Education
 schuerlein.de,Jan Schuerlein trading as Schuerlein IT,Web Host
 schumacherclinical.com,TSG Resources,Healthcare
+schurz.com,Schurz Communications,ISP
 schwab.com,Charles Schwab,Finance
 schwaz.net,Stadtwerke Schwaz,Utilities
 science.az,Institute of Information Technologies of National Academy of Science Azerbaijan,Education
@@ -23465,9 +24236,11 @@ scis.gov.az,Special Communication Service of Azerbaijan,Government
 scit-tech.ro,Scit Tehnology,ISP
 scjohnson.com,S.C. Johnson,Manufacturing
 scloud.sg,SCloud Singapore,IaaS
+scm-lp.com,Stevens Capital Management LP,Finance
 scn-iq.com,super network for internet service,ISP
 scn-net.ne.jp,Shonan Cable Network,ISP
 scnet.com.br,SCNet,ISP
+scnm.edu,Southwest College of Naturopathic Medicine & Health Sciences,Education
 sco.gov.pk,Special Communication Organization,ISP
 scoe.net,Sacramento County Office of Education,Education
 scomm.ru,Service-Communication,ISP
@@ -23476,6 +24249,7 @@ scootnet.com.au,Scoot NET Partners PTY LTD T/A Scootnet,ISP
 scopesky.com,"ScopeSky for communications, internet and technology services",MSP
 scopesky.online,ScopeSky,ISP
 scorm.com,SCORM,SaaS
+scorpion-shipping.net,Scorpion Shipping,Logistics
 scotch.vic.edu.au,Scotch College,Education
 scotiabank.com,Bank of Nova Scotia,Finance
 scotnet.co.uk,Scotnet,ISP
@@ -23495,6 +24269,8 @@ scrtc.com,South Central Rural Telecommunications Cooperative,ISP
 scrtc.net,South Central Rural Telecommunications Cooperative,ISP
 scs.co.kr,Seokyung Cable Television,ISP
 scsk.jp,SCSK,MSP
+scstatehouse.gov,South Carolina Legislative Services Agency,Government
+scstudentloan.org,South Carolina Student Loan,Nonprofit
 sct-telecom.fr,Societe Commerciale DE Telecommunication SCT,ISP
 sctcweb.com,SCTC Willamette Valley Internet,ISP
 sctelcom.net,South Central Telephone Association,ISP
@@ -23547,6 +24323,7 @@ seagate.com,Seagate,Manufacturing
 sealbond.co.jp,Nippon Sealbond,Manufacturing
 seamlessfiberinnovations.com,Seamless Fiber Innovations,ISP
 seanet.com.br,Seanet,ISP
+seapines.com,Sea Pines Resort,Travel
 searanchconnect.org,GigabitNow Norcal,ISP
 searchitbd.net,Search IT,ISP
 seaside.ns.ca,Seaside Communications,ISP
@@ -23595,6 +24372,7 @@ secureshore.cloud,Secure Shores Data Center,Web Host
 securian.com,Securian Financial,Finance
 securitechsystems.ca,Securitech Systems,MSP
 securities.com,Internet Securities Bulgaria,ISP
+securitiesamerica.com,Securities America,Finance
 security-mail.net,Secuserve,Email Security
 securitymetrics.com,SecurityMetrics,MSSP
 securitynet.cz,SecurityNet.cz,ISP
@@ -23604,6 +24382,7 @@ secyt.gov.ar,Secretaria de Ciencia y Tecnologia Argentina,Government
 sedesc.es,Sede Sistemas Y Comunicaciones,ISP
 sedgwick.gov,Sedgwick County Information Services,Government
 sedmultitel.it,SED Multitel,ISP
+sedonatek.com,Sedona Technologies,Technology
 seed.net.tw,Seednet,ISP
 seedshosting.jp,Seeds Hosting,Web Host
 seedvps.com,SeedVPS,Web Host
@@ -23658,6 +24437,7 @@ semarangkota.go.id,Dinas Komunikasi dan Informatika Pemerintah Kota Semarang,Gov
 sematel-rj.com.br,Telmais Telecomunicações,ISP
 semeartelecom.com.br,Semear Telecom,ISP
 semfronteiras.net.br,Sem Fronteiras,ISP
+seminolecountyfl.gov,Seminole County Government,Government
 seminolestate.edu,Seminole State College of Florida Home Page,Education
 semlimitetelecom.com.br,Sem Limite Telecom,ISP
 semppreonline.com.br,Semppre Online Internet,ISP
@@ -23690,6 +24470,7 @@ senseconnectit.net,Sense Connect It,ISP
 senselan.ch,senseLAN,ISP
 sentara.com,Sentara,Healthcare
 sentech.co.za,Sentech,ISP
+sententia.com.au,Sententia,Web Host
 sentex.ca,Sentexx,ISP
 sentex.net,Sentex Communications,ISP
 sentia.com,Sentia,MSP
@@ -23764,6 +24545,7 @@ servergalactic.asia,Server Galactic,Web Host
 servergalactic.com,Infotechna,Web Host
 servergarden.hu,Servergarden,Web Host
 servergroup.com.bd,HiFiServer Technologies Datacenter (Server Group),Web Host
+serverhosh.com,Serverhosh Internet Service,Web Host
 serverhost.net,Server Host,Web Host
 serverhouse.co.uk,ServerHouse,Web Host
 serverhs.org,WebHS,Web Host
@@ -23824,6 +24606,8 @@ servtec.net.br,ServTEC,ISP
 ses-astra.fr,SES Astra,ISP
 ses-stiftung.de,Schwester Euthymia Stiftung,Healthcare
 ses.com,SES (Formerly Intelsat),ISP
+sesameworkshop.org,Sesame Workshop,Nonprofit
+sesc.com.br,Sesc,Healthcare
 sessiontelecoms.co.za,Session Telecoms(PTY),ISP
 set-se.ru,Severo-Eniseysk-Telecom,ISP
 setardsl.aw,SETAR,ISP
@@ -23861,11 +24645,15 @@ seyix.sc,Seychelles Internet Exchange Point Association,ISP
 sezampro.rs,Orion Telekom,ISP
 sf.gov,City and County of San Francisco,Government
 sfasu.edu,Stephen F. Austin State University,Education
+sfbli.com,Southern Farm Bureau Life Insurance Company,Finance
+sfc.edu,St. Francis College,Education
 sfccmo.edu,State Fair Community College,Education
 sfcn.org,Spanish Fork Community Network,Utilities
+sfcollege.edu,Santa Fe Community College,Education
 sfctek.com.tr,SFCTEK Bilisim Yazilim ve Telekomunikasyon Hiz. San. ve Tic. LTD. STI,ISP
 sfera-it.si,SFERA IT,MSP
 sfera-net.ru,Sfera Telecom,ISP
+sfhp.org,San Francisco Health Plan,Finance
 sfl.com.gh,Broadspectrum,ISP
 sfmc.net,Saint Francis Medical Center,Healthcare
 sfmix.org,SFMIX,ISP
@@ -23884,6 +24672,7 @@ sgb.pl,SGB-Bank Spolka Akcyjna,Finance
 sgbl.com.lb,Societe Generale De Banque Au Liban SAL,Finance
 sgbroadband.in,Sg Broadband Internet Pvt,ISP
 sgc.hk,SGC-Cloud Alliance,MSP
+sgk.gov.tr,Sosyal Guvenlik Kurumu(SGK),Government
 sgnetararuama.com.br,Global Flash Telecom E Tecnologia,ISP
 sgrcnetwork.com,SGRC,ISP
 sgs.se,Goteborgs Studentbostader (SGS),Education
@@ -23932,6 +24721,7 @@ shawbrook.co.uk,Shawbrook,Finance
 shawnee.com,Shawnee Communications,ISP
 shawneelink.net,ShawneeLink,ISP
 shawu.edu,Shaw University,Education
+shazam.net,SHAZAM,Finance
 shb.com.vn,Saigon - Hanoi Commercial Joint Stock Bank,Finance
 shebatech.com.bd,Sheba Technologies,ISP
 sheen.tel,Sheen Telecom Consultants,ISP
@@ -24053,6 +24843,7 @@ sierra-view.com,Sierra View Medical Center,Healthcare
 sierracommunication.com,Sierra.Net Network & Data Solution,ISP
 sierraexperts.com,Sierra Experts IT,Web Host
 sierranetworks.net,Telecomunicaciones Sierra Networks Sierranet CIA,ISP
+sierraschicaswifi.com.ar,Sierras Chicas WiFi,ISP
 sierratel.com,Sierra Tel,ISP
 sierratel.sl,Sierratel,ISP
 sierrawireless.com,Sierra Wireless,ISP
@@ -24081,6 +24872,7 @@ signaltv.net,Signal TV,ISP
 signature-bd.com,Signature-bd,ISP
 signet.com.br,Signet,ISP
 signet.nl,Signet,ISP
+signetbank.com,Signet Bank,Finance
 signetbreedband.nl,Signet,ISP
 signetbroadband.com,Signet Broadband,ISP
 signets.com.br,Signet,ISP
@@ -24143,6 +24935,7 @@ simnet.net.br,SimNET TELECOM agora é SpeedyFast!,ISP
 simnet.ua,Simnet,ISP
 simonpersada.com,Simon Persada,ISP
 simons-rock.edu,Bard College at Simon's Rock,Education
+simpar.com.br,Simpar,Logistics
 simple-fiber.com,Simple Fiber,ISP
 simple-server.ru,Andrey Lebedev,Web Host
 simple.com.ve,"GALAXY ENTERTAINMENT DE VENEZUELA, S.C.A.",ISP
@@ -24317,6 +25110,7 @@ sjnettelecom.com.br,SJNet Telecom,ISP
 sjnetwork.com.br,Sjnet Telecomunicacoes,ISP
 sjofartsverket.se,Swedish Maritime Administration,Government
 sjog.org.au,ST John OF GOD Healthcare,Healthcare
+sjrollins.com,SJ Rollins Technologies,Technology
 sjsym.cn,Guangzhou Shujie Suyuan Culture Communication,ISP
 sjtransindo.com,Sumatera Jaya Transindo,Logistics
 sju.edu,Saint Joseph's University,Education
@@ -24568,6 +25362,8 @@ smbclab.com,SMBC Bank International plc,Finance
 smc.edu,Santa Monica Community College District,Education
 smc.sa.edu.au,ST Michael'S College,Education
 smcbd.com,SM Communication,ISP
+smcc.cc.ms.us,Southwest Mississippi Community College,Education
+smcdsb.on.ca,Simcoe Muskoka Catholic District School Board,Religion
 smcgov.org,County of San Mateo,Government
 smcjbz.nl,Jeroen Bosch Ziekenhuis,Healthcare
 smcjpn.co.jp,SMC Corporation,Manufacturing
@@ -24584,10 +25380,12 @@ smiritycable.com,Smirity Cable,ISP
 smith.edu,Smith College,Education
 smithbucklin.com,Smithbucklin,Consulting
 smithdrug.com,Smith Drug Company,Healthcare
+smithgroup.com,SmithGroup,Healthcare
 smithville.com,Smithville Fiber,ISP
 smithvilletelephone.net,Smithville Telephone CO,ISP
 smkb.ac.il,"The Kibbutzim Seminar - College of Education, Technology and Arts (AR)",Education
 smn.com.ua,Palvi Telecom,ISP
+smn.gob.ar,Servicio Meteorologico Nacional,Government
 smnet.net.br,Smnet Telecomunicacoes,ISP
 smoltelecom.ru,Smoltelecom,ISP
 sms-teleport.com,SMS Teleport,ISP
@@ -24623,6 +25421,7 @@ snet.co.id,Sahabat Internet Nusantara,ISP
 snet.com,SNET,ISP
 snetfibra.com.br,S-Net Telecom,ISP
 snettertontele.com,Snetterton Telecom,ISP
+snhu.edu,Southern New Hampshire University,Education
 sninternet.com,Six Nations Internet,ISP
 sninternet.com.br,SN Internet Navegantes,ISP
 sniperhill.net,Sniperhill Internet services,ISP
@@ -24631,6 +25430,7 @@ snohomishcountywa.gov,"Snohomish County, WA",Government
 snowd.com,Snowd Security VPN,SaaS
 snowflake.app,Snowflake,SaaS
 snowvalley.co.za,Snowvalley Communications,ISP
+snru.ac.th,Sakon Nakhon Rajabhat University,Education
 snsinternet.com,Sns Internet Services,ISP
 snsitbd.com,SNS IT,Web Host
 snsnetwork.co.id,SNSNetwork,ISP
@@ -24727,6 +25527,7 @@ solfibraotica.com.br,Sol Internet Fibra Óptica,ISP
 solid.ru,Joint Stock Company Commercial Bank Solidarnost,Finance
 solides.net.id,Solusi Internet De,ISP
 solidfibre.co.za,Solid Fibre,ISP
+solidheberg.fr,Solidheberg,Web Host
 solidigm.com,Solidigm,Web Host
 solidnetwork.org,SolidNetwork Technologies,Web Host
 solidtools.com,SolidTools,ISP
@@ -24751,6 +25552,7 @@ solucionesliven.com,Soluciones Liven,ISP
 solunet.com.ar,Grupo Solunet,ISP
 solunetfibra.com.br,Solucao Servicos DE Internet Tanabi,ISP
 solunetisp.com,Solunet ISP,ISP
+soluslp.com,Solus Alternative Asset Management LP,Finance
 solutech.com,SOLUTECH,ISP
 solutions.com.sa,STC,ISP
 soluzionipotenza.it,Soluzioni Potenza,ISP
@@ -24909,6 +25711,7 @@ spambusters.email,Spambusters,Email Security
 spamfiltering.com,Hosting UK,Web Host
 spamtitan.com,SpamTitan,Email Security
 span.eu,Span.eu,MSP
+spanlink.com,Spanlink Communications,ISP
 sparcc.org,SPARCC,Government
 spark.co.nz,Spark,ISP
 sparkassen-it.de,Sparkassen-IT,MSP
@@ -24924,6 +25727,7 @@ sparktel.az,Sparktel,ISP
 sparktele.com,Spark Telecommunication,ISP
 sparq.com.au,Sparq (Energex),Utilities
 sparqnet.net,Sparqnet,ISP
+spartahospital.com,Sparta Community Hospital,Healthcare
 spartanburgregional.com,Spartanburg Regional Healthcare System,Healthcare
 spartanhost.org,Spartan Host,Web Host
 spasnet.ru,DN Telecom,ISP
@@ -25051,6 +25855,7 @@ speedyway.com.br,Vianet,ISP
 speet.com.br,Speet Telecom,ISP
 speicherzentrum.de,Speicherzentrum,Web Host
 spglobal.com,S&P Global,Finance
+sphealth.org,St. Peter's Health,Government
 sphere-telecom.com,Sphere Telecom,ISP
 spherebox.in,Spherebox,ISP
 spherion-southbend.com,Spherion,Staffing
@@ -25094,6 +25899,7 @@ spokanetribe.com,Spokane Tribe of Indians,ISP
 spotler.com,Spotler,Marketing
 spotnet.co.il,SpotNet,ISP
 spottelecom.ru,Spot Telecom,ISP
+spragueenergy.com,Sprague Energy,Utilities
 springcitycable.com,Spring City Cable TV,ISP
 springernature.com,Springer Nature,Education
 springfield-ma.gov,"City of Springfield, Massachusetts",Government
@@ -25101,6 +25907,7 @@ springfield.ma.us,Springfield Public Schools,Education
 springnet.net,SpringNet,ISP
 springshosting.com,Springs Hosting Secure Data Center | Colorado Managed IT Services,Web Host
 springtideco.com,Springtide Communications,ISP
+springventuregroup.com,Spring Venture Group,Finance
 sprinkvillenetworks.co.ke,Sprinkville Networks,ISP
 sprint-bg.net,Sprint Bulgaria,ISP
 sprint-inet.ru,SPRINTInet (Спринт-инет),ISP
@@ -25147,9 +25954,11 @@ srnet.it,Sr Net Italy,ISP
 sro.vic.gov.au,State Revenue Office Victoria,Government
 srpnet.com,Salt River Project,Utilities
 srs.gov,Savannah River Site,Government
+srscommunications.net,SRS Communication,ISP
 srspharmacy.com,SRS Pharmacy Systems,Healthcare
 srt.com,SRT Communications,ISP
 srtc.coop,Santa Rosa Telephone Cooperative,ISP
+sru.ac.th,"Suratthani ratjabhat university, Thailand",Education
 sru.edu,Slippery Rock University,Education
 srv.tel,Servis Telecom,ISP
 srvape.com,Smart Ape LLC,Web Host
@@ -25203,6 +26012,7 @@ stackmail.com,20i,Web Host
 stacksdiscovery.com,Stacks,Web Host
 stacktelecom.ru,Stack Telecom,IaaS
 stacuity.com,Stacuity,ISP
+stadionmoney.com,Stadion Money Management,Finance
 stadlmann.at,Stadlmann,MSP
 stadt-koeln.de,City of Cologne,Government
 stadtnetz-bamberg.de,Stadtnetz Bamberg,ISP
@@ -25235,6 +26045,7 @@ stanford.edu,Stanford University,Education
 stanleycollege.edu.au,Stanley College,Education
 stansat.pl,STANSAT,ISP
 staples.com,Staples,Retail
+star.london,star.london,Web Host
 star.ne.jp,Xserver,Web Host
 star.psi.br,Star,ISP
 starbroadband.net,Rising Star Cable TV Services,ISP
@@ -25262,12 +26073,14 @@ starkmans.com,Starkmans Health Care Depot,Healthcare
 starktelecom.af,Stark Telecom,ISP
 starktelecom.uz,East Stark-Tv,ISP
 starlan.com,Starlan Telecom,ISP
+starlightfiber.com,Starlight Fiber,ISP
 starlinenet.com.br,Starline Serviços DE Internet,ISP
 starlingbank.com,Starling,Finance
 starlingsgoa.com,starlings wireless communications,ISP
 starlinx.com,StrLinX,MSP
 starman.net.br,Star Man Net,ISP
 starmannet.com.br,Starman,ISP
+starmountlife.com,Starmount Insurance Agency,Finance
 starnet.com.my,Starnet Communications,ISP
 starnet.cz,Starnet,ISP
 starnet.lutsk.ua,FOP Slupko Oleksandr Anatolyevich,ISP
@@ -25323,6 +26136,7 @@ statelecom.net.br,STA Telecom,ISP
 statenet.in,Statenet Wifi OPC,ISP
 statens-it.dk,Statens IT Denmark,Government
 statestreet.com,State Street,Finance
+statewidecs.com,Statewide Central Station,Physical Security
 static1.com,Static 1,Web Host
 station030.com,123eHost,Web Host
 stationnet.com.br,Station Net,ISP
@@ -25355,6 +26169,7 @@ stedwards.edu,St. Edwards University,Education
 steel.com.ar,LARRAURI GUALBERTO JOSE,ISP
 steelcase.com,Steelcase,Healthcare
 steelwebtelecom.com.br,Steel WEB Provedores DE Acesso,ISP
+stegh.on.ca,St. Thomas-Elgin General Hospital,Healthcare
 stel.cl,Stel,ISP
 stel.it,STEL,ISP
 stelecom.cd,Standard Telecom Congo Sarl- STC,ISP
@@ -25371,6 +26186,7 @@ stemconnect.net,Stem Connect,MSP
 steps-tele.com,Steps Telecom For Internet,ISP
 stered.mx,Stered Telecomunicaciones SA de CV,ISP
 steripackgroup.com,SteriPack Medical Poland,Healthcare
+sterlingbankng.com,Sterling Bank,Finance
 sterlingpr.com,Sterling Communications,Government
 stertec.co.jp,KUNIMORI-STAR Group,MSP
 stetnet.com.br,webby agora é alares,ISP
@@ -25381,6 +26197,7 @@ stevenscollege.edu,Thaddeus Stevens College of Technology,Education
 stevenson.edu,Stevenson University,Education
 stewarthowe.com,Newfold Digital,Web Host
 steway.com,Steway,ISP
+stfrancishawaii.org,St Francis Healthcare System of Hawaii,Healthcare
 stfx.ca,St. Francis Xavier University,Education
 sti-group.co.id,Semesta Teknologi Informatika,MSP
 sti.net,Sierra Tel,ISP
@@ -25393,6 +26210,7 @@ stil.dk,STIL Denmark,Government
 stillwaterschools.org,Stillwater Area Public Schools,Education
 stimo.net,Stimo.NET,ISP
 stimulustech.com,Stimulus Tech,ISP
+stirling.wa.gov.au,City of Stirling,Government
 stisahel.com,Societe 'Sahel Tele Internet' SA/,ISP
 stitelecom.net.br,STI Telecom,ISP
 stj-telecom.com,STJ,ISP
@@ -25402,15 +26220,19 @@ stjoes.ca,St. Joseph's Healthcare Hamilton,Healthcare
 stjohns.edu,St. John's University,Education
 stjohns.health,St. John's Health,Healthcare
 stjohnscollegespringfield.edu,St. John's College,Education
+stjosephbangor.org,ST Joseph Hospital,Healthcare
 stjude.org,St. Jude Children's Research Hospital,Healthcare
 stkate.edu,St. Catherine University,Education
 stlawu.edu,St. Lawrence University,Education
 stlfiberco.net,STL Fiber,ISP
+stlukes-stl.com,St. Luke's,Healthcare
 stlukes.com.ph,St. Luke's Medical,Healthcare
 stmarys-ca.edu,Saint Mary's College of California,Education
 stmarysmaine.com,St. Mary's Health System,Healthcare
 stmarytx.edu,St Mary's University,Education
+stmichaels.vic.edu.au,St. Michael's Grammar School,Education
 stmk.gv.at,Amt der Steiermaerkischen Landesregierung,Government
+stmu.ca,St Mary's University,Education
 stnc.cn,Shanghai Science and Technology Network,ISP
 stncommunication.com,STN Communication & Advertising,ISP
 stnet.ad.jp,CATV Tokushima,ISP
@@ -25421,6 +26243,7 @@ stockholmsstadsnat.se,Bredband2 Stockholms Stadsnat,ISP
 stockmanbank.com,Stockman Bank,Finance
 stockton.edu,Stockton University,Education
 stocktonca.gov,City of Stockton,Government
+stoel.com,Stoel Rives LLP Attorneys,Legal
 stoinet.com,STOI Internet,ISP
 stokes.nc.us,"Stokes County, North Carolina",Government
 stokinfotelecom.com.br,STOK INFO TELECOM,ISP
@@ -25428,6 +26251,7 @@ stolaf.edu,St. Olaf College,Education
 stomabags.com,Stomabags.com,Healthcare
 stone-rich.at,Otto M. Steinmann e.U,ISP
 stonehill.edu,Stonehill College,Education
+stoneridge.com,Stoneridge,Manufacturing
 stonybrook.edu,Stonybrook University,Education
 stonynet.com.br,StonyNet,ISP
 storesonlinepro.com,StoresOnline,SaaS
@@ -25440,6 +26264,7 @@ stortinget.no,Stortinget (Norwegian Parliament),Government
 stou.ac.th,Sukhothai Thammathirat Open University,Education
 stova.io,Stova,SaaS
 stowecomm.com,Stowe Communications,ISP
+stpauls.nsw.edu.au,St Paul's Grammar School Penrith,Education
 stpeters.qld.edu.au,St Peters Lutheran College Website,Education
 stpi.in,STPI,Government
 stpl.network,Sudhana Telecommunications,ISP
@@ -25452,6 +26277,7 @@ stratanetworks.co.nz,Strata Networks,MSP
 stratanetworks.com,Strata Networks,ISP
 strategicgroup.net.au,Strategic Group,MSP
 strategictreasurer.com,Strategic Treasurer,Finance
+strateji.com.tr,Strateji Menkul Değerler,Finance
 strateqgroup.com,Strateq Group — Innovation Driven IT Solutions Malaysia,Healthcare
 stratfordtelephone.com,Stratford Mutual Telephone Company,ISP
 strathmore.edu,Strathmore University,Education
@@ -25511,6 +26337,7 @@ stupino.net,Limited Liability Company SKS Telecom,ISP
 stupp.com,Stupp Fiber,ISP
 stuttgart-ix.de,Stuttgart-IX,ISP
 stv.ee,STV Estonia,ISP
+stvin.org,CHRISTUS St. Vincent Regional Medical Center,Healthcare
 stvincents.com.au,St Vincents & Mater Health Sydney,Healthcare
 stvtelecom.pt,"RSIL, Lda",ISP
 stw.at,Stadtwerke Klagenfurt,Utilities
@@ -25536,6 +26363,7 @@ subinet.pl,Subinet.pl,ISP
 subisu.net.np,Subisu Cablenet,ISP
 subnet.net.id,Subnet Data Nusantara,ISP
 subnet05.ru,Subnet,ISP
+subnetdigital.com,Subnet Digital,Web Host
 subr.edu,Southern University,Education
 subrigo.net,Subrigo,MSP
 suburbanfiberco.com,Suburban Broadband,ISP
@@ -25570,6 +26398,7 @@ sulnet.com.br,Sulnet Telecom,ISP
 sulnetrc.com.br,Sulnet RC Internet Provider Informatica,ISP
 sulnettelecom.com.br,Sulnet Telecom,ISP
 sulonline.net,Sul Internet,ISP
+sulross.edu,SUL ROSS,Education
 sulselnet.id,Sulsel Layanan Internet,ISP
 sulseprov.go.id,Dinas Komunikasi Informatika Statistik DAN Persandian Provinsi Sulawesi Selatan,Government
 sultel.net.br,Sultel,ISP
@@ -25597,6 +26426,7 @@ sums.ac.ir,Shiraz University of Medical Sciences,Education
 sumselprov.go.id,Dinas Perhubungan Kominfo Provinsi Sumatera Selatan,Government
 sumtel.ru,Sumtel,ISP
 sumtelecom.com.br,Sum Telecom,ISP
+sumtercountyfl.gov,"Sumter County, FL",Government
 sumutprov.go.id,Sumutprov,Government
 sun.ac.jp,University of Nagasaki,Education
 sunbroadband.in,Sun Broadband And Data Services,ISP
@@ -25664,6 +26494,7 @@ superip.com.br,SuperIP,ISP
 superitelecom.com.br,Ibituruna TV por assinatura S/C,ISP
 superlink.co.id,Superlink,ISP
 superlink.ps,SuperLink سوبر لينك,ISP
+superlinknetworks.com,SuperLink,ISP
 superlinkprovedor.com.br,Superlink,ISP
 superloop.au,Superloop,ISP
 superloop.com,Superloop,ISP
@@ -25686,6 +26517,7 @@ supernetmais.com.br,Supernetmais Telecomunicações,ISP
 supernetwork.net.br,SuperNetwork Telecom,ISP
 supernovabih.ba,Supernova,ISP
 supernovainternet.com.br,Super Nova Telecom,ISP
+supernus.com,Supernus Pharmaceuticals,Healthcare
 superondas.com.br,SuperOnd,ISP
 superonline.net,Turkcell Superonline,ISP
 superoptic.net,Super Optik Tech,ISP
@@ -25745,10 +26577,12 @@ susqu.edu,Susquehanna University,Education
 susquehannabroadband.com,Susquehanna Broadband,ISP
 sust.edu,Shahjalal University of Science and Technology,Education
 sustentatelecom.com.br,Sustenta Telecom,ISP
+susu-tech.net,Susu Teknologi Indonesia,MSP
 susu.ru,South Ural State University,Education
 sut.ac.th,Suranaree University of Technology,Education
 sutd.edu.sg,20 Dover Drive Singapore 138682,Education
 sutterhealth.org,Sutter Health,Healthcare
+suttonbank.com,Sutton Bank,Finance
 suvoz.es,SUVOZ,ISP
 suzko.com,SUZKO,Web Host
 sv-en.ru,Svyaz-Energo,ISP
@@ -25789,11 +26623,13 @@ swayzee.com,Swayzee Telephone,ISP
 swcp.com,Southwest Cyberport,ISP
 sweb.ru,SpaceWeb,Web Host
 swedbank.se,Swedbank,Finance
+swedishamerican.org,Swedishamerican Health System,Healthcare
 swedishcovenant.org,Swedish Covenant Hospital,Healthcare
 sweep.nz,SWEEP NZ,ISP
 sweet.tv,OTT Ukraine,Entertainment
 sweetsa.com.ar,Sweet Briar College,Education
 swgfl.org.uk,SWGfL South West Grid for Learning,Education
+swgroup.ru,Superwave Group,ISP
 swhl.de,Stadtwerke Lubeck,Utilities
 swhosting.com,sw hosting & communications technologies,ISP
 swiatlowodem.pl,Blisko (Biznes Swiatlowodem),ISP
@@ -25828,10 +26664,12 @@ switch.net.lb,Switch Telecom,ISP
 switch.pl,Switch.pl,ISP
 switchdatacenters.com,Switch Datacenters,Web Host
 switchfiber.ph,Switch Fiber,ISP
+switchitsupport.com,Switch I.T. Support,MSP
 switchtel.co.za,Switch Telecom,ISP
 swizcloud.fr,SwizCloud,Web Host
 swko.net,SWKO - SouthWest Kansas Online,ISP
 swlink.com.br,SWLINK,ISP
+swmich.edu,Southwestern Michigan College,Education
 swn.net,SWN Stadtwerke Neumünster,Utilities
 swoca.net,SWOCA,MSP
 swoop.com.au,Swoop,ISP
@@ -25848,6 +26686,7 @@ sxbctv.com,Shaanxi Broadcast & TV Network,ISP
 sxu.edu,Saint Xavier University,Education
 syariahmandiri.co.id,Bank Syariah Mandiri,Finance
 syau.edu.cn,Shenyang Agricultural University,Education
+syb.com,Stock Yards Bank AND Trust Company,Finance
 sybcom.de,SYBCOM,MSP
 sybyl.com,Sybyl Kenya,MSP
 syctnet.com,Shuangyu Communication Technology co,ISP
@@ -25979,6 +26818,7 @@ taaconnect.com,TAAconnect,MSP
 tabalongkab.go.id,Dinas Komunikasi dan Informatika Kabupaten Tabalong,Government
 tabapuanet.com.br,TabapuaNET,ISP
 tabasamufiber.com,Tabasamu Fibre Networks,ISP
+tabor.edu,Tabor College,Education
 tabriz.ir,Information and Communication Technology Organization of Tabriz Municipality,ISP
 tabush.com,Tabush,Web Host
 tac-communications.co.uk,TAC Communications,ISP
@@ -26002,6 +26842,7 @@ tagtelzw.com,Tagtel Communications (Pvt),ISP
 taguanet.com.br,TaguaNet,ISP
 tahoe.com.bd,Tahoe Communication,ISP
 tahoeix.org,TahoeIX,ISP
+taiamerica.com,Toyota Tsusho America,Logistics
 taifo.com.tw,TAIFO,ISP
 taigatelecom.ca,Taiga Telecom,ISP
 taiget.ru,Taiget,ISP
@@ -26041,6 +26882,7 @@ tami.pl,TAMI,MSP
 tamiu.edu,Texas A&M International University,Education
 tamkeentech.sa,Tamkeen Technologies,MSP
 tampagov.net,"City of Tampa, Florida",Government
+tamro.com,Tamro,Healthcare
 tamu.edu,Texas A&M University,Education
 tamusa.edu,Texas A&M University San Antonio,Education
 tamut.edu,Texas A&M University-Texarkana,Education
@@ -26100,6 +26942,7 @@ tataindicomtotalinternet.in,TATA Communications Internet Services,ISP
 tatais.ru,TatAISneft,ISP
 tatamitrasolusi.co.id,Fiber Bahana Tatamitra Solusi,ISP
 tataplayfiber.com,Tata Play Broadband,ISP
+tatapowersolar.com,Tata Power Solar,Manufacturing
 tatar.ru,Tatarstan IT-park,Government
 tatatel.co.in,Tata Teleservices,ISP
 tatatelebusiness.com,Tata Teleservices,ISP
@@ -26144,6 +26987,7 @@ tccb.gov.tr,TC Cumhurbaskanligi Idari Isler Baskanligi,Government
 tccd.edu,Tarrant County College District,Education
 tccfr.ro,Telecomunicatii CFR,ISP
 tce.pi.gov.br,Piaui Tribunal DE Contas DO Estado,Government
+tce.pr.gov.br,TCE-PR,Government
 tcell.tj,Tcell,ISP
 tcemcfiber.org,Tri-County Fiber Communications,ISP
 tcenter.ru,ER-Telecom Holding,ISP
@@ -26202,8 +27046,10 @@ tdtdigital.mx,TDT Digital SA DE CV,ISP
 te.eg,Telecom Egypt,ISP
 tea.bg,TEA,Web Host
 team-cymru.org,Team Cymru,Email Security
+team-sos.com,TEAM SOS,ISP
 team.blue,team.blue,Web Host
 teamcenturion.com,Centurion Group,Healthcare
+teamcloud.my,TeamCloud - Malaysia,Web Host
 teamglac.com,TeamGLAC,Healthcare
 teamhealth.com,TeamHealth,Healthcare
 teamhuber.com,Huber & Associates,MSP
@@ -26211,6 +27057,7 @@ teaminternet.com,Team Internet,ISP
 teamipro.com,IPRO,MSP
 teammidwest.com,MEC Midwest Energy and Communications,ISP
 teamnetwork.co.nz,TEAMnetwork,MSP
+teampool.com,teampool,Staffing
 teb.com.tr,Turk Ekonomi Bankasi Anonim Sirketi,ISP
 tebingtinggikota.go.id,Dinas Komunikasi dan Informatika Kota Tebing Tinggi,Government
 tebokab.go.id,Dinas Komunikasi dan Informatika Kabupaten Tebo,Government
@@ -26244,6 +27091,7 @@ techmedia.com.pl,Tech-Media Gliwice | ☎ 32 238 75 93,ISP
 techminds.ca,TechMinds Canada,ISP
 technefiber.com,Techne Fiber,ISP
 techni.de,Jurgen Eckhard Petri,ISP
+technikum-wien.at,Technikum Wien,Education
 technobytes.com.br,Techno Bytes Telecom,ISP
 technoconnect.io,Technoconnect,MSP
 technokursk.ru,Tehno (Kursk),ISP
@@ -26255,6 +27103,7 @@ technolutions.co.za,Technolutions South Africa,Web Host
 technolutions.com,Technolutions,SaaS
 technolutions.net,Technolutions,SaaS
 technoonbd.com,MD. JAKIR HOSSAIN T/A Techno One Line,ISP
+technoproholdings.com,Technopro Holdings,Staffing
 technovage.io,Technovage Solution,MSP
 technozone.com.ph,Technozone Corporation,Construction
 techpath.com.au,TechPath,ISP
@@ -26334,6 +27183,7 @@ telappliant.com,Telappliant,MSP
 telasera.com,Telasera Technologies,Web Host
 telbeskid.com.pl,Internet światłowodowy i telewizja | telbeskid.com.pl,ISP
 telbo.net,TELBO,ISP
+telbros.cl,Telbros,ISP
 telcel.com,Telcel,ISP
 telcion.com,Telcion,Web Host
 telco.com.ar,TelCo,ISP
@@ -26428,6 +27278,7 @@ telecom.net.ec,Telecom,ISP
 telecom.ru,Telecom.ru,ISP
 telecom.tm,Turkmentelecom,ISP
 telecom.tw,Sky Digital Taiwan (ImCloud),ISP
+telecom2.net,Telecom2,ISP
 telecom26.ch,Telecom26,ISP
 telecomarmenia.am,Telecom Armenia (Team),ISP
 telecombis.ru,Bogorodskoe Information Systems,ISP
@@ -26631,6 +27482,7 @@ tellcorpce.com.br,TELL,ISP
 tellecom.com.br,Mar Provedor (Tellecom),ISP
 tellerwifi.com,TellerWifi,ISP
 tellius.com.br,Tellius,ISP
+tellmed.org,Telluride Medical Center,Healthcare
 tellynk.com.br,Tellynk,ISP
 telma.km,Telecom Comores S.A (Telco S.A),ISP
 telma.mg,Yas,ISP
@@ -26673,6 +27525,7 @@ telsur.cl,Telefónica del Sur,ISP
 telta.de,TELTA Citynetz,ISP
 teltan.com.mx,Internet Teltan,ISP
 teltrex.com,Teltrex,ISP
+teltrust.com,Teltrust,ISP
 teluq.ca,Tele-Universite,Education
 telus.com,TELUS,ISP
 telus.net,TELUS,ISP
@@ -26692,6 +27545,7 @@ tempe.gov,City of Tempe,Government
 tempest.net,Tempest Hosting,Web Host
 temple.edu,Temple University,Education
 templehealth.org,Temple University Health System,Healthcare
+templejc.edu,Temple College,Education
 temporeal.com,Bipmar Telecomunicações,ISP
 tempus.net.pl,Wojciech Jerzy Winkel trading as Tempus Telecom,ISP
 tempusnet.com.py,Tempus Group,ISP
@@ -26738,6 +27592,7 @@ teranetwork.com.br,Tera Network,ISP
 terared.tv,Inicio Terared,ISP
 teraswitch.com,TeraSwitch Networks,Web Host
 teremki.net.ua,Teremky LAN ISP,ISP
+terex.com,Terex,Manufacturing
 tericom.su,Tericom,ISP
 ternet.or.tz,TERNET Tanzania Education and Research Network,Education
 terra.com,Terra Networks,Web Host
@@ -26783,6 +27638,7 @@ texnet.com.br,PBR Servicos DE Telecomunicacoes,ISP
 textelecom.net,TEX Telecom,ISP
 textowngroup.com,Textown Group,Manufacturing
 teyla.ru,T-systems Limited Liability Company,ISP
+tfhd.com,Tahoe Forest Hospital District,Healthcare
 tfiber.ro,SIL-MIRO COM SRL,ISP
 tfl.com.fj,Telecom Fiji,ISP
 tfl.gov.uk,Transport for London,Government
@@ -26798,6 +27654,7 @@ tgnet.de,true global communications,ISP
 tgnetworkbd.com,TG Network,ISP
 tgnnetworks.com,Tgn Networks,ISP
 tgtel.com,Thacker-Grigsby Communications,ISP
+thaiairways.com,Thai Airways,Travel
 thaicom.net,Thaicom,ISP
 thainguyen.gov.vn,"CENTER FOR INFORMATION AND COMMUNICATION TECHNOLOGY, Thai Nguyen Department of Information and Communications",ISP
 thaitoko.com,Thai Toko Engineering,Construction
@@ -26810,6 +27667,7 @@ the.net.id,OpenIXP,ISP
 the4thutility.co.uk,The 4th Utility,ISP
 theaccessgroup.com,The Access Group,SaaS
 theapplebank.com,Apple Bank for Savings,Finance
+thebankofsa.com,The Bank of San Antonio,Finance
 thebrookfieldgroup.com,The Brookfield Group,MSP
 thebunker.net,The Bunker (Cyberfort),Web Host
 thecable.net,The Cable St. Kitts,ISP
@@ -26846,17 +27704,20 @@ thenetheads.com,Md. Manzurul Haque Khan T/A THE NET HEADS,ISP
 thenextsuccess.com.mm,The Next Success,ISP
 theonebroadband.co.uk,The One Broadband,ISP
 theorem.digital,Theorem,ISP
+theravance.com,Theravance Biopharma US,Healthcare
 thermofisher.com,Thermo Fisher Scientific,Healthcare
 therocksnet.com,Rocks Computer Services,ISP
 thesainet.in,Siliguri Meghrekha Net Services,ISP
 thesolarsystems.net,Joint Power Technology,Web Host
 thessigroup.com,SSI Group,Healthcare
 thetaservers.com,AE Hosting,Web Host
+thevillageshealth.com,The Villages Health,Healthcare
 thewahtel.com,The Wah Telecom,ISP
 thewire.ca,The Wire,Web Host
 thewomens.org.au,Precinct Health Service,Healthcare
 thglobalvision.net,T.H. Global Vision,ISP
 thibodaux.com,Thibodaux Hospitals,Healthcare
+thiel.edu,Thiel College,Education
 thin-nology.com,Thin-nology,Web Host
 thinco.es,Agustin Lorenzo Sempere trading as Thinco Telecom,ISP
 thinkbignets.com,IQ Fiber (ThinkBig Networks),ISP
@@ -26933,6 +27794,7 @@ tiftregional.com,Tift Regional Health System,Healthcare
 tigakom.com,Tigatra Infokom,ISP
 tiger-telecom.ru,Tiger-Telecom,ISP
 tigerconnect.com,TigerConnect,SaaS
+tigerresort.com,"Tiger Resort, Leisure & Entertainment",Travel
 tigertech.net,Tiger Technologies,Web Host
 tiggee.com,Tiggee (DigiCert),Email Security
 tigo.co.tz,Tigo,ISP
@@ -26949,6 +27811,7 @@ tigron.net,Tigron,MSP
 tii-usa.com,Technology International,Consulting
 tikona.in,Tikona,ISP
 tilaa.com,Tilaa,Web Host
+tilda.kz,Tilda Publishing Kaz,Retail
 tillmanfiber.com,Tillman Fiber,ISP
 tiltas.lt,Verslo Tiltas,MSP
 tim.com.br,TIM Brasil,ISP
@@ -26982,6 +27845,7 @@ tino.vn,Tino Group,Web Host
 tins.ad.jp,Tsukuba Internet Service,ISP
 tint.or.th,Thailand Institute of Nuclear Technology (Public Organization),Education
 tipira.com.br,Tipira Internet Digital,ISP
+tippmanngroup.com,Tippmann Group,Food
 tira.com.ua,Telecompany LiS,ISP
 tirol.gv.at,www.tirol.gv.at,Government
 tis-dialog.ru,TIS Dialog,ISP
@@ -27002,6 +27866,7 @@ titanhq.com,TitanHQ,Email Security
 titanlabs.ai,Titan Labs,Web Host
 titantelecoms.au,Titan Telecoms,ISP
 titech.ac.jp,Institute of Science Tokyo,Education
+titusvillehospital.org,Titusville Area Hospital,Healthcare
 tivit.com,Tivit,MSP
 tix.it,Tuscany Internet eXchange,ISP
 tiyatel.com,Tiyatel,ISP
@@ -27033,6 +27898,7 @@ tlcm.tv,"Telecomunicaciones DE Marcala, Sociedad Anonima DE Capital Variable",IS
 tlftelecom.com.br,TLF Telecom,ISP
 tlink.cl,Tlink,ISP
 tlncpl.com,Tln Communication,ISP
+tlpnet.net,Tilakpur Network,ISP
 tlu.edu,TLU,Education
 tlwifi.com,Tenmile Lake Wifi,ISP
 tm.com.my,TM,ISP
@@ -27051,6 +27917,7 @@ tmdhosting.com,TMDHosting,Web Host
 tmh.org,Tallahassee Memorial HealthCare,Healthcare
 tmknet.com.br,TMK NET,ISP
 tmkultra.net.br,Tmk Net,ISP
+tmlawyers.com,Taylor McCaffrey LLP,Legal
 tmo.gov.tr,Toprak Mahsulleri Ofisi Genel Mudurlugu,Government
 tmodns.net,T-Mobile USA,ISP
 tmone.com.my,TM Technology Services,ISP
@@ -27082,6 +27949,7 @@ tnsgrupo.es,TNS Grupo Oliva Valley,ISP
 tnsi.com,TNS Transaction Network Services,SaaS
 tnsplus.kz,TNS-Plus,ISP
 tnstate.edu,Tennessee State University,Education
+tnt.com.au,TNT Express Shipping,Logistics
 tntech.edu,Tennessee Technological University,Education
 tntel.kz,Tvoy Novy Telecom LLP,ISP
 tntelecom.net,Terra Nova Telecom,ISP
@@ -27130,6 +27998,7 @@ tongacable.to,Tonga Cable,ISP
 tongionline.net,TONGI ONLINE,ISP
 tonquanghuy.com,AnPhatIDC,Web Host
 toob.co.uk,toob,ISP
+tooeleco.gov,Tooele County,Government
 toomuchwifi.co.za,TooMuchWifi,ISP
 top-ix.org,TOP-IX,ISP
 top-tokyo.co.jp,TOP CORPORATION,Healthcare
@@ -27173,8 +28042,10 @@ topway.com.cn,Topway,ISP
 topwebtelecom.com.br,TOP WEB TELECOM,ISP
 topwifi.id,Link Tujuh Seven,ISP
 toquetelecom.com.br,Toque Telecom,ISP
+torc.ai,Torc Robotics,Logistics
 torchlake.com,Chain O' Lakes Internet,ISP
 toribio.eu,Internet CLOUD Services,ISP
+torix.ca,Toronto Internet Exchange TorIX,ISP
 tornado.be,Tornado Telecom,ISP
 tornado.com.pk,Tornado Networks,ISP
 tornadodc.com,Joseph Hofmann trading as 'Tornado Datacenter GmbH & Co. KG',Web Host
@@ -27233,6 +28104,7 @@ towerstream.com,Towerstream,ISP
 townfibre.top,TownFibre Connect,ISP
 towngastelecom.com,Towngas Telecom,ISP
 townisp.com,Shrewsbury Electric SELCO,Utilities
+townsville.qld.gov.au,Townsville City Council,Government
 townsvilleinternet.com.au,Townsville Internet,ISP
 towson.edu,Towson University,Education
 toya.com.pl,Toya,ISP
@@ -27257,6 +28129,7 @@ tptus.ru,Eniseyneftegas Territorial Industrial Technical Management of Communica
 tpu.ru,Tomsk Polytechnic University,Education
 tpx.com,TPx Communications,ISP
 tra.gov.om,Telecommunications Regulatory Authority (TRA),ISP
+trabajo.gob.ar,"Ministerio de Trabajo, Empleo y Seguridad Social",Government
 trabia.com,Trabia,IaaS
 tracecom.net.br,Tracecom,ISP
 tracefiber.com,Trace Fiber Networks,ISP
@@ -27412,6 +28285,7 @@ tropmet.res.in,Indian Institute of Tropical Meteorology,Education
 troy.edu,Troy University,Education
 troycable.net,Troy Cablevision,ISP
 trsnyc.org,Teachers' Retirement System of the City of New York,Government
+trt19.jus.br,TRT da 19a Regiao,Legal
 trtelecom.net,TR Servicos de Telecomunicacoes,ISP
 trubridge.com,TruBridge,Healthcare
 true.th,TRUE,ISP
@@ -27458,6 +28332,7 @@ trytek.ru,Trytek,ISP
 ts-s.co.za,Technical Support Solutions (Pty),MSP
 tsabit.net.id,Riyozha Telekomunikasi Indonesia,ISP
 tsbbank.co.nz,TSB Bank,Finance
+tsc.nsw.edu.au,The Scots College,Education
 tscab.org,Telangana State Cooperative Apex Bank,Finance
 tscmnet.com.br,Tscm NET Brasil Telecomunicações,ISP
 tscom.com.br,Tec System Sistemas Eletronicos,ISP
@@ -27511,6 +28386,7 @@ tu-sofia.bg,Technical University of Sofia,Education
 tu-varna.bg,Technical University of Varna,Education
 tu.ac.th,Thammasat University in thailand,Education
 tuatahifibre.co.nz,Tuatahi First Fibre,ISP
+tubankab.go.id,"Dinas Komunikasi dan Informatika, Statistik Dan Persandian Kabupaten Tuban",Government
 tubaron.com.br,Tubaron Telecom,ISP
 tube-hosting.com,Ferdinand Zink trading Tube-Hosting,Web Host
 tube-hosting.de,Ferdinand Zink trading as Tube-Hosting,Web Host
@@ -27529,6 +28405,7 @@ tuespacionet.cl,Tu Espacio NET,ISP
 tufanonline.com.bd,Tufan Online,ISP
 tufibraperu.com,Tufibra Peru S.A.C,ISP
 tufts.edu,Tufts University,Education
+tuftsmedicalcenter.org,Tufts Medical Center,Healthcare
 tugraz.at,Graz University of Technology,Education
 tuhsd.org,Tolleson Union High School District #214,Education
 tukan.hu,Tukan,Web Host
@@ -27678,6 +28555,7 @@ twmbroadband.com,Taiwan Mobile,ISP
 twncorp.com,Cherryland Services,ISP
 twnic.net.tw,Taiwan Mobile,ISP
 twnic.tw,Taiwan Mobile,ISP
+twoa.ac.nz,320 Factory Rd,Education
 tworocklan.com,Two Rock LAN,ISP
 twsolutions.com.br,tw Solutions,ISP
 twspeed.com.br,TWSpeed Telecom,ISP
@@ -27699,6 +28577,7 @@ tyollisyysrahasto.fi,Työllisyysrahasto,Government
 typeform.com,Typeform,SaaS
 typo3server.info,Mittwald,Web Host
 tz.ru,Telecom TZ,ISP
+tzcert.go.tz,TZ-CERT,ISP
 tzulo.com,Tzulo,Web Host
 u-bc.net,UBC,ISP
 u-c-s.ru,UralKonnektServis,ISP
@@ -27752,6 +28631,7 @@ uapinc.com,UAP,Automotive
 uaprostir.com,UAProstir,ISP
 uar.net,UARNet,ISP
 uark.edu,University of Arkansas,Education
+uartes.edu.ec,Universidad DE LAS Artes,Education
 uat.edu,University of Advancing Technology,Education
 uat.edu.mx,Universidad Autonoma de Tamaulipas,Education
 uatechpark.org,Campus Research,Education
@@ -27780,6 +28660,7 @@ ubmex.com.br,UBX Datacenter,Web Host
 ubnet.com.ar,Ubnet proveedor de Internet en la Patagonia Argentina,ISP
 ubs.com,UBS,Finance
 ubsnet.ru,ubsnet.ru,ISP
+ubt.com,Union Bank and Trust Company,Finance
 ubu.ac.th,Ubon Ratchathani University,Education
 ubxcloud.com,UBX Cloud,Web Host
 uc.cl,Pontificia Universidad Catolica de Chile,Education
@@ -27789,13 +28670,17 @@ uca.edu.sv,Universidad Centroamericana Jose Simeon CAÑ,Education
 ucab.edu.ve,Universidad Catolica Andres Bello,Education
 ucalgary.ca,University of Calgary,Education
 ucanet.ru,UCA Networks Moscow,ISP
+ucanr.edu,"The Regents of the University of California, Agriculture and Natural Resources",Education
 ucar.edu,University Corporation for Atmospheric Research,Education
 ucasal.edu.ar,Universidad Catolica DE Salta,Education
 ucatv.co.jp,Utsunomiya Cable TV,ISP
 ucb.com.bd,United Commercial Bank,Finance
+ucb.edu.bo,UCB,Education
 ucbwi.com,United Community Bank,Finance
+ucc.co.ug,Uganda Communications Commission,ISP
 ucc.edu,Union County College,Education
 ucc.edu.gh,THE UNIVERSITY OF CAPE COAST,Education
+uccaribe.edu,UCC,Education
 uccs.edu,University of Colorado Colorado Springs,Education
 ucd.ie,University College Dublin,Education
 ucdavis.edu,UC Davis,Education
@@ -27853,6 +28738,7 @@ udc.hk,Hong Kong Communications,Web Host
 udd.cl,Bienvenido a la UDD,Education
 udea.edu.co,Universidad DE Antioquia,Education
 udel.edu,University of Delaware,Education
+udemedellin.edu.co,Corporacion Universidad DE Medellin,Education
 udg.mx,Universidad de Guadalajara,Education
 udlap.mx,Universidad de las Americas Puebla,Education
 udm.ru,UDM Izhevsk,ISP
@@ -27867,6 +28753,7 @@ udst.edu.qa,University of Doha for Science and Technology,Education
 udtonline.com,United Data Technologies,MSP
 udusok.edu.ng,Usmanu Danfodiyo University,Education
 uec.ac.jp,The University of Electro-Communications,Education
+uees.edu.ec,UEES,Education
 uel.br,Universidade Estadual de Londrina,Education
 uem.br,Universidade Estadual de Maringá - UEM,Education
 uem.mz,Eduardo Mondlane University,Education
@@ -27976,6 +28863,7 @@ ukservers.com,UK Servers,Web Host
 uksw.edu,Universitas Kristen Satya Wacana,Education
 uky.edu,University of Kentucky,Education
 ul-net.co.kr,ULNetworks,ISP
+ula.edu.mx,ULA,Education
 ula.ve,Universidad de los Andes Venezuela,Education
 ulakbim.gov.tr,ULAKBIM,Education
 ulalaunch.com,United Launch Alliance,Defense
@@ -27987,6 +28875,7 @@ uli.net.br,ULI Telecom,ISP
 ulisboa.pt,Castro Telecom,ISP
 uliznet.co.id,Uliz Netmedia Solusindo,ISP
 ulm.edu,ULM,Education
+ulp.org,University of Louisville Physicians,Education
 ulsan.ac.kr,University of Ulsan,Education
 ultahost.com,UltaHost,Web Host
 ultel.net,Ultel,ISP
@@ -28041,6 +28930,7 @@ ultravision.com.mx,Ultracel,ISP
 ultraweb.ca,Backland Communications,MSP
 ultrawebhosting.com,Ultra Web Hosting,Web Host
 ultrawifi.com.br,Voue Telecom,ISP
+ultrawisp.com,UltraWISP,ISP
 ultraxx.com.br,Ultraxx,ISP
 ulu.net.tr,Ulunet Internet ve Iletisim Hizmetleri San. ve Tic. Ltd. Sti,ISP
 um-tel.com,Ultra Mandiri Telekomunikasi,ISP
@@ -28060,6 +28950,7 @@ umaxinternet.com,U-Max Internet,ISP
 umb.com,"UMB Bank, NA",Finance
 umbc.edu,"University of Maryland, Baltimore County",Education
 umbrella.net.ua,Ambrella,ISP
+umbrellacablesystems.com,Umbrella Cable Systems,ISP
 umbrellar.com,Umbrellar,MSP
 umc.edu,University of Mississippi Medical Center,Healthcare
 umcs.pl,Maria Curie-Sklodowska University,Education
@@ -28106,6 +28997,7 @@ unaj.edu.ar,Universidad Nacional Arturo Jauretche,Education
 unal.edu.co,Universidad Nacional de Colombia,Education
 unam.edu.ar,Universidad Nacional de Misiones,Education
 unam.mx,Universidad Nacional Autónoma de México,Education
+unapec.edu.do,UNAPEC,Education
 unatelecom.com.br,UNA Telecomunicações,ISP
 unav.edu,Universidad de Navarra,Education
 unb.br,Universidade de Brasilia,Education
@@ -28183,6 +29075,7 @@ unicommultisystem.net,Unicom Multi System,ISP
 unicomnet.co,UNICOMNET,ISP
 uniconnect.it,Uniconnect,ISP
 uniconnect.net.br,Uniconnect Servicos DE Telecomunicacoes,ISP
+unicredit.ro,UniCredit Bank,Finance
 unicredit.ru,UniCredit Bank,Finance
 unicreditbank.hu,UniCredit Bank Hungary Zrt,Finance
 unicreditgroup.ba,UniCredit Bank,Finance
@@ -28253,6 +29146,7 @@ uniritter.edu.br,Sociedade de Educacao Ritter dos Reis,Education
 unirn.edu.br,Centro Universitário do Rio G. do Norte - UNIRN,Education
 unirtelecom.com.br,Unir Telecom,ISP
 unis.edu.br,Grupo Unis,Education
+unisabana.edu.co,Universidad DE LA Sabana,Education
 uniscape.nl,Uniscape,ISP
 unisel.edu.my,Universiti Selangor,Education
 uniserve.com,Uniserve,ISP
@@ -28310,6 +29204,7 @@ univassouras.edu.br,Univassour,Education
 univates.br,Univates,Education
 univcb.ro,Constantin Brancoveanu University,Education
 univdhaka.edu,university of dhaka,Education
+univem.edu.br,UNIVEM,Education
 universal-shoji.co.jp,Universal Shoji,Industrial
 universal.net.id,Universal Net,ISP
 universalbank.com.ua,Universal Bank,Finance
@@ -28376,6 +29271,7 @@ uob.co.th,UOB Bank Thailand,Finance
 uoc.gr,University of Crete,Education
 uoeh-u.ac.jp,"University of Occupational and Environmental Health, Japan",Education
 uofcumberlands.com,University of the Cumberlands,Education
+uoflhealthcare.com,UofL Health,Healthcare
 uog.edu,University of Guam,Education
 uoguelph.ca,University of Guelph,Education
 uoi.gr,University of Ioannina,Education
@@ -28426,7 +29322,9 @@ upm.fi,UPM,Manufacturing
 upmaisfibra.com.br,Uplink Mais Fibra,ISP
 upmc.com,UPMC,Healthcare
 upmc.edu,Upmc Global Operations Center,Healthcare
+upmin.edu.ph,Official Website of UP Mindanao,Education
 upmrcl.co.in,Uttar Pradesh Metro Rail,Government
+upn.mx,UPN,Education
 upnet.vn,Upnet Technology Solutions,Web Host
 upnetcaucaia.com.br,Upnet,ISP
 upnetgba.com.br,Internet Up-Net Telecom,ISP
@@ -28446,6 +29344,7 @@ uprisefiber.com,Uprise Fiber,ISP
 ups.com,UPS,Logistics
 upsa.edu.bo,UP,Education
 upsamail.edu.gh,"University of Professional Studies, Accra (UPSA)",Education
+upsher-smith.com,Upsher-Smith,Healthcare
 upsi.edu.my,UPSI | Official Portal,Education
 upstate.edu,SUNY Upstate Medical University,Education
 upstream-network.co.uk,Upstream Network,ISP
@@ -28474,6 +29373,7 @@ uranox.com.br,Uranox Telecom,ISP
 urbanwave.co.za,Urban Wave,ISP
 urbanwifinetworks.com,Urban Wifi Networks,ISP
 urbanxconnect.co.za,UrbanX,ISP
+urbe.edu,URBE - Universidad Dr. Rafael Belloso,Education
 urdatel.com,Urdatel,ISP
 urdisc.com.ua,V.Shimanovsky Ukrainian Research and Design Institute of Steel Construction,Education
 uregina.ca,University of Regina,Education
@@ -28481,6 +29381,7 @@ urfibre.co.uk,UrSolutions,ISP
 urfu.ru,Ural Federal University,Education
 uri.br,URI,Education
 uri.edu,University of Rhode Island,Education
+uricer.edu.br,URI,Education
 urlstart.com,URLStart,Web Host
 ursc.gov.in,U R Rao Satellite Centre,Government
 ursinus.edu,Ursinus College,Education
@@ -28489,9 +29390,13 @@ us-cloud.top,Arosscloud (Uscloud),Web Host
 usach.cl,Universidad de Santiago de Chile,Education
 usachoice.net,U S A Choice Internet Services CO,ISP
 usacs.com,Usacs,Healthcare
+usaepay.com,GOR,SaaS
 usagm.gov,USAGM,Government
+usaid.gov,U.S. Agency for International Development,Government
+usainteanne.ca,Universite Sainte-Anne,Education
 usanpedro.edu.pe,Universidad San Pedro,Education
 usap.gov,United States Antarctic Program,Government
+usas.edu.my,Universiti Sultan Azlan Shah,Education
 usask.ca,University of Saskatchewan,Education
 usazy.com,USAzy,Web Host
 usb.ac.ir,University of Sistan and Baluchestan,Education
@@ -28516,6 +29421,7 @@ usf.edu,University of South Florida,Education
 usfca.edu,University of San Francisco,Education
 usfiberpower.com,Fiberpower,ISP
 usfoods.com,US Foods® Food Supplier & Distributor,Healthcare
+usfx.bo,Universidad SAN Francisco Xavier DE Chuquisaca,Education
 usg.edu,University System of Georgia,Education
 usgs.gov,U.S. Geological Survey,Government
 usi.edu,University of Southern Indiana,Education
@@ -28546,6 +29452,7 @@ usq.edu.au,University of Southern Queensland,Education
 ussignal.com,US Signal,MSP
 ussignalcom.net,US Signal,MSP
 usssa.com,USSSA,Sports
+ust.ac.kr,UST,Education
 ust.cl,Universidad Santo TOM,Education
 ust.edu.ph,Santo Tomas E-Service Providers,Education
 ust.hk,Hong Kong University of Science and Technology,Education
@@ -28570,6 +29477,7 @@ utclonline.co.ug,Uganda Telecom,ISP
 utcourts.gov,State OF Utah Courts,Government
 utdallas.edu,University of Texas at Dallas,Education
 uteam.ua,UTeam Ivano-Frankivsk,ISP
+utech.edu.jm,"University of Technology, Jamaica",Education
 utelcom.ru,Utelcom,ISP
 utelecom.com.ua,Ukrainian Telecommunication Group (UTG),ISP
 uteleservices.com,Utele Services,ISP
@@ -28643,6 +29551,7 @@ uvtnet.cz,UVT Internet s.r.o,ISP
 uw.edu,University of Washington,Education
 uw.edu.pl,University of Warsaw,Education
 uwa.edu.au,University of Western Australia,Education
+uwalkin.io,uwalkin IT Solutions,MSP
 uwaterloo.ca,University of Waterloo,Education
 uwec.edu,University of Wisconsin-Eau Claire,Education
 uwf.edu,University of West Florida,Education
@@ -28655,6 +29564,7 @@ uws.edu.au,Western Sydney University,Education
 uww.edu,University of Wisconsin-Whitewater,Education
 uwyo.edu,University of Wyoming,Education
 uxhost.co.uk,Uxhost,Web Host
+uz.ac.zw,University of Zimbabwe,Education
 uz.zgora.pl,Uniwersytet Zielonogorski,Education
 uzhnet.com,Uzhnet,ISP
 uzlovaya.net,Uzlovaya.net,ISP
@@ -28673,6 +29583,7 @@ v1telecom.com.br,V1 Telecom,ISP
 v2net.com.br,V2Net,ISP
 v2soft.com,V2Soft,MSP
 v6node.com,v6Node.com,Web Host
+v6telecom.com.br,Vsix Comunicação E Tecnologia,Web Host
 v7provider.com.br,V7Provider,ISP
 v8net.com,V8net,ISP
 v8solaretelecom.com.br,V8 Telecom,ISP
@@ -28713,6 +29624,7 @@ valleyhealth.com,Valley Health System,Healthcare
 valleyinternational.org,Valley International,ISP
 valleypres.org,Valley Presbyterian Hospital,Healthcare
 valleysmarthomes.com,Valley Smart Homes,ISP
+valleytel.coop,Valley FiberCom,ISP
 valliant.net,Valliant Telephone Company,ISP
 valnetrd.com,Valnet,ISP
 valoo.fi,Valoo,ISP
@@ -28722,6 +29634,7 @@ valorchristian.com,Valor Christian High School,Education
 valorit.net,Valor Information Technologies,MSP
 valornode.net,Valor Node,Web Host
 valp.org,Valparaiso Broadband Communication Systems,ISP
+valuedrugco.com,Value Drug Company,Healthcare
 valuehost.ru,ValueHost 2.0,ISP
 valuehosted.com,THE Value Hosted,Web Host
 valueweb.com,FloridaNet (ValueWeb),Web Host
@@ -28763,10 +29676,12 @@ vassback.se,Vassbacks Fibernat ek. for,ISP
 vastcomm.net,Vast Communications,ISP
 vastspace.net,Vastspace,Web Host
 vaticanstate.va,Vatican City State,Government
+vatora.uk,Vatora,Web Host
 vats-on.ru,VATS-ON,ISP
 vaultica.com,Vaultica,Web Host
 vautron.de,Vautron Rechenzentrum,Web Host
 vavatec.com.br,Vavatec Telecomunicacoes,ISP
+vavcom.com.ar,VAVCOM,ISP
 vaxxine.com,Vaxxine Computer Systems,ISP
 vayacom.com,Vayacom,ISP
 vayuonline.in,Vayu Online,ISP
@@ -28782,6 +29697,7 @@ vbtelecom.com.br,VB Telecom Com. e Serv. de Info,ISP
 vc3.com,VC3,MSP
 vcbd.net,Virtual Communications,ISP
 vcbl.in,The Visakhapatnam Cooperative Bank,Finance
+vcc.ca,Vancouver Community College,Education
 vcclhosting.com,VCCL Cloud,Web Host
 vccs.edu,Virginia Community College System,Education
 vcdc.co.ir,Vira Cloud DataCenter,Web Host
@@ -28796,6 +29712,7 @@ vcomnet.com.br,V. Comnet Telecom,ISP
 vconnect.com.br,Vconnect Telecom,ISP
 vcsb.com.my,VC Telecoms,ISP
 vctelecom.com.br,Voce Telecomunicações,ISP
+vcu.com,Vantage Credit Union,Finance
 vcu.edu,Virginia Commonwealth University,Education
 vcuhealth.org,VCU Health System Authority,Healthcare
 vd.ch,Canton de Vaud,Government
@@ -28866,6 +29783,7 @@ velocity.com.bd,Velocity Internet,ISP
 velocity.ec,Ecuafibra,ISP
 velocity1.co.uk,Magnet Networks,ISP
 velocitybroadband.in,Velocity Broadband,ISP
+velocitycu.com,Velocity Credit Union,Finance
 velocityhost.com.au,Velocity Host,Web Host
 velocityinternetservices.com,Velocity Internet India Private,ISP
 velocitymsc.com,Velocity Managed Solutions,MSP
@@ -28882,6 +29800,7 @@ veloo.com.br,Veloo Telecom,ISP
 velosternet.com,Victor.net Telecom,ISP
 velosting.com,VP Broadband,ISP
 velotech.net,Velocity Communications,ISP
+velox-systems.com,Velox,MSP
 veloxfiber.com.br,Velox,ISP
 veloxinet.com,Veloxinet,ISP
 veloxnet.net,Veloxnet Internet de Alta Velocidade LTDA - M.E,ISP
@@ -28956,6 +29875,7 @@ verneglobal.com,Verne,Web Host
 vernet.lv,Vernet (Versija),ISP
 verobroadband.com,Vero Fiber,ISP
 verointernet.com.br,Internet de Verdade,ISP
+veros.com,Veros,Real Estate
 versanet.de,1&1 Versatel,ISP
 versatel.de,1&1 Versatel,ISP
 versetelecoms.com,Verse Telecom,ISP
@@ -29107,6 +30027,8 @@ vikingbroadband.com,Viking Broadband,ISP
 vikingcloud.com,VikingCloud,MSP
 vikinghost.nl,Viking Host,Web Host
 vikingitaly.com,Viking Italy,ISP
+vikingturizm.com.tr,Viking Turizm,Travel
+vikkibank.vn,Vikki Digital Bank,Finance
 vikscom.net,Vikscom,ISP
 vilanet.com.br,Saner Telecom Informatica,ISP
 vilanet.net,Vilanet Telecom. Serv. E Reparo DE Fortaleza,ISP
@@ -29133,6 +30055,7 @@ vinertelecom.ua,Viner Telecom,ISP
 vinnitsa.com,Veco Vinnitsa,ISP
 vintekvietnam.vn,Vintek Viet NAM Technology Telecom,ISP
 vinu.edu,Vincennes University,Education
+vinylinteractive.com,Vinyl Interactive,Marketing
 violatel.com,Viola Communications,ISP
 vip.hr,A1,ISP
 vipconnect.com.br,VIP Connect Telecom,ISP
@@ -29159,6 +30082,7 @@ vipturbo.com.br,VIPTURBO,ISP
 vipvilhena.com.br,Vip Vilhena,ISP
 vipway.net.br,VIPWAY,ISP
 vipy.hu,VIPY.hu,Web Host
+virair.co.uk,VirAir Networks,ISP
 virginia.edu,The University of Virginia,Education
 virginia.gov,The State of Virginia,Government
 virginia529.com,Virginia College Savings Plan,Education
@@ -29252,18 +30176,22 @@ vit.com.tr,VITAL TEKNOLOJI TELEKOMUNIKASYON BILGISAYAR HIZMETLERI VE SANAYI TICA
 vit.de,RZV - Rechenzentrum Verden,Web Host
 vit.ua,Video Internet Technologies,ISP
 vitalink.us,VITALink,ISP
+vitalityworks.net,Vitality Works,Manufacturing
 vitalnetprovedor.com.br,Vital Net,ISP
 vitaltelecom.net,Vital Telecom,ISP
 vitalwerks.com,Vitalwerks Internet Solutions,ISP
+vitas.com,VITAS Healthcare,Healthcare
 vitelcom.net,ONE Communications,ISP
 vitele.com.ua,Vitelecom,ISP
 vitelglobal.in,Vitel Global India,ISP
 vitelwireless.com,Vitel Wireless,ISP
+viterra.com,Viterra,Agriculture
 vitoria.es.gov.br,Municipio DE Vitoria,Government
 vitorianet.com.br,Solutions Telecom Provedor de Internet,ISP
 vitorianetworks.com.br,Vitoria Networks Internet Fibra,ISP
 vitroconnect.de,vitroconnect,ISP
 vitrodc.com,Vitro,Web Host
+vittia.com.br,Vittia,Agriculture
 viuinternet.com.br,A melhor internet de fibra óptica do litoral! | Viu Internet,ISP
 viunet.net,Viunet Provimento DE Acesso A Internet,ISP
 viutelecom.com.br,Viu Internet,ISP
@@ -29340,6 +30268,7 @@ vncloudtech.vn,Viet NAM Cloud Technology Joint Stock Company,ISP
 vndata.vn,VNDATA,Web Host
 vndhost.com,Visual Net Design LC,ISP
 vndic.com,D.I.C Viet Nam Technology Joint Stock Company,Web Host
+vndirect.com.vn,VNDirect Securities,Finance
 vnet.com.br,Ictus (V.Net Brasil),ISP
 vnet.com.ve,VIGINET C.A,ISP
 vnet.sk,VNET Slovakia,ISP
@@ -29374,7 +30303,9 @@ voainternet.com.br,Voa Internet,ISP
 voanet.com.br,VOANET,ISP
 voartelecom.com.br,Voar Telecom,ISP
 vobissgh.com,Vobiss Solutions,ISP
+vocalnet.srv.br,Vocal NET Telecomunicações,ISP
 vocalocity.com,Vonage Business (Vocalocity),SaaS
+vocalogic.com,DialPath,Retail
 vocetelecom.com.br,Voce Telecom,ISP
 vocom.com,Vocom International,ISP
 voconnect.co.za,VOffice Solutions,ISP
@@ -29425,6 +30356,7 @@ voice-com.ru,Voice Communication,ISP
 voicecorp.com.br,Voice,ISP
 voicehost.co.uk,VoiceHost,PaaS
 voiceland.gr,Voiceland,ISP
+voicelogic.io,Voice Logic,ISP
 voicenetpulse.com,Voice Net Pulse,ISP
 voicetecuk.com,Voicetec,ISP
 voimar.com,VOIMAR Telecoms,ISP
@@ -29507,6 +30439,7 @@ vosnet.ru,Home.Net Voskresensk,ISP
 vossfiber.no,Voss Fiber,ISP
 vostrom.com,VOSTROM,MSSP
 vostron.com,Vostron,Web Host
+votacall.com,Votacall,ISP
 vote4mentalhealth.org,NAMI,Healthcare
 votervoice.net,VoterVoice,SaaS
 vovidacommunications.com,Vovida Communications,ISP
@@ -29576,6 +30509,7 @@ vsx.com.br,VSX Networks,ISP
 vt.edu,Virginia Tech,Education
 vtal.com,V.tal,ISP
 vtb-bank.by,CJSC VTB Bank (Belarus),Finance
+vtb-bank.kz,Subsidiary VTB Bank JSC Kazakhstan,Finance
 vtb.am,VTB Armenia Bank,Finance
 vtb.ge,VTB Bank Georgia,Finance
 vtb.ru,VTB Bank (Public Joint-Stock Company),Finance
@@ -29623,6 +30557,7 @@ vvsu.ru,Federal State Budgetary Educational Institution of Higher Education Vlad
 vwfs.de,Volkswagen Bank,Finance
 vwhs.org,Valley-Wide Health,Healthcare
 vwnet.com.br,VWNET Telecom,ISP
+vwu.edu,Virginia Wesleyan University,Education
 vxbits.net,VXbits,Web Host
 vxchnge.com,Vxchnge,Web Host
 vxfiber.com,VX Fiber,ISP
@@ -29634,6 +30569,7 @@ vyperhosting.com,Vyper Hosting,Web Host
 vytec.com.br,Vytec | Consultoria para Provedores de Internet,ISP
 vyvebroadband.com,Vyve Broadband,ISP
 vyvebroadband.net,Vyve,ISP
+vzch.com,VZ Corporate Services,Finance
 w-ix.com,W-IX,ISP
 w-net.info,Wnet Tellecom,ISP
 w2atelecom.com.br,W2A Telecom,ISP
@@ -29647,6 +30583,7 @@ wabash.com,Wabash Mutual Telephone Company,ISP
 wabash.net,Wabash Independent Networks,ISP
 wabroadband.com,Washington Broadband,ISP
 wachter.com,Wachter Technology Solutions,Healthcare
+wacotx.gov,City of Waco,Government
 wacowifi.com,Waco Wifi,ISP
 wad.pl,WadowiceNet,ISP
 wadax-sv.jp,WADAX,Web Host
@@ -29662,6 +30599,7 @@ waicore.com,WAIcore,ISP
 waikato.ac.nz,University of Waikato,Education
 wainet.co.jp,Cable Media WaiWai,ISP
 wakayama-u.ac.jp,Wakayama University,Education
+wake.gov,Wake County Government,Government
 wakewireless.com,Wake Wireless,ISP
 wal-mart.com,Walmart,Retail
 walcom.com.do,Walcom Es La Red,ISP
@@ -29671,10 +30609,12 @@ walgreens.com,Walgreens Co,Healthcare
 walhallacloud.com,Walhalla Cloud,Web Host
 walinginternet.net.np,Waling Internet,ISP
 wallawalla.edu,Walla Walla University,Education
+wallgrind.nl,Wallgrind Solutions,Web Host
 walmartstores.com,Walmart,Retail
 walshcollege.edu,Walsh College | Walsh,Education
 wanadoo.fr,Orange,ISP
 wananchi.com,Wananchi Group,ISP
+wananga.ac.nz,Twwoa,Education
 wanao.com,Wanao,SaaS
 wancom.net.pk,Wancom Pakistan,ISP
 wandoor.co.in,Wandoor Multiventures,ISP
@@ -29714,6 +30654,7 @@ wasp-sa.co.za,Wireless Associate Service Providers CC,ISP
 watchcomm.net,Watch Communications,ISP
 watchfront.co.uk,Watchfront,ISP
 wateen.com,Wateen,ISP
+waterloo.ca,City of Waterloo,Government
 waterloofiber.com,Waterloo Fiber,ISP
 watrust.com,Washington Trust Bank,Finance
 wattagehosting.com,Wattage Hosting,Web Host
@@ -29766,10 +30707,14 @@ wbgtelecom.com.br,WBG Telecom,ISP
 wbhcp.com,Williams Bros Pharmacy,Healthcare
 wbmx.com.br,Webmax Tecnologia,ISP
 wbr.net.br,WBR Telecom,ISP
+wbrcouncil.org,West Baton Rouge Parish Council,Religion
 wbrnet.com.br,WBR Net,ISP
 wbroadband.net.au,Wholesale Communications Group,ISP
 wbtelecom.net.br,WB Telecom,ISP
 wca-ti.com.br,WCA Telecom,ISP
+wcasd.net,West Chester Area School District,Education
+wcc.com.mm,Goal Link ISP,ISP
+wcc.nsw.edu.au,William Branwhite Clarke College,Education
 wccta.com,Wccta,ISP
 wci.com,Allstream,ISP
 wcminternet.com.br,Grupo WCM net,ISP
@@ -29783,6 +30728,7 @@ wcupa.edu,West Chester University,Education
 wcvt.com,Waitsfield and Champlain Valley Telecom,ISP
 wd.net.nz,PC Soft,ISP
 wd6.net,WD6.NET,ISP
+wdc.govt.nz,Whangarei District Council,Government
 wdc.pl,Warsaw Data Center Sp. z o.o.,Web Host
 wdide.com.br,W.Dide Telecom,ISP
 wdm.pl,WDM Sp. z o.o.,ISP
@@ -29935,6 +30881,7 @@ webzi.mx,Webzi,Web Host
 webzilla.com,Webzilla,Web Host
 webzine1.com,Webzine Online,Web Host
 webzineonline.com,Webzine Online,Marketing
+webzone.net.au,"Webzone Internet, Internet Service Provider",ISP
 wecenergygroup.com,WEC Energy,Utilities
 weclix.com.br,Weclix,ISP
 wecode.ro,WeCode,Web Host
@@ -29952,6 +30899,7 @@ wehaveservers.com,WeHaveServers.com,Web Host
 wehost.gg,WeHost,Web Host
 wehost.ro,Digital Hosting,Web Host
 weinternet.club,VG NET Serviços DE Telecom,ISP
+weissasset.com,Weiss Asset Management,Finance
 weissinternet.com,Weiss Internet,ISP
 wektormedia.pl,Światłowodowe multimedia dla domu Wektormedia,ISP
 wekudata.se,Wekudata,IaaS
@@ -29963,6 +30911,7 @@ welinkbroadband.com,Welink,ISP
 well-comm.ru,Wellcom,ISP
 well-telecom.ru,WellTelecom,ISP
 well.com,The WELL,Email Provider
+wellborn.com,Wellborn Cabinet,Manufacturing
 wellbrasil.com,Inorpel Ind. Nordestina de Prod. Eletricos,ISP
 wellesley.edu,Wellesley College,Education
 wellesleyma.gov,"Wellesley, MA",Government
@@ -29974,6 +30923,7 @@ wellserver.ru,WellServer,Web Host
 wellsfargo.com,Wells Fargo,Finance
 wellstar.org,Wellstar Health System,Healthcare
 weltel.co.za,Weltel,ISP
+wemabank.com,Wema Bank Plc,Finance
 wemacom-breitband.de,WEMACOM Breitband,ISP
 wemaconnect.de,Wemaconnect,ISP
 wenet.lviv.ua,IE Khoma Yury Romanovich,ISP
@@ -29987,6 +30937,7 @@ weserve.nl,Weserve,ISP
 weservit.nl,RouteLabel V.O.F,IaaS
 wesleyan.edu,Wesleyan University,Education
 wesleyanschool.org,Wesleyan School,Education
+wesleycollege.net,Wesley College,Education
 wessexinternet.com,Wessex Internet,ISP
 west.com.br,Wtl Telecomunicacoes (WEST),ISP
 westbrook.ms,Westbrook Construction,Construction
@@ -30006,6 +30957,7 @@ westernedge.in,Westernedge Telecommunications,ISP
 westernit.com,Western IT,ISP
 westernu.edu,Western University OF Health Sciences,Healthcare
 westex.coop,Wes-Tex Telecommunications,ISP
+westgatecomputers.com,Westgate Computers Data Center,Web Host
 westherts.ac.uk,West Herts College,Education
 westhost.com,Westhost.com,Web Host
 westianet.com,Western Iowa Networks,ISP
@@ -30037,6 +30989,7 @@ wfprovedor.com.br,Coladini & Coladini,ISP
 wft.net.br,WFT,ISP
 wfu.edu,Wake Forest University,Education
 wgeld.org,City of Westfield (WG&E),Utilities
+wgh.org,Warren General Hospital,Healthcare
 wginfor.com,Gutiery E Martins,ISP
 wgo.com.br,WGO,ISP
 wgrtelecomunicaciones.com,WGR Telecomunicaciones Valle DE LOS Pedroches,ISP
@@ -30100,6 +31053,7 @@ wia.cz,WIA Telecommunications,ISP
 wialus.co.nz,Wialus Solutions,ISP
 wiartech.com,WIAR Technologies,ISP
 wiatel.com,Western Iowa Telephone Association (A Cooperative),ISP
+wiaw.net,Western Iowa Wireless,ISP
 wiber.com.ar,Wiber Internet,ISP
 wiber.es,MismeNet Telecomunicaciones,ISP
 wiber.it,WIBER connect different,ISP
@@ -30166,6 +31120,7 @@ wifilinks.es,Wifilinks,ISP
 wifimax.pl,WifiMax,ISP
 wifimaxcolombia.com.co,WIFIMAX COLOMBIA,ISP
 wifimm.it,Cosimo Vitale trading as WIFI MULTIMEDIA,ISP
+wifimotored.com.mx,Motored Fibra,ISP
 wifine.ru,Intercity (Wifine),ISP
 wifinetcom.net,Wifinetcom,ISP
 wifinettelecom.com.br,Wi-Fi NET Telecomunicacoes E Multimidia SCM,ISP
@@ -30232,6 +31187,7 @@ willistonfl.org,Williston Fiber,ISP
 willnet.org,WilliNet,ISP
 willoweb.net,WilloWeb,ISP
 willynet.com.br,WILLYNet,ISP
+wilmu.edu,Wilmington University,Education
 wilnet.com.br,W F Santos,ISP
 wilor.es,Wilor,ISP
 wilson-creek.net,Wilson Creek Communications,ISP
@@ -30274,6 +31230,7 @@ winforbyte.com.br,Winforbyte Telecom,ISP
 wingbank.com.kh,Wing Bank,Finance
 wingmen.dk,Wingmen,MSP
 wingnet.com.br,WINGNET,ISP
+wingnet.net,WingNET Internet Services,ISP
 wingnetwork.co.in,Vua Internet Services,ISP
 wingo.ch,Wingo,ISP
 wingsnet.in,Wingsnet Internet,ISP
@@ -30358,6 +31315,7 @@ wispinternet.com.br,Wisp Solucoes DE Acesso,ISP
 wispline.ru,Wispline,ISP
 wispnet.gr,Wispnet,ISP
 wispone.it,Wispone,ISP
+wisponline.ca,WISP Internet Services,ISP
 wispoto.com,Wispoto,ISP
 wisprenn.com,WISPRENN,ISP
 wispsolution.com.ar,Wisp Solution,ISP
@@ -30384,6 +31342,7 @@ wizbiz.net.nz,WIZwireless,ISP
 wizmoworks.com,Wizmo,MSP
 wizofis.com,Communication Construction Services,ISP
 wizon.es,Wizon Telecom,ISP
+wiztech.biz,Wiztech Internet,ISP
 wjbtn.com,The Western James Bay Telecom Network,ISP
 wjhtedu.com,Beijing WangJu,ISP
 wjinternet.com.br,WJ internet,ISP
@@ -30399,6 +31358,7 @@ wlantech.pl,PTU WLAN-TECH PLUS,ISP
 wlatelecom.com.br,WLA Telecom,ISP
 wlenet.com.br,Wlenet,ISP
 wletc.com,Wireless Etc,ISP
+wlfoods.com,West Liberty Foods,Food
 wlink.com.np,WorldLink Communications,ISP
 wlinks.com.br,Wlinks Internet,ISP
 wlinktelecom.net.br,Wlink Provedor DE Acesso A Redes DE Telecom,ISP
@@ -30414,6 +31374,7 @@ wmas.nhs.uk,West Midlands Ambulance Service NHS Foundation Trust,Education
 wmatera.com.br,WMatera Telecom,ISP
 wmc-si.pl,WMC Systemy Informatyczne,ISP
 wmn.net.id,Wijaya Mandiri Network,ISP
+wmq.org.au,Wesley Mission Queensland,Healthcare
 wms.cz,CEZNET (WMS),ISP
 wmservice.com.do,WMService,ISP
 wmtel.net,WMTel,ISP
@@ -30439,7 +31400,9 @@ wntellecom.net.br,WN Tellecom,ISP
 wntpr.net,WorldNet Telecommunications,ISP
 wobcom.de,Wobcom Wolfsburg,ISP
 wockhardt.com,Wockhardt,Healthcare
+wodongatafe.edu.au,Wodonga TAFE,Education
 wofford.edu,Wofford College,Education
+wojsko-polskie.pl,Polish Air Force University,Education
 wolast.com,Wolast Technologies,Web Host
 wolfpaw.com,Wolfpaw Data Centres,Web Host
 wolfram.com,Wolfram,SaaS
@@ -30455,6 +31418,7 @@ wonogirikab.go.id,Dinas Komunikasi dan Informatika Kabupaten Wonogiri,Government
 wonosobokab.go.id,Pemerintah Kabupaten Wonosobo,Government
 woodforest.com,Woodforest National Bank,Finance
 woodside.com.au,Woodside Energy,Industrial
+woodsrogers.com,Woods Rogers,Legal
 woodstocktel.net,Woodstock Communications,ISP
 woodward.edu,Woodward Academy,Education
 woodynet.net,WoodyNet (Packet Clearing House),Nonprofit
@@ -30515,6 +31479,7 @@ worldshore.com,Worldshore Networks,ISP
 worldspacebs.com,Wsns,ISP
 worldspice.net,WorldSpice,ISP
 worldstream.com,Worldstream,Web Host
+worldvision.com.au,World Vision Australia,Nonprofit
 worldwifi.com.br,Worldwifi,ISP
 worldxambioa.com.br,Worldxambioa Informatica,ISP
 worria.com,Cloudie,Web Host
@@ -30588,6 +31553,7 @@ wvinternet.com,SecureNet,ISP
 wvnet.at,WVNET Information und Kommunikation,ISP
 wvnet.edu,WVNET,Education
 wvnfibra.com.br,WVN Fibra | Sua próxima conexão,ISP
+wvpa.com,Wabash Valley Power Association,Utilities
 wvsom.edu,WV School of Osteopathic Medicine,Education
 wvstateu.edu,West Virginia State University,Education
 wvu.edu,West Virginia University,Education
@@ -30595,6 +31561,7 @@ wvusd.k12.ca.us,Walnut Valley Unified School District,Education
 wvw-wifi.com,WvW,ISP
 ww-net.pl,WW-Net,ISP
 wwctelecom.com.br,WWC Telecom,ISP
+wwcusa.com,World Wide Communications,ISP
 wwest.net,WWEST Communications,ISP
 wwt.net,West Wisconsin Telcom,ISP
 wwu.edu,Western Washington University,Education
@@ -30677,6 +31644,7 @@ xhost.cl,XHost,Web Host
 xiangao.com.hk,Xiangao International Telecommunication,ISP
 xiber.net,Xiber,ISP
 xigentsolutions.com,Xigent,MSP
+xignux.com,Xignux,Food
 xilinx.com,Xilinx,Manufacturing
 ximbo.com,XIMBO Internet,ISP
 xinet.com.mx,Xinet,MSP
@@ -30729,6 +31697,7 @@ xserver.ua,XServer,Web Host
 xsinfosol.com,XS Infosol,SaaS
 xta.cat,Xarxes de Telecomunicacions Alternatives,ISP
 xtelonline.com,XTEL Communications,ISP
+xtenit.com,Xtenit,Marketing
 xtfibra.com.br,XT Fibra,ISP
 xtglobal.vg,XT Global Networks,ISP
 xtium.com,Xtium,MSP
@@ -30768,6 +31737,7 @@ yahoo.com,Yahoo,Email Provider
 yahoo.in,Thangam Communication,ISP
 yahooinc.com,Yahoo,Email Provider
 yahsat.ae,Yahsat,ISP
+yakimawa.gov,City of Yakima,Government
 yakotelecom.ro,Yako Telecom,ISP
 yale.edu,Yale University,Education
 yamagata-u.ac.jp,Yamagata University,Education
@@ -30827,6 +31797,7 @@ yigithosting.com.tr,Yigit Hosting Bilisim E-Ticaret Gida Sanayi Ticaret Limited 
 yildiz.edu.tr,Yildiz Teknik Universitesi,Education
 yinyer.mx,Yinyer,ISP
 yipi.com.br,YIPI Telecom,ISP
+yirehnetworks.com,Yireh Networks Services,ISP
 yisu.com,Yisu Cloud,Web Host
 ykc.com,Y K Communications,ISP
 ykwc.com,Yellowknife Wireless,ISP
@@ -30874,6 +31845,7 @@ yourconnect.com,Yourconnect,Web Host
 yourhosting.nl,Yourhosting,Web Host
 yourhostingaccount.com,Newfold Digital,Web Host
 yourmailgateway.de,netcup,Web Host
+yournet.com.br,Your NET Servicos DE Telecomunicacoes,ISP
 yournetcommunications.net,Your Net Communications,ISP
 yournorthland.com,Vyve Broadband,ISP
 youroneit.com,OneIT,Web Host
@@ -30945,9 +31917,11 @@ zamanitelecom.com,Zamani Telecom Niger SA,ISP
 zamix.com.br,Zamix Multiplay,ISP
 zamnet.ec,ZamNet,ISP
 zamnet.zm,Zamnet,ISP
+zamorano.edu,Universidad Zamorano,Education
 zamren.zm,ZAMREN,Education
 zamtech.com.br,Zamtech Fibra Óptica,ISP
 zamtel.zm,Zamtel,ISP
+zanaco.co.zm,Zambia National Commercial Bank Plc,Finance
 zanagroup.net,Zana Mohammed Mahdi A.Rahman company for Internet Service Provider,ISP
 zannatinternational.com,ZANNAT INTERNATIONAL,ISP
 zaoitt.ru,ITT,ISP
@@ -31043,10 +32017,12 @@ zgh.cl,Grupo ZGH,Web Host
 zhengxinghk.com,Zhengxing Technology HK,Web Host
 zhigulinet.ru,Zhigulevsk Cable Network,ISP
 zhouyitelecom.org,ZhouyiSat Communications,ISP
+zhu.edu.ua,Classic Private University,Education
 zhukovsky.net,Оператор связи Zhukovsky.Net,ISP
 ziagotechnologies.com,Ziago Technologies,MSP
 zicom.pl,Zicom Next,ISP
 ziconet.com.br,Ezequiel DOS Santos Alves - Internet,ISP
+zicta.zm,Zambia Information and communication Technology Authority,ISP
 zictia.go.tz,Zanzibar Information Communication Technology Infrastructure Agency (ZICTIA),ISP
 zid.com,ZiD Internet,ISP
 ziggo.nl,Ziggo,ISP
@@ -31059,9 +32035,11 @@ zinca.com,Zinca (Cesena Net),ISP
 zineprovedor.com.br,Zine Telecomunicações Provedor,ISP
 zinet.co.id,Zinet Media Nusantara,ISP
 zingfibre.co.za,Zing Fibre,ISP
+zingisp.com,Zing Broadband,ISP
 zinia.co.za,Zinia,ISP
 zinniatel.es,Zinnia Telecomunicaciones,ISP
 zinoxtechnologies.com,Zinox Technologies,MSP
+zinx.co.zw,Zimbabwe Internet Exchange,ISP
 zionbb.net,Zion Broadband,ISP
 zionsbancorp.com,Zions Bancorporation,Finance
 ziosting.com,Ziosting,Web Host
@@ -31120,6 +32098,7 @@ zoomnetprovedor.com.br,Zoom NET,ISP
 zoomtelcom.net,Zoom Telcom,ISP
 zoopnet.com.br,ZoopNet,ISP
 zooy.com.mx,Fibra A LA CA,ISP
+zou.ac.zw,ZOU,Education
 zp.edu.ua,Zaporizhzhia Polytechnic National university,Education
 zray.net,ZRAY Technologies,ISP
 zrlnet.com,ZRL Provedor DE Internet,ISP
@@ -31151,6 +32130,7 @@ zuttel.com.br,Zuttel fibra,ISP
 zux.net.br,Zux Internet,ISP
 zvcturbonet.com.br,ZVC Turbo Net,ISP
 zvitelecom.ru,ZVI Telecom,ISP
+zvonok.com,"Privet, Internet",ISP
 zwmedia.pl,ZW MEDIA,ISP
 zxonlineltd.com,Zx Online,ISP
 zybosys.com,Domain Registration India – Zybosys,Web Host

--- a/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
+++ b/parsedmarc/resources/maps/known_unknown_base_reverse_dns.txt
@@ -19,6 +19,7 @@
 1001darknights.com
 10099.com.cn
 100derece.com
+100percentit.com
 1010data.com
 101voice.com
 103-inspitele.com
@@ -60,6 +61,7 @@
 1ans.ru
 1api.net
 1baza.ru
+1c.co.nz
 1c.ru
 1cb.kz
 1click.al
@@ -84,6 +86,7 @@
 2-berega.ru
 2-way.nl
 2000cn.com.au
+2000net.it
 2012plus.pl
 203888.xyz
 205280.xyz
@@ -127,6 +130,7 @@
 2ghz.net
 2gis.com
 2gms.com
+2go.com.ph
 2gotrade.com
 2hip.nl
 2k.com
@@ -220,6 +224,7 @@
 4lan.eu
 4life.com
 4ms.co.uk
+4netpr.com
 4networks.com.br
 4over.com
 4pay.ro
@@ -269,6 +274,7 @@
 69systems.com
 6com.net
 6connect.net
+6project.org
 7-eleven.com
 702com.net
 702netops.net
@@ -284,14 +290,17 @@
 7gis.ru
 7i.net.sa
 7ion.co.id
+7km.net
 7road.com
 7skynet.id
 7solution.ch
 7space.com
 7strawby.com
+7utra.ru
 7vibes.co
 8-wire.net
 8.to
+800loanmart.com
 8086.net
 81890.net
 8451.com
@@ -322,6 +331,7 @@ a-h-s.com.pl
 a-link.net.ua
 a-m.hu
 a-mobile.biz
+a-sms.net
 a-soft.si
 a-t-g.com
 a-teknoloji.com.tr
@@ -348,6 +358,7 @@ aaac.pk
 aaacooper.com
 aaae.org
 aaanortheast.com
+aaarena.com
 aaas.org
 aaawirelessit.com
 aab-edu.net
@@ -364,6 +375,7 @@ aadr.ro
 aafcu.com
 aafes.com
 aaff.nl
+aafintl.com
 aahs.org
 aai.aero
 aal.com.au
@@ -378,6 +390,7 @@ aams4.jp
 aams5.jp
 aams8.jp
 aamva.org
+aanetworks.org
 aaniin.net
 aansysnetwork.com
 aaran.cloud
@@ -391,6 +404,7 @@ aartsen.com
 aashto.org
 aass.sm
 aatrix.com
+aau.org
 aaylex.ro
 ab-net.cz
 ab.gr
@@ -439,6 +453,7 @@ abicom.fr
 abidsolution.com
 abifiber.net
 abileneisd.org
+abilitybusiness.com
 abilitype.net.br
 abinbevefes.com
 abiproduct.ru
@@ -480,6 +495,7 @@ absbackup.com
 absci.com
 abscloud.eu
 absenterprises.co.in
+absgroup.ru
 absinv.com
 absolute-cs.com
 absolute-performance.com
@@ -560,6 +576,7 @@ accruent.com
 acctn.com.ph
 accu-mold.com
 accurantcloudservices.com
+accuray.com
 accurishosting.ca
 accuwebhosting.com
 acdlabs.com
@@ -578,6 +595,7 @@ acemicroservices.com
 acenet.al
 acenet.net.id
 acenetbj.com.br
+acer.com
 acero.coop
 acerpro.com
 acespower.com
@@ -600,12 +618,14 @@ achievacu.com
 achim.ru
 achmea.nl
 achnet.am
+achow101.com
 aci.it
 acibadem.com.tr
 acibademsistina.mk
 acinternet.net.br
 acknowledge.nl
 acl.ng
+aclcargo.com
 acli.com
 aclibrary.org
 acm.media
@@ -644,6 +664,7 @@ acs-hartmann.de
 acs-solutions.de
 acs.ao
 acs.edu.lb
+acs.org
 acsata.com
 acsltd.com
 acswineto.co.id
@@ -681,6 +702,7 @@ activepage.com.br
 activeport.com.au
 activesoft.ro
 activfinancial.com
+activia.com.ar
 activision.com
 activium-id.com
 activo.ca
@@ -772,6 +794,7 @@ adhifanashasaqeena.id
 adibisa.net
 adicomsoft.ro
 adidas-group.com
+adidas.com
 adie.sn
 adilink.id
 adinanet.xyz
@@ -809,6 +832,7 @@ admincomp.com
 adminit.cz
 admiral.hr
 admiralmarkets.ee
+admis.com
 admkrsk.ru
 admnsk.ru
 admtechinc.com
@@ -818,6 +842,7 @@ adnsolutions.net
 adopt.su
 adorama.com
 adoromonitoramento.com.br
+adp.com.br
 adpdigital.com
 adrad.com
 adrana.ro
@@ -835,6 +860,7 @@ adrtel.it
 ads-securities.com
 adsaber.uz
 adsalarm.com
+adsinc.net
 adslplus.ch
 adsmyanmar.com
 adsn.fr
@@ -867,6 +893,7 @@ advancedicucare.com
 advancedrad.com
 advancedridingtechniques.info
 advancedsoftware.eu
+advancedtech.com
 advancial.org
 advania.co.uk
 advania.dk
@@ -898,18 +925,21 @@ aeb.am
 aecc.com
 aeci.org
 aecom.com
+aedas.com
 aedilweb.com
 aegeanair.com
 aegeurope.com
 aegis00.net
 aegisglobal.com
 aegisisc.com
+aegislink.com
 aegm.com
 aegon.ro
 aegonpensii.ro
 aegvision.com
 aegworldwide.com
 aeis.ch
+ael.com
 aelbra.org.br
 aem.ro
 aemaknet.com.br
@@ -967,6 +997,7 @@ afblakemore.com
 afcomsat.com
 afd.fr
 afe-solutions.com
+affco.co.nz
 affidea.com
 affidea.ro
 affiliated.com
@@ -984,12 +1015,14 @@ aflt-systems.ru
 afni.com
 afoc.org.ar
 afoyi.com
+afphabitat.cl
 afradata.email
 afreenet-bf.com
 afrenit.com.bd
 afri-com.net
 afribone.net.gn
 africa-ren.cam
+africanbank.co.za
 africanemployers.com
 africell.ao
 africell.cd
@@ -1041,6 +1074,7 @@ agid.gov.it
 agile-1.com
 agilenaas.com
 agilenetwork.com.br
+agilerack.com
 agili.inf.br
 agilimo.de
 agilinformatica.com
@@ -1055,10 +1089,12 @@ aginsurance.be
 agios.com
 agip.com
 agirc-arrco.fr
+agkconsulting.com
 aglc.ca
 agm.com
 agmonitoring.com
 agnet.com.br
+agnicoeagle.com
 agnitio.no
 agnity.com
 agnsbroadband.in
@@ -1071,6 +1107,7 @@ agoravita.com
 agoscorporate.it
 agp.com
 agps-poitoucharentes.com
+agra.org
 agram-brokeri.hr
 agrambanka.hr
 agrein.com.ua
@@ -1084,11 +1121,13 @@ agroeco.ru
 agronetlider.net.br
 agroprosperis.com
 agroredes.net.br
+agroseguro.es
 agrosoyuz.com
 agrostroj.cz
 agrupp.com
 ags.school.nz
 agsconnect.com.br
+agsea.com
 agsindia.com
 agsistemas.net.ar
 agti.co.id
@@ -1105,11 +1144,13 @@ agyonet.com.br
 aha.ru
 ahead.com
 ahg.af
+ahlkripto.com
 ahmadiyya.de
 ahml.ru
 aholck.net
 ahost.eu
 ai-freight.com
+ai-media.tv
 ai.co.uk
 ai270.net
 ai33.ru
@@ -1119,6 +1160,7 @@ aia.com.my
 aia.gr
 aib.ie
 aicgroup.biz
+aicm.com.mx
 aiconline.com
 aics.ad.jp
 aid.se
@@ -1154,6 +1196,7 @@ airalo.com
 airanet.id
 airasia.com
 airastana.com
+airbaltic.com
 airbeam.it
 airbites.net
 airbnb.com
@@ -1228,6 +1271,7 @@ aitacargas.uy
 aitanet.com.br
 aitch.systems
 aitelecom.net
+aiti-kace.com.gh
 aiti.id
 aitire.cloud
 aitlbd.com
@@ -1237,7 +1281,9 @@ aitupay.kz
 aity.ch
 aiu3.net
 aiut.com.pl
+aixp.ca
 aixtra.net
+aizdevums.lv
 aja.com
 ajantunes.com
 ajaxmediatech.com
@@ -1287,6 +1333,7 @@ akingump.com
 akjindo.com
 akkgroupinc.com
 akkyhosting15.mx
+akl-airport.co.nz
 akmlink.id
 aknadeliverability.com
 aknet.net.br
@@ -1322,6 +1369,7 @@ aktiftech.com
 aktivcom.net
 akto.com.br
 akton.net
+akumin.com
 akunacapital.com
 akvanet.com
 akwa.fr
@@ -1338,6 +1386,7 @@ alacriynetsystem.net
 aladdin.ru
 alagas.net
 alamdaur.id
+alamedaalliance.org
 alamincomputers.net
 alanit.ru
 alanmadsen.com
@@ -1377,6 +1426,7 @@ alcen.id
 alchemy-global.net
 alchemy.net
 alchemyvps.com
+alcit.com
 alcl.cloud
 alcoa.com
 alcolac.com.au
@@ -1401,6 +1451,7 @@ alendei.com
 aleragroup.com
 alerce-group.com
 alert-group.nl
+alertalarmhawaii.com
 alesolutions.com
 alesund.kommune.no
 alet-broker.ru
@@ -1481,6 +1532,7 @@ alkonhosting.net
 all-for-one.com
 all.com.br
 all42.it
+allantgroup.com
 allaria.com.ar
 allay-studios.com
 allcloud.cc
@@ -1488,6 +1540,7 @@ allconnect.com.br
 allconnections.com.br
 allegacyfcu.org
 alleghenycounty.us
+alleghenycourts.us
 alleghenytechnologies.com
 allegiance-health.com
 allegiantair.com
@@ -1497,6 +1550,7 @@ allegro.eu
 allegro.pl
 allegronet.co.il
 alleima.com
+allenco.com
 allenisd.org
 allentownsd.org
 allergan.com
@@ -1528,12 +1582,14 @@ allianzinvestors.com
 alliedbusiness.jp
 alliedint.com
 allieditservices.com
+alliedpilots.org
 alliedtelesis.co.nz
 alliex.com
 allinteractive.com.au
 allmobilevideo.com
 allneins.com
 allness.it
+allo.com.bd
 allo.ua
 allofiber.net
 allon.info
@@ -1631,6 +1687,7 @@ alt.ru
 alta-lingua.com
 alta.kommune.no
 alta.ru
+altacondominium.com
 altagas.ca
 altaiholod.ru
 altairline.net
@@ -1646,6 +1703,7 @@ altaworx.com
 altayer.com
 altec.com
 altec.com.ar
+altech.co.za
 altechsistemindonesia.com
 altecnets.com
 altegronet.ru
@@ -1657,6 +1715,7 @@ alteregomedia.org
 alteris.pl
 altermundi.net
 alternatifbank.com.tr
+alternativa.net.ar
 alternativaip.net.br
 alternativatelecom.net.br
 alternet.com.br
@@ -1674,6 +1733,7 @@ alto.co.id
 altonetz.net
 altopia.com
 altra.org
+altron.com
 altron.cz
 altron.ua
 altrondata.net
@@ -1686,6 +1746,7 @@ altunhost.com
 altuscloud.sg
 altushost.com
 altvfx.com
+alukoenigstahl.com
 aluminati.org
 aluminumpipetubing.com
 alus.co.id
@@ -1709,7 +1770,9 @@ ama-networx.net
 ama.net.id
 ama.pf
 amaazingcoach.com
+amadeus.co.in
 amadeus.com
+amag.at
 amag.ch
 amaisd.org
 amalyze.com
@@ -1735,6 +1798,7 @@ amber-light.de
 amberbit.lv
 amberstudio.com
 amberway.bz
+ambest.com
 ambientevirtual.net.br
 ambientia.fi
 ambifox.de
@@ -1752,6 +1816,7 @@ amcon.com
 amctheatres.com
 amcwebsoft.ro
 amd.net.id
+amdocs.cl
 amedia.pl
 amediasolutions.fr
 ameeramegabuana.co.id
@@ -1788,6 +1853,7 @@ americantours.com
 americascu.org
 americats.co
 amerigas.com
+ameripharminc.com
 ameriprise.com
 ameripriseadvisors.com
 amerisafe.net
@@ -1798,7 +1864,9 @@ amfm.live
 amforc.com
 amg.net.id
 amgen.com
+amgh.com
 amgrkrd.ru
+amhealthsystems.com
 amherst.com
 amhinformatica.es
 ami.com
@@ -1834,11 +1902,13 @@ amostv.net
 amostv.ru
 amount.com
 amparex.com
+ampath.co.za
 ampersand.it
 ampf.com
 amphenol.com
 amplefuture.com
 amplightventures.com
+amplisys.ca
 amplusserver.info
 ampnet.net
 ampr.be
@@ -1849,9 +1919,11 @@ amrest.eu
 amret.com.kh
 amrnetbd.com
 ams-net.de
+ams.co.nz
 ams.com
 amsalem.com
 amscloud.co.id
+amscot.com
 amsnet.pl
 amssystem.pl
 amst.co.at
@@ -1890,6 +1962,7 @@ anaheim.net
 anahotels.ro
 anais-it.com
 analogi.co.id
+analysisgroup.com
 analyticall.com.au
 anambas.net
 ananyacomp.in
@@ -1904,12 +1977,14 @@ ancel.net.uy
 ancert.com
 ancestry.com
 anchin.com
+anchoragecap.com
 anchorfundhub.com
 anchorhocking.com
 ancidigitale.it
 ancom.org.ro
 ancounterflux.online
 ancpi.ro
+andalanmediaraya.net
 andalas-net.id
 andalasmedia.net.id
 andalsoftware.com
@@ -1922,6 +1997,7 @@ andersoninc.com
 andersonkelly.com
 andesaservices.com
 andesat.com.ar
+andesmar.com.ar
 andespark-ixp.net
 andikanet.id
 andinatel.pe
@@ -1931,6 +2007,7 @@ andoz.tj
 andra.com.pl
 andrasta.com.br
 andrews.hu
+andrewsdistributing.com
 andrewsfcu.org
 andrex.sk
 andrexen.com
@@ -1945,6 +2022,7 @@ anegis.com
 anekanet.com
 anekasiaknusantara.com
 anesthesiallc.com
+anet.com.au
 anetliberec.cz
 anextel.ru
 anextour.com
@@ -1969,9 +2047,11 @@ angkasawave.net.id
 anglicare-tas.org.au
 anglishment.com
 anglocoal.com.au
+angolalng.com
 angranyun.com
 angryturnip.com
 angstrem-mebel.ru
+anh.gob.bo
 anico.com
 anico.com.ar
 animasgr.it
@@ -1987,6 +2067,7 @@ anixnics.com
 anixter.jobs
 anjoquimica.com.br
 ankatelsoft.ro
+anklefootfl.com
 ankura.com
 anl.ro
 anlian.hk
@@ -2004,6 +2085,7 @@ ans.af
 ans.cz
 ansaldoenergia.com
 anserservice.ca
+anses.gov.ar
 ansible.org
 ansonnet.com
 answersingenesis.org
@@ -2014,14 +2096,17 @@ ant-san.com
 antara.co.id
 antaree.com
 antarescyber.net
+antarexcyber.io
 antbd.net
 antds.ru
 anteasrl.it
 antec-kabel.de
 antec-servicepool.de
+anteil.com
 anteldata.net.uy
 antemeta.fr
 antena3.ro
+antenasysistemas.com
 antennaworld.hu
 antennet.co.id
 antey-e.ru
@@ -2101,11 +2186,13 @@ aparadiserental.com
 apart.pl
 apatit.com
 apator.com
+apc.com.pa
 apcela.com
 apconet.mx
 apcs.com.au
 ape1r0n.com
 apeagers.com.au
+apec.com.vn
 apelby.com
 apelsin-it.com
 aperia.com
@@ -2144,6 +2231,7 @@ apks.com
 aplikabisnis.com
 aplikadata.id
 aplitt.pl
+apmortgage.com
 apn.com.br
 apnanetwork.net
 apoiocom.com.br
@@ -2198,6 +2286,7 @@ apsfl.co.in
 apsupports.com
 apt.ro
 aptaero.com
+aptar.com
 aptaracorp.com
 apteka24.ua
 aptekazhivika.ru
@@ -2214,6 +2303,7 @@ apvtelecom.com.br
 apx.com
 apyl.com
 aq.ru
+aqua.org
 aquafon.com
 aqualectra.com
 aquanet.pl
@@ -2242,8 +2332,10 @@ arandomserver.com
 aranger.at
 aransk.ru
 araratbank.am
+ararental.org
 araskargo.com.tr
 aratelecom.net.br
+arauco.cl
 aravisconnect.fr
 araxxe.com
 araztech.az
@@ -2258,12 +2350,15 @@ arcelormittal.com
 arcgames.com
 arch.mc
 archcapservices.com
+archcoal.com
 arche.net
 archerlaw.com
 archeton.pl
 archidiecezjalubelska.pl
 archidoc.pl
 archildrens.org
+architecht.com
+archive.systems
 archous.tech
 arcinfra.com
 arckanet.net
@@ -2294,6 +2389,7 @@ ardshinbank.am
 are.com
 area-7.it
 area.trieste.it
+areandina.edu.co
 areaproject.com
 areawidetech.com
 arebz.com
@@ -2302,6 +2398,7 @@ aremarkedb.no
 arena-pac.net
 arena.com.tr
 arenariga.com
+arenda-ost.ru
 arenhost.com
 arentel.ru
 aresmgmt.com
@@ -2310,6 +2407,7 @@ arex.or.kr
 arexico.com
 arganet.com.br
 argensur.com
+argo-ict.com
 argo.pl
 argoblockchain.com
 argon.id
@@ -2352,6 +2450,7 @@ arise.pl
 aristi.co.id
 aristid.com
 aristocrat.com
+aristocrattechnologies.com
 aristotelenet.net
 ariyaserver.com
 arizonacardinalsjerseyshop.com
@@ -2374,6 +2473,7 @@ arlab.com.ar
 arlequim.com
 arlingtontvcoop.net
 arlnissan.com
+arlp.com
 arm.com
 arm.in.ua
 armada.mil.ar
@@ -2382,7 +2482,9 @@ armaninollp.com
 armanway.com
 armatis-lc.com
 armatis.com
+armcom.am
 armed.am
+armeec.bg
 armelektron.ru
 armeva.com.tr
 arminco.com
@@ -2405,6 +2507,7 @@ arpa-hireachdns.com
 arpa-mithriltele.net
 arpa.db
 arpage.ch
+arpandora.com
 arpc.ir
 arpce.cg
 arpitel.it
@@ -2427,6 +2530,7 @@ arsim.pl
 arsma.pl
 arsplus.ru
 arstelecom.ru
+art-nerd.com
 artajasa.co.id
 artaknet.com
 artatel.com
@@ -2436,7 +2540,9 @@ artbuild-up.com
 arte-fact.net
 arte.tv
 artea.lt
+artear.com.ar
 arteb.com.br
+artechinfo.com
 artefact.com
 artefrance.fr
 arteliagroup.com
@@ -2528,6 +2634,7 @@ as200508.net
 as200676.net
 as201132.net
 as201281.net
+as201392.network
 as201398.net
 as201723.net
 as201744.net
@@ -2543,6 +2650,7 @@ as204258.net
 as204506.net
 as204526.net
 as204776.net
+as204830.net
 as205240.net
 as205315.net
 as205365.net
@@ -2579,6 +2687,7 @@ as211431.net
 as211544.net
 as211553.net
 as211776.net
+as212024.net
 as212049.net
 as212085.eu
 as212378.net
@@ -2589,6 +2698,7 @@ as212921.net
 as213007.com
 as213052.net
 as213151.net
+as213339.net
 as213392.net
 as213436.uk
 as213449.net
@@ -2706,6 +2816,7 @@ as63477.net
 as7883.net
 as8.net
 as918.net
+asa.org
 asabd.org
 asabri-id.com
 asac.as
@@ -2714,6 +2825,7 @@ asahachimaru.com
 asahi-hp.jp
 asahi-kasei.com
 asakreasi.net
+asana.com
 asanpardakht.ir
 asante.org
 asarta.ru
@@ -2721,6 +2833,7 @@ asatel.co.ke
 asax.ir
 asbank.com.tr
 asbaumhosting.com
+asc.com.au
 ascania.ua
 ascanius.ch
 ascenaretail.com
@@ -2778,6 +2891,7 @@ asiakom.net
 asiamegalink.com
 asiancitybd.com
 asianet.co.id
+asianet.ge
 asianetonlinebd.com
 asiasat.com
 asiatel.com.bd
@@ -2799,9 +2913,12 @@ asl.com.hk
 aslimnica.lv
 asline.net
 aslroma2.it
+asm-inc.com
 asmap.org.ua
+asme.org.sg
 asmecam.it
 asml.com
+asmpt.com
 asmtech.com.mx
 asmterni.it
 asmvigevano.it
@@ -2825,7 +2942,9 @@ aspidersolutions.com
 aspirapps.com
 aspirehosting.net
 aspiresys.com
+aspose.com
 asr24.com
+asrc.com
 asrc.ro
 asrcfederal.com
 asredanesh.com
@@ -2853,6 +2972,7 @@ assore.com
 assoreturn.fr
 assured-networks.com
 assuredguaranty.com
+assurity.com
 assuta.co.il
 ast-electro.ru
 ast-networks.com
@@ -2881,6 +3001,7 @@ astro-tech.net
 astro.com.my
 astrolavos.com.gr
 astroshapes.com
+astrostar.ru
 astrum-entertainment.ru
 asttecs.com
 astu.tm
@@ -2906,6 +3027,7 @@ atb.az
 atbank.com.tr
 atbmarket.com
 atcall.it
+atcc.org
 atcinfocom.in
 atconsultants.co.za
 atcovvorld.com
@@ -2918,6 +3040,7 @@ atemis.eu
 atenaustralia.com.au
 atento.com
 atento.com.ar
+atentochile.cl
 ates-net.ru
 atf-inc.com
 ath.com.co
@@ -2949,6 +3072,7 @@ atlantapublicschools.us
 atlanticare.org
 atlanticbay.com
 atlanticbb.net
+atlanticcoastmortgage.com
 atlanticgrupa.com
 atlantictechnologycentre.ca
 atlanticus.com
@@ -2963,6 +3087,7 @@ atlasair.com
 atlasbusiness.com
 atlasiron.com.au
 atlasmi.net
+atlasvanlines.com
 atmajaya.ac.id
 atmessage.net
 atmosenergy.com
@@ -2979,6 +3104,7 @@ aton.ru
 atozinfolink.com
 atozled.com
 atpi.com
+atracom.com.ua
 atraircraft.com
 atriasolutions.com
 atriatek.co.id
@@ -2988,6 +3114,7 @@ atropol.eu
 atsa.bg
 atsenergo.ru
 atservers.net
+atsinc.com
 atso.org.tr
 atsol.com
 atssfiber.ph
@@ -3000,6 +3127,7 @@ attmail.com
 attodigitalhk.com
 attrel.com
 atualfibra.com.br
+atul.co.in
 atulaya.com
 atusprovedor.com.br
 atv-plus.net
@@ -3027,10 +3155,12 @@ audatex.com.au
 audatex.net
 audaxis.com
 audiblemagic.com
+audicolsas.co
 audienceserv.com
 audigill.org.uk
 audiocodes.com
 audiotele.ru
+audit-telecom.ru
 aufa.net.id
 aufbewahrungsbox-pro.shop
 augsburg.de
@@ -3079,9 +3209,11 @@ austrianairlines.ag
 austurljos.is
 auth-servers.net
 authority.ru
+auto-owners.com
 auto-wares.com
 autoadria.ro
 autobahn.de
+autocentercity.ru
 autoconfig.be
 autoconnex.ru
 autocrib.com
@@ -3114,6 +3246,7 @@ autostrade.it
 autostradealtoadriatico.it
 autototal.ro
 autowrecking.com
+auva.at
 auvergnerhonealpes.fr
 auvert-jean-peintre-sculpteur.com
 auxilium.online
@@ -3129,6 +3262,7 @@ avafin.com
 avakatan.com
 avala.bg
 avalan.su
+avalonbay.com
 avalondc.net
 avaloq.com
 avanceinternet.com.br
@@ -3139,9 +3273,11 @@ avante-group.com
 avantelecom.ru
 avanzatelecom.com.br
 avarn.fi
+avasad.ch
 avast.com
 avatara-llc.com
 avatrade.com
+avbob.co.za
 avcdigital.com.ar
 avcomm.com.au
 avd.de
@@ -3227,11 +3363,13 @@ avtodor-tr.ru
 avtogermes.ru
 avtoline.ru
 avtomir.ru
+avtotor.ru
 avuscapital.com
 avvgo.com
 awanpintar.id
 awanti.com
 aware.co.th
+awas.ovh
 awc-inc.com
 awd.com.au
 awdnetworks.com.do
@@ -3249,6 +3387,7 @@ awqaf.org
 aws.us
 awsg.at
 awsmyanmar.com
+awta.com.au
 awxsites.com
 ax-net.co.za
 ax-s-anywhere.com
@@ -3264,6 +3403,7 @@ axalnet.sk
 axamansardplc.com
 axarwifi.com
 axasoft.sk
+axcelis.com
 axcess-financial.com
 axcient.com
 axeinfo.fr
@@ -3341,6 +3481,7 @@ azintex.com
 azkaindonetwork.id
 azkrmc.com
 azkyalnetwork.com
+azleisd.net
 aznetwork.net
 azocarcr.com
 azonne.com
@@ -3350,6 +3491,7 @@ azurance.com
 azurip.com
 azurita.es
 azv.sh
+azwardigitalnetworks.id
 azwater.com
 azworld.com
 azymut.pl
@@ -3372,6 +3514,7 @@ b2g.kz
 b3zdna.net
 b4com.tech
 b4tlc.it
+b5yazilim.com
 b7c.de
 b8sales.com
 b92.net
@@ -3386,6 +3529,7 @@ babilon-m.tj
 babyaholics.com
 babyone.de
 babypenguin.co
+bac.net
 bach-it.gmbh
 bacher.at
 bachmann.info
@@ -3395,6 +3539,7 @@ backoffice.hr
 backstageva.com
 backup.pl
 badata.de
+badbit.it
 badcoder.net
 badgermeter.com
 badm.ua
@@ -3463,6 +3608,7 @@ baliaura.com
 balkangate.com
 balkantel.com.mk
 ballbinge.shop
+ballhort.com
 ballisticcell.com
 balocco.it
 baloise.be
@@ -3487,9 +3633,11 @@ banatnet.ro
 banatsync.com
 banbeis.gov.bd
 bancabc.co.zw
+bancatlan.hn
 bancfirst.com
 banchile.cl
 banchilevida.cl
+bancobic.ao
 bancomontepio.pt
 bandainamcoent.eu
 bandalargaupnet.com.br
@@ -3531,14 +3679,17 @@ banksiteservices.com
 bankstownsports.com
 bankunited.com
 banratte.net
+banrural.com.gt
 bantelusa.com
 banvit.com
 baokhanhict.vn
 baoshuo.ren
 baoviet.com.vn
+baptistfirst.org
 baptisthealth.net
 baptisthealthsystem.com
 barbazampc.coop
+barber-nichols.com
 barbhudson.com
 barbourville.com
 barchart.com
@@ -3616,7 +3767,9 @@ baupartner.ro
 baupost.com
 bausoftware.de
 bautec.se
+bauwatch.com
 baxglobal.com
+bayalarm.com
 bayan.com.ph
 bayareamesh.us
 baycoclerk.com
@@ -3627,6 +3780,7 @@ bayer.com.ar
 bayer04.de
 bayerfcu.org
 bayeropluxtel.org
+bayhealth.org
 bayind.pro
 baykndenim.com
 baylorhealth.com
@@ -3644,8 +3798,10 @@ bbarianet.org
 bbgerlos.at
 bbh.com
 bbhinc.com
+bbk.eus
 bbklaw.com
 bbl.net.bd
+bbmc.org
 bbn.com
 bbn.net.id
 bbnetworks.net
@@ -3673,6 +3829,7 @@ bcc.es
 bcc.gov.bd
 bccard.com
 bccardvn.com
+bccls.org
 bccm.pl
 bccsistemiinformatici.it
 bcdtravel.com
@@ -3685,6 +3842,7 @@ bcix.de
 bcl.net.au
 bclc.com
 bclonline.net
+bcm-solution.ro
 bcm.net.ua
 bcmedia.co.id
 bcmone.com
@@ -3706,8 +3864,10 @@ bcuinc.com
 bcv.com.ua
 bcx.co.mz
 bcy.gov.vn
+bdainc.com
 bdata.at
 bdflex.com.br
+bdgtechnologies.com
 bdh-klinik-hessisch-oldendorf.de
 bdhonda.com
 bdhub.com
@@ -3743,12 +3903,14 @@ bearandbullmarketnews.com
 bearcom.com
 bearingpoint.com
 bearmetal.eu
+bearrivermutual.com
 beautyluxedf.com
 beautynetworksalon.com
 beazer.com
 beazley.com
 bebyte.it
 beca.com
+becklar.com
 becknet.com
 beckshybrids.com
 becu.org
@@ -3766,6 +3928,7 @@ beenets.net
 beeone.nl
 beeonline.com.bd
 beetlenetwork.net
+beffect.net
 befl.ru
 beg.aero
 begasoft.ch
@@ -3797,6 +3960,7 @@ belfla.be
 belgazprombank.by
 belgiantrain.be
 belinvestbank.by
+bellajanela.com.br
 bellatlantic.com
 bellavistasat.net
 belldirect.com.au
@@ -3809,6 +3973,7 @@ beloil.by
 belrts.ru
 beltele.com
 belz.com
+bemismfg.com
 bemobile.ua
 bemol.com.br
 bemowo.waw.pl
@@ -3818,6 +3983,7 @@ benapole.net
 benchmark.bg
 benco.com
 bend.k12.or.us
+bend.or.us
 bendcompass.com
 benders.se
 bendery.md
@@ -3839,6 +4005,7 @@ benevis.com
 benga.com
 bengol.net
 benify.com
+benin-ix.org.bj
 benjojo.co.uk
 benocs.com
 benoit.com.br
@@ -3885,6 +4052,7 @@ bermond.vg
 bern.ch
 bernards.com
 berninausa.com
+berron.ar
 berrybyte.net
 bertelsmann.de
 bertina.ir
@@ -3929,7 +4097,9 @@ betfair.com
 betfred.com
 betha.com.br
 bethanie.com.au
+bethany.org
 bethelsd.org
+bethss.com
 betinvest.com
 betsoftware.com
 betssongroup.com
@@ -3961,6 +4131,7 @@ bfn.by
 bft.network
 bft.ru
 bgbs.bg
+bgc.cc
 bgc.com.au
 bgc.se
 bgcom.pl
@@ -3976,6 +4147,7 @@ bgp.net.pl
 bgp.news
 bgp.pw
 bgp.rodeo
+bgp.sa
 bgp.tools
 bgp.tw
 bgp.wtf
@@ -3993,6 +4165,7 @@ bharari.net
 bharathcloud.com
 bharathitechnologies.com
 bharatnetwork.in
+bharatpetroleum.in
 bhataranet.id
 bhawanitech.com
 bhel.com
@@ -4027,6 +4200,7 @@ bicos.net
 bida.com.tr
 bidbax.no
 bidfood.com.au
+bidiin.mk
 bidstrading.com
 bidtellect.com
 bielmar.pl
@@ -4065,6 +4239,7 @@ bignetwork.com
 bignetworkindonesia.com
 bigpoint.net
 bigriversteel.com
+bigtech.biz
 bigtelecom.com.br
 bigtube.net
 bigweb.host
@@ -4082,11 +4257,13 @@ biletdv.ru
 biletik.online
 bilgibirikim.com
 bilgorod.net
+bilhost.com
 bilibili.com
 bilintel.com
 bilisimanadolu.com
 bill360.com
 billbird.pl
+billericak12.com
 billerud.com
 billetweb.fr
 billgosling.com
@@ -4138,6 +4315,7 @@ biosme.com
 biosophy.net
 biotc.ru
 biotelecom.com.br
+bioton.pl
 biotronik.com
 biotronik.de
 biovitrum.ru
@@ -4155,6 +4333,7 @@ bisadata.net
 bischofskonferenz.at
 bisd.net
 bisd.us
+bisdigital.com
 bisecthosting.com
 bismillahit.net.bd
 bisnet.co.za
@@ -4176,6 +4355,7 @@ bitcomp.sk
 bitdeer.com
 bitdefender.ro
 bitel.com.co
+bitem.com.co
 bitency.nl
 bitfibra.com.br
 bitfirenetworks.com
@@ -4183,6 +4363,7 @@ bitfissure.com
 bithawk.ch
 bitmatix.biz
 bitmax.net
+bitmex.com
 bitnap.net
 bitnet.do
 bitniaga.net.id
@@ -4234,6 +4415,7 @@ bjbraila.ro
 bjs.com
 bjwsa.org
 bk-kvartal.ru
+bk.com
 bk.ru
 bkash.com
 bkhost.com.vn
@@ -4244,16 +4426,19 @@ bkm.com.tr
 bkmedien.at
 bkom.cz
 bkonlinebd.net
+bkpinfo.com.br
 bkt.com.al
 bkvm.com
 bkvtelemedia.net
 bkw.ch
+blachere.fr
 blackbaud.com
 blackbird.co.uk
 blackboard.com
 blackburn-technologies.com
 blackducksoftware.com
 blackfaos.com
+blackgold.ca
 blackhawk-net.com
 blackhawknetwork.com
 blackhillscorp.com
@@ -4265,6 +4450,7 @@ blackngreen.com
 blackoakcasino.com
 blackpoint.de
 blackpointcyber.com
+blackrock-clinic.com
 blacksea.net.ua
 blackstone.com
 blackwaterregion.com
@@ -4275,6 +4461,7 @@ blainsupply.com
 blambangan.net.id
 blameitonthe.network
 blank-clan.de
+blankrome.com
 blattnerenergy.com
 blazehost.cz
 blazingbullet.com
@@ -4307,6 +4494,7 @@ blood.ca
 bloodfire9.com
 bloodntissue.org
 bloodsystems.org
+bloodworksnw.org
 bloomberg.net
 bloomberg.org
 bloombergindustry.com
@@ -4314,6 +4502,7 @@ bloomingdales.com
 bloomington.k12.mn.us
 bloono.com
 blount.com
+blounttn.org
 bls.ch
 bls.hosting
 bls.it
@@ -4338,13 +4527,16 @@ bluecloudworks.com
 bluecoded.nl
 bluecom.fr
 bluecom.so
+blueconnections.com.au
 bluecrestcapital.com
 bluecrossma.com
+bluediamondgrowers.com
 bluediamondtrading.co.za
 bluedogtech.co.za
 bluedot.pl
 blueeagleindia.com
 bluefin.com
+bluefur.net
 bluegix.com
 bluehole.net
 blueinfra.fr
@@ -4372,6 +4564,7 @@ bluerange.se
 bluerim.net
 blueriver.net
 blueriverstone.com
+bluescopebuildings.com
 bluescreen.ro
 blueseasdesigns.com
 blueshieldca.com
@@ -4407,13 +4600,16 @@ blynkstyle.com
 bm-lyon.fr
 bm5.pl
 bma.bm
+bmacorp.com
 bmb-green.cz
 bmc.com
 bmc.com.tr
 bmcah.cn
+bmcsoftware.co.il
 bmctech.pe
 bmd.in.ua
 bmd.mn
+bmdtransportation.com
 bmfportburgas.com
 bmitbd.com
 bmj.net.pl
@@ -4429,9 +4625,13 @@ bmwvaruosad.tk
 bmy.link
 bn.org.pl
 bnasg.com
+bne.com.au
 bnet.cl
+bnetglobal.com
 bni-life.co.id
 bnkfn.co.kr
+bnksys.co.kr
+bnpmedia.com
 bnpparibas.it
 bnr.bg
 bnsbd.com
@@ -4466,6 +4666,7 @@ bojicloud.com
 bojin.co
 bokcenter.com
 bokf.com
+boku.com
 bol-bg.com
 bol.com
 bolbd.net
@@ -4510,6 +4711,7 @@ boomerangtelecom.net.br
 boominfotech.net
 boomsolutionspr.com
 boonepower.net
+boostnet.mx
 boostrun.com
 bootbarn.com
 boras.se
@@ -4544,6 +4746,7 @@ bose.nl
 bose.res.in
 boskalis.com
 bosnet.id
+boss.gt
 bossa.pl
 bost-law.com
 bosti.co.id
@@ -4559,6 +4762,7 @@ bottomline.com
 bouldercounty.org
 boulderlibrary.org
 boundedby.fr
+bounteous.com
 bourne-leisure.co.uk
 boursakuwait.com.kw
 bourse.lu
@@ -4580,6 +4784,7 @@ boylesports.com
 boystown.org
 bozonk.net
 bozzutos.com
+bpac.com.ec
 bpaserver.net
 bpatc.org.bd
 bpay.md
@@ -4598,8 +4803,10 @@ bps-net.jp
 bps-sberbank.by
 bps101.net
 bpsf.net
+bpsprocessing.com
 bpxlogistics.com
 bqe.com
+br-automation.com
 br.de
 br27.com.br
 brabantwater.nl
@@ -4610,6 +4817,7 @@ bracepl.com
 brack.ch
 brackenly.live
 bracmail.net
+bradesco.com.mx
 bradyid.com
 braganetwork.co.id
 brahmayasa.com
@@ -4625,6 +4833,7 @@ bramco.com
 brammer.pl
 brandaonet.net.br
 branddevelopers.co.nz
+brandefense.io
 brandergroup.net
 brandfi.co.ke
 brandl.ro
@@ -4644,12 +4853,14 @@ brasilnett.com.br
 brasilnetworks.com.br
 brasiltelecom.net.br
 brasnetinformatica.com.br
+brastel.co.jp
 brastorage.com.br
 brasul.net.br
 bratislava.sk
 bratsk-city.ru
 brava.inf.br
 brava.net.br
+brave.com
 braveservicekey.online
 bravesoft.com
 bravom.com
@@ -4663,6 +4874,7 @@ brazilianoffers.de
 brazosportisd.net
 brd.ro
 brd.zp.ua
+breadbyte.cloud
 breadcloud.com
 breadfinancial.com
 breckinridge.com
@@ -4673,6 +4885,7 @@ breezle.net
 breitband-korn.de
 breitbandmessung.de
 brellatransplc.shop
+bremc.com
 bremerhaven.de
 bremtechnology.com.br
 brenac.eu
@@ -4685,6 +4898,7 @@ brewers.com
 brewerscience.com
 brewsteracademy.org
 brf-br.com
+brgsports.com
 briantel.com
 bridanareksasekuritas.co.id
 bridevibe.hu
@@ -4695,6 +4909,7 @@ bridgestone-eu.com
 bridgestoneamericas.com
 bridgestudios.com
 bridgetele.com
+bridonamerican.com
 briggsandstratton.com
 brightedge.com
 brighthorizons.com
@@ -4741,6 +4956,7 @@ broadviewfcu.com
 broadwaycover.com
 broadwaytechnology.com
 brocard.ua
+brocksolutions.com
 brockwaytv.com
 brodos.com
 broighter.com
@@ -4748,6 +4964,7 @@ broker.de
 broker.ru
 brokerkf.ru
 bromilendrovix.com
+bromirski.net
 bronsonhg.org
 brontobytecloud.com
 bronxnet.ro
@@ -4920,6 +5137,7 @@ bunn.com
 bunnings.com.au
 bunny.net
 bunnyconnect.net
+bunzlusa.com
 buoytoys.com
 bupa.com.au
 bupaacibadem.com.tr
@@ -4932,6 +5150,7 @@ burgnet.cz
 burgo.com
 burlington.com
 burlington.k12.il.us
+burn.net
 burningman.org
 burnsmcd.com
 burongroup.com
@@ -4943,6 +5162,7 @@ bursamalaysia.com
 bursatec.com.mx
 burstbroadcast.com
 burtinet.com
+burton.com
 bus.co.rs
 bus8.us
 busanbank.co.kr
@@ -4986,6 +5206,7 @@ bvs.net.id
 bvunet.net
 bw-sw.com
 bwdb.gov.bd
+bwdsb.on.ca
 bwe.capital
 bwholdings.com.au
 bwinparty.com
@@ -5014,6 +5235,7 @@ bytefetch.co.uk
 bytehouse.co.uk
 byteisp.com
 bytenests.com
+bytenetworking.com
 bytenodeweb.com
 byteopt.com
 byteshopinternet.com.br
@@ -5032,6 +5254,7 @@ c-24.de
 c-group.pro
 c-ig.net
 c-mobile.it
+c-s-v.ru
 c-solution.biz
 c-svyaz.com
 c-way.co.za
@@ -5041,6 +5264,7 @@ c24.nl
 c2cvoip.co.uk
 c2hosting.com
 c2kni.org.uk
+c2kplus.com
 c2net.cz
 c3aero.com
 c3i-inc.com
@@ -5084,6 +5308,7 @@ cablerv.com.mx
 cablesat.com.ar
 cablevision.com.uy
 cableyojoatv.com
+cabp.com
 cabstechnetwork.com
 caccaweb.com
 caci.co.uk
@@ -5125,6 +5350,7 @@ caisnetwork.com.br
 caiso.com
 caiu.org
 caixabank.es
+caixaseguradora.com.br
 cajutel.com
 cajutel.sl
 cakehomeim.com
@@ -5141,6 +5367,7 @@ calatech.co
 calbank.net
 calbtechnologies.com
 calcas.com
+calcit.si
 calcontec.com.br
 calculo.com
 calculquebec.ca
@@ -5153,11 +5380,14 @@ calhounisd.org
 caliberhomeloans.com
 calibour.com
 calibresys.com
+calicolabs.com
 calik.com
+caliper.com
 calix.com
 call2phone.com
 callaghaninnovation.govt.nz
 callawaygolf.com
+callcentersindia.com
 callcpc.com
 calleguas.com
 callflex.net.br
@@ -5176,10 +5406,12 @@ calvaedi.com
 calvary-lutheran.net
 calvertauto.com
 calvertnet.k12.md.us
+calwater.com
 calyonamericas.com
 calyxnetworks.org
 calzavara.com.ar
 camaleaonet.com.br
+camara.cl
 camaramed.org.co
 camau.gov.vn
 camber.com
@@ -5192,10 +5424,12 @@ cambridgefx.com
 cambtel.com
 cambuhytelecom.com.br
 camdata.de
+camden.k12.nj.us
 came.com
 camellenses.com
 cameosolutions.com
 camera.it
+cameron.tx.us
 cameronmch.com
 camlog.com
 campaigndeputy.com
@@ -5223,12 +5457,15 @@ canalplus-caledonie.com
 canalsnet.com.ar
 canarie.ca
 cancaonova.com.br
+cancer.gov.co
 cancercenter.com
 cancerresearchuk.org
 canda.com
+candid.com
 candorsolution.com
 candr.com
 caneev.de
+canik.com
 canikarms.com
 canix.ca
 canlith.com
@@ -5255,6 +5492,7 @@ capacivolley.com
 cape.co
 capecodhealth.org
 capefn.com
+caperadiology.com
 caperegional.com
 capeta-system.com
 capgroup.com
@@ -5321,6 +5559,7 @@ carefusion.com
 caregivershomecare.com
 carelonbehavioralhealth.com
 caremountmedical.com
+carestream.com
 caretechsolutions.com
 careyint.com
 carfax.com
@@ -5340,6 +5579,7 @@ carinsurancequotesds.us
 carlislehomes.com.au
 carlosmanuel.com
 carlsberg.ua
+carlyle.co.in
 carmax.com
 carocomp.ro
 carolinaautoauction.com
@@ -5362,7 +5602,9 @@ carringtonmh.com
 carrollcountyschools.com
 carrolltoncityschools.net
 cars.com
+carsforsale.com
 cartel.md
+cartellone.com.ar
 carters.com
 cartes-bancaires.com
 cartoys.com
@@ -5405,6 +5647,7 @@ cassems.com.br
 cassi.com.br
 cast.org.cn
 castandcrew.com
+castingworkbook.com
 castleaccess.com
 castlecookehawaii.com
 castlefunders.com
@@ -5426,10 +5669,12 @@ catalytic.co.za
 catapult.org.uk
 cataratasnet.com.br
 catastrophemanagementsolutions.com
+catchengineering.com
 cateringuk.top
 cathaypacific.com
 catholic.org.au
 catixs.net
+catmktg.co
 catnix.net
 catoca.com
 catocorp.com
@@ -5455,8 +5700,10 @@ cbch.ru
 cbe.ab.ca
 cbec.coop
 cbegroup.com
+cbf.com.br
 cbgr.ru
 cbh.com
+cbh.com.au
 cbinet.net
 cbma.it
 cbmm.com.br
@@ -5465,6 +5712,7 @@ cbni.net
 cbnnettelecom.com.br
 cbntelecom.com.br
 cboe.com
+cboss.ru
 cbr-net.com
 cbr.net.id
 cbre.com
@@ -5478,6 +5726,7 @@ cbsoregon.com
 cbt.co.id
 cbti.net
 cbts.com
+cbussuper.com.au
 cbws.nl
 cc-networx.com
 cc.com.ua
@@ -5522,6 +5771,7 @@ cclgroup.ca
 cclnetworks.ca
 ccma.cat
 ccmbenchmark.com
+ccmedia.fr
 ccnbi.com
 ccnbroadband.net
 ccomtelecom.com.br
@@ -5532,6 +5782,7 @@ ccpgames.com
 ccs.cz
 ccs.ru
 ccsiph.com
+ccsnet.net
 ccstv.com.br
 cctt.ru
 ccu.com
@@ -5543,6 +5794,8 @@ cd13.fr
 cda-net.it
 cda.gov.bd
 cdbnet.com.cn
+cdccoors.com
+cdcpak.com
 cdcservices.com
 cde.si
 cdek.ru
@@ -5581,6 +5834,7 @@ cds-global.com
 cdsc.com.np
 cdstephens.net
 cdt.ru
+cea.com.au
 ceb.lk
 cebi.com
 cebit.com.pl
@@ -5598,6 +5852,7 @@ ced-rus.ru
 cedacri.it
 cedc.com
 cedefop.eu.int
+cedesurk.org
 cedgetec.com
 cedia.org.ec
 cedoc-ltd.net
@@ -5633,12 +5888,14 @@ celenet.es
 celer-tech.com
 celerium.com.br
 celero.net
+celesc.com.br
 celestica.com
 celinet.com.br
 celje.si
 celjo.com
 celjo.com.ar
 celko.com
+cellarmasters.com.au
 cellcomgsm.com
 cellebrite.com
 cellhire.com
@@ -5674,6 +5931,7 @@ cenibra.com.br
 cenosnetworks.com
 censys.io
 centauri-solutions.com
+centennialarts.com
 center-inform.ru
 center-sapr.com
 centerbridge.com
@@ -5728,11 +5986,13 @@ centuryfurniture.com
 centurygamingtechnologies.com
 centurylinknetworkbd.com
 centuryone.hk
+cepal.org
 cepc.net
 cepix.pl
 cepral.coop
 cer-ranchos.com.ar
 ceragon.com
+ceramica.ru
 cerberusmail.co.uk
 cered.com.ar
 cerema.fr
@@ -5755,6 +6015,7 @@ certisign.com.br
 certsign.ro
 certusoft.com
 cerved.com
+ces-ltd.com
 cesal.cz
 cescom.net.ar
 ceskaposta.cz
@@ -5782,6 +6043,7 @@ cf-emailsecurity.net
 cfc-rdc.com
 cfca.com.cn
 cfe.be
+cff.org
 cfins.com
 cfjblaw.com
 cfld.uk
@@ -5792,20 +6054,25 @@ cfr.ro
 cft.ru
 cgate-global.com
 cgbest.co.kr
+cgcompass.com
 cgd.pt
 cgdweb.com.ar
 cgesd.k12.or.us
 cgg.com
 cgi.de
 cgiar.org
+cgichicago.com
 cginorge.no
 cgit.se
 cgm-arztsysteme.de
 cgm.com
 cgn.it
 cgnad.com
+cgok.dp.ua
+cgr.go.cr
 cgsa.com.ec
 cgsi.co.th
+cgsinc.ca
 cgsinc.ro
 cgstogo.com
 cgv.id
@@ -5910,6 +6177,7 @@ chg-meridian.com
 chia.net
 chiabinet.id
 chiaochiao.com.tw
+chicagoparkdistrict.com
 chicagotrading.com
 chick-fil-a.com
 chickasaw.net
@@ -5923,6 +6191,7 @@ chilco.com.co
 child-wisdom.com
 childnet.us
 childrens.com
+childrensal.org
 childrensmn.org
 childrensplace.com
 chili.mu
@@ -5971,6 +6240,7 @@ chpg.mc
 chr-hansen.com
 chr.is
 chregionalmedien.ch
+christchurchairport.co.nz
 christianacare.org
 christianbook.com
 christiandior.com
@@ -6019,17 +6289,22 @@ cianet.ro
 cianetwork.com.br
 ciberconceito.com
 cibernek.com.ar
+cibernetgt.com
 cibil.com
 cibmall.net
 cic.com
+cic.hk
 cicapital.com
 cicloti.com.br
+cicny.com
 cidadei.com.br
 cidatel.co.id
 cidis.bo
 ciechanow24.pl
+ciechgroup.com
 cielo.com.br
 cielo.io
+cienradios.com
 cif-ra.ru
 cifi.com.au
 cifin.co
@@ -6039,6 +6314,7 @@ cifra-broker.ru
 cifrabeat.ru
 ciframedia.net
 cifyitservices.com
+ciginsurance.com
 cigniti.com
 cigs.co.id
 cih.com
@@ -6061,6 +6337,7 @@ cinemark.com
 cineryayinholding.com.tr
 cineworld.co.uk
 cinfin.com
+cinnaminson.com
 cinoxmedianet.id
 cintas-corp.com
 cintel.pe
@@ -6072,6 +6349,7 @@ cipherwave.net
 cir2.com
 circalasvegas.com
 circl.lu
+circle75networks.com
 circleb.eu
 circlek.com
 circlekeurope.com
@@ -6080,12 +6358,14 @@ circleone.net.id
 circles.co
 circuitoftheamericas.com
 circuitosaljarafe.com
+ciri.com
 cirilgroup.com
 cirion-tech.com.co
 ciriontechnologies.com
 cironspharm.com
 cirque.dk
 cirrus.com
+cirrusaircraft.com
 cirrusnetworks.com.au
 cisd.org
 cishost.ru
@@ -6160,8 +6440,12 @@ citynetwireless.it
 citynetwork.bg
 cityofathens.gr
 cityofbartow.net
+cityofcarrollton.com
 cityofchesapeake.net
+cityofconcord.org
+cityofcortez.com
 cityofcovington.org
+cityofdavid.org.il
 cityofdavis.org
 cityofdubuque.org
 cityofemmett.org
@@ -6169,11 +6453,17 @@ cityofgainesville.org
 cityofgriffin.com
 cityofhenderson.com
 cityofkm.com
+cityoflewisville.com
 cityofmarshall.com
 cityofmesquite.com
+cityofnampa.us
+cityofnsb.com
 cityofprague.cz
 cityofrockhill.com
+cityofsanrafael.org
+cityofsouthlake.com
 cityofvacaville.com
+cityofventura.net
 citypartner.pl
 citysol.ru
 citystrada.pl
@@ -6183,6 +6473,7 @@ ciu20.org
 ciudadglobal.com.ar
 civey.com
 civicos.com
+civilization.ca
 civilnetworkbd.com
 civitanet.com
 civitasgroup.ro
@@ -6206,9 +6497,11 @@ claas.de
 clackamas.us
 claimremedi.com
 clairglobal.com
+clal-ins.co.il
 clalit.org.il
 clara.net
 claranet.id
+clarecomputer.com
 claremontcomputer.net
 clarenceprofessionalgroup.com.au
 clariant.com
@@ -6221,6 +6514,7 @@ clarivate.com
 clark.tw
 clark.wi.us
 clarkassociatesinc.biz
+clarkebroadcasting.com
 clarkmhc.com
 clarks.com
 clarksvillemotel.com
@@ -6229,6 +6523,7 @@ claro.com.py
 claro.com.uy
 claro.net.br
 claroty.com
+clarovantdigital.com
 clarus-telecom.ru
 classic.com.np
 classicgold.co.th
@@ -6281,6 +6576,7 @@ clicfacil-placas-telecom.com.br
 click-network.com
 click2houston.com
 clickatell.com
+clickbond.com
 clickearthonline.com
 clickiannetwork.com
 clicknconnect.co.in
@@ -6302,6 +6598,7 @@ clinch.ch
 clink.hk
 clink.ru
 clinton.k12.nc.us
+clintonmemorial.org
 cliqhost.com
 cliquedf.com.br
 clm.com
@@ -6322,6 +6619,7 @@ cloud-home.biz
 cloud-mx-ns.net
 cloud-pro.ru
 cloud-vault.ro
+cloud-xpress.com
 cloud.mu
 cloud21cn.com
 cloud2y.com
@@ -6336,6 +6634,7 @@ cloudace.com.vn
 cloudalize.com
 cloudandheat.com
 cloudandmore.ca
+cloudapt.com
 cloudasia.com
 cloudata.co.id
 cloudbackbone.net
@@ -6446,10 +6745,13 @@ clougix.com
 cloupard.kz
 cloupard.uz
 cloverknollcrafter.com
+clovis.ca.us
 cls.fr
 clsa.com
 cltel.net
 cltgroup.it
+clubcar.com
+clubgroup.com.au
 clubhouseonline-e3.com
 cludo.pl
 clue.ch
@@ -6460,6 +6762,7 @@ cluetrust.net
 clunetech.com
 cluster-llc.ru
 cluster-team.com
+clusterfast.com
 clyvo.net
 cm-lisboa.pt
 cm-tong.com
@@ -6485,6 +6788,7 @@ cmenetworks.net
 cmercury.com
 cmet.net
 cmgfi.com
+cmh-ix.net
 cmhc-schl.gc.ca
 cmhservices.net
 cmillc.org
@@ -6568,6 +6872,7 @@ cnusd.k12.ca.us
 cnw.co
 cnw.es
 cnx.net.kh
+cnxprojetos.com.br
 co-operative.coop
 co-opfs.org
 co-opinsurance.com
@@ -6585,6 +6890,7 @@ coamo.com.br
 coast-media.net
 coastalfcu.org
 coastcapitalsavings.com
+coastcoast.com
 coastelectric.coop
 coastguard.gov.bd
 coasthills.coop
@@ -6615,6 +6921,7 @@ code-vault.net
 code40.com
 code42.com
 codeasset.ltd
+codebgp.com
 codeforhost.com
 codeforhost.com.bd
 codefriend.top
@@ -6652,6 +6959,7 @@ cog.ut.us
 cogento-backbone.com
 cogindo.co.id
 cogitnet.eu
+coglative.com
 cognex.com
 cogniscient.in
 cognition.ai
@@ -6662,6 +6970,7 @@ cohnreznick.com
 cohr.com
 coi.gov.pl
 coimbatorecapital.com
+coinbase.com
 coinjar.com
 coinnet.site
 cointractcoy.org
@@ -6676,6 +6985,7 @@ colgate.com
 coli.com.gh
 colibri-consulting.be
 colibriwithus.com
+colina.com
 colinanet.com
 collectionhouse.com.au
 collectivegateway.net.au
@@ -6694,6 +7004,7 @@ colliersar.com
 collierschools.com
 colliersheriff.org
 colliertech.org
+collinsfoods.com
 colman.net.nz
 colmex.mx
 colo.co.id
@@ -6725,8 +7036,10 @@ columbia.wi.us
 columbiacu.org
 columbianetworks.ca
 columbiarea.coop
+columbiasports.co.jp
 columbus.in.ua
 columbusairports.com
+columbusdata.net
 colun.cl
 colvilletribes.com
 colvir.com
@@ -6758,6 +7071,7 @@ comdrev.com.pl
 come2speed.com
 comel-it.com
 comenersol.com
+comet.bg
 comexcomputer.org
 comfeel.cz
 comfibra.com.br
@@ -6794,7 +7108,9 @@ communitycare.com
 communitycares.com
 communityfinancialinsurance.com
 communityix.org
+communityplaythings.com
 communityrack.org
+communityvision.com
 commvault.com
 commverge.com
 comnet-ks.com
@@ -6811,6 +7127,7 @@ compacta.net.br
 compagniedechauffage.fr
 compal.com
 companet.online
+companioncorp.com
 company3.com
 companystnet.com
 comparepsdns.com
@@ -6821,9 +7138,11 @@ compass-eos.com
 compass.at
 compass.co.il
 compass.education
+compassfoundation.io
 compassion.com
 compassplus.com
 compassplus.ru
+compastelecom.kz
 compeer.com
 compel.com.ar
 compel.ru
@@ -6858,6 +7177,7 @@ computate.co.za
 computel.com.lb
 computel.nl
 computerdata.com
+computerjones.com
 computerland.be
 computerland.net.ua
 computerline.com
@@ -6887,6 +7207,7 @@ comstbarth.fr
 comsumersearch.com
 comtec-europe.co.uk
 comtec.com
+comtech.com
 comtechbg.com
 comteck.com
 comtecsystems.net
@@ -6910,6 +7231,7 @@ comunicate.ec
 comunidadtresplay.com
 comunidat.com.ar
 comutel.co.rs
+comvision.tv
 comviva.com
 comwel.or.kr
 comxnetworks.com
@@ -6937,6 +7259,7 @@ condor-edv.com
 condor.com
 condor.com.ni
 condornet.sk
+cone-forest.ru
 conect.net.pl
 conect.se
 conecta.com.ar
@@ -6969,6 +7292,7 @@ conecttiva.com.br
 conectx.ro
 conecweb.com.br
 coneris.com
+conetrix.com
 conexa.com.ve
 conexaofibra.com.br
 conexaojknet.com.br
@@ -7020,6 +7344,7 @@ connect4.be
 connectafibra.cat
 connectanet.net.br
 connectcov.net
+connecteast.com.au
 connected.com
 connected.com.au
 connectedoz.com.au
@@ -7031,6 +7356,7 @@ connectinternet.com.br
 connectioncameroon.com
 connectionlinks.com.br
 connectionnetworks.net
+connections.ca
 connections.net
 connectionshub.co
 connectionstelecom.com.br
@@ -7069,6 +7395,8 @@ conscia.com
 conscia.nl
 consensus.one
 conservateur.fr
+conservation.org
+consistpro.com
 consoftmg.com.br
 consol.de
 consortia.com.mx
@@ -7086,6 +7414,7 @@ consultecit.com.mx
 consultingit.com
 consultingradiologists.com
 consultisp.com.br
+consultoriafr.com.br
 consultronic.com
 consumerinfo.com
 consumerspower.org
@@ -7219,12 +7548,14 @@ cooptacural.com.ar
 cooptotoral.com
 cooptransito.com.ar
 coopvh.com.ar
+coordinador.cl
 coordinator.ua
 coospral.com.ar
 cootelser.com.ar
 coowo.com
 copaair.com
 copart.com
+copel.com
 coperdia.com.br
 coperni.co
 copesna.com.ar
@@ -7240,6 +7571,7 @@ copyseis.com
 coralgables.com
 corallnet.ru
 coralnet.or.jp
+coralpay.com
 coraltravel.pl
 cordacu.org
 cordial.com
@@ -7355,6 +7687,7 @@ countiesenergy.co.nz
 countrybg.net
 countryfinancial.com
 countrylink.in
+countrymusichalloffame.org
 countryroad.com.au
 countrytradeingplc.com
 county.org
@@ -7369,6 +7702,7 @@ covenanteyes.com
 covenanthc.org
 covenantmfo.com
 coventryfirst.com
+cover-all.ca
 covestro.com
 covestro.de
 covestro.us
@@ -7382,6 +7716,7 @@ cowmedia.de
 cowtowninternet.com
 coxfiber.net
 coxlinkit.com
+coxmediagroup.com
 coyotelogistics.com
 coyspu.com.ar
 cozaq.com
@@ -7420,6 +7755,7 @@ cppib.com
 cpr.ca
 cps-online.at
 cps.com.ar
+cpsd.us
 cpshr.us
 cpssoft.com
 cptv.com.ar
@@ -7430,6 +7766,7 @@ cr30.ru
 crackerbarrel.com
 craft-hosting.ru
 craftgate.io
+craftsilicon.com
 craigslist.org
 craneco.com
 cranleigh.org
@@ -7442,6 +7779,7 @@ cravath.com
 crawco.com
 crazypanda.ru
 crc.com
+crc.com.hk
 crc.coop
 crc.net
 crcrealty.com
@@ -7463,6 +7801,7 @@ credit-suisse.com
 credit.com
 creditacceptance.com
 creditbank.com
+creditbureau.com
 creditcall.com
 creditcorp.com.au
 creditcorporation.com.pg
@@ -7472,6 +7811,7 @@ creditdata.ru
 creditinfo.org.vn
 creditoagricola.pt
 creditpulsehq.com
+creditreform.at
 credorax.com
 credos.ru
 cree.com
@@ -7484,6 +7824,7 @@ crepundia.net
 cressforda.live
 crestmorn.xyz
 crestridgea.xyz
+crestron.com
 cretal.com.ar
 cretec.kr
 cretecarrier.com
@@ -7512,6 +7853,7 @@ criticalcontrol.com
 criticalserver8.net
 criver.com
 crlcorp.com
+crmsp.link
 crnagora.net
 crnetfibra.com.br
 croatiaairlines.hr
@@ -7522,10 +7864,12 @@ crombielockwood.co.nz
 cron.id
 cronos.be
 cronos.ru
+crook.or.us
 crosig.hr
 cross-d-bar-troutranch.com
 cross.am
 cross.net.id
+crosscert.com
 crosscom.com
 crosskey.fi
 crosslac.com
@@ -7546,6 +7890,7 @@ crowley.pl
 crown.com
 crownaku.com
 crownnetworks.net
+crpfa.ro
 crpt.ru
 crschools.us
 crstelecom.com.br
@@ -7553,6 +7898,7 @@ crt.fr
 crtech.hk
 crtechnologie.com.br
 crts.gov.ma
+crucerodelnorte.com.ar
 crucial.ro
 crunchdev.com
 crusoeenergy.com
@@ -7575,6 +7921,7 @@ crytek.com
 csa1.com
 csas.cz
 csat.ru
+csbe.qc.ca
 csbf.qc.ca
 csc.com
 csc.ru
@@ -7594,6 +7941,7 @@ csdd.gov.lv
 csdesiles.qc.ca
 csdeu.net
 csdiran.ir
+csduroy.qc.ca
 cse.ru
 csebo.it
 cservis.cz
@@ -7602,6 +7950,7 @@ csgalileo.org
 csgarnet.com
 csgi.com
 csi-processing.com
+csihome.com
 csii.com.hk
 csimaisnet.com.br
 csiu.org
@@ -7622,6 +7971,7 @@ csolutions.lv
 csp-partnership.co.uk
 cspfmba.ru
 cspirefiber.net
+csportneuf.qc.ca
 csquaredsystems.com
 csra.com
 csrgc.com.cn
@@ -7686,6 +8036,7 @@ cube2.ee
 cubedata.net
 cubeglobalstorage.com
 cubeict.co.za
+cubic.com
 cubiclerebels.com
 cubilloconstrucciones.com
 cubiscomm.net
@@ -7721,6 +8072,7 @@ current-networks.com
 currenta.com
 currtins.com
 curtisinst.com
+curtisswright.com
 curug.id
 cus.pl
 cuscal.com
@@ -7743,11 +8095,14 @@ customs.gov.vn
 customs.tj
 customscard.ru
 custos.es
+cutco.com
 cuteip.net
 cutel.net
 cutx.org
 cuvic.es
 cuwest.org
+cuzk.cz
+cvch.org
 cvci.com.ar
 cvd.pl
 cve.com
@@ -7833,6 +8188,7 @@ cybersocafrica.com
 cyberspace.com.bd
 cyberspace.in
 cyberstreet.net
+cybertech.com
 cybertech.inf.br
 cybertech.ru
 cybertek.co.id
@@ -7902,6 +8258,7 @@ da.dk
 daa.ie
 daapply.com
 daaz.ru
+dabble.ventures
 dabis.eu
 dabltech.co.il
 dabrowa-gornicza.pl
@@ -7912,7 +8269,9 @@ daddario.com
 dadehpardaz.com
 daec.com.ar
 daedalean.ai
+daedelus.com
 daelim.co.kr
+daewonpharm.com
 daf.nl
 dafinternet.com
 dag.cars
@@ -7978,6 +8337,7 @@ danet.kh.ua
 danetworks.com.pk
 daneznet.com
 danfoss.com
+danga.com
 dangote.com
 daniel24.net
 danishbd.com
@@ -8000,16 +8360,21 @@ daramic.com
 daratel.com
 darbygroup.com
 darc.de
+darcom.com.ar
+darigold.com
 darinet.ru
 darkam.ru
 darkmatter-it.de
 darksystems.hu
+darktide.net
 darmajaya.ac.id
 darmstadt.de
 darnet.net.pl
 darnet.pl
 dars.si
+dart.biz
 dart.net
+dart.org
 dartcontainer.com
 darva.com
 darvagcloud.com
@@ -8018,6 +8383,7 @@ das-vierte-portal.de
 dasa3.com.br
 dasabo.com
 dasainfra.com
+dasanzhone.com
 dasarata.com
 dash.net.id
 dashersdugout.com
@@ -8026,6 +8392,7 @@ dassault-aviation.com
 dastans.ru
 dat1.net.ar
 data-edge.com
+data.com.au
 dataair.net.ec
 dataart.com
 dataartasedaya.net.id
@@ -8043,8 +8410,11 @@ datacentrics.com.br
 datacheck.com.pk
 dataco34.com.ar
 datacom.bg
+datacom.ca
 datacom.ind.br
 datacom.la
+datacom.mn
+datacomit.com.au
 datacor.com
 datacruz.com
 datacubo.net
@@ -8120,6 +8490,7 @@ dataremote.com
 dataroute.it
 dataru.ru
 datasafe.fi
+datasafesrv.com
 datasciences.co.za
 datasec.sa
 datasecuritynode.com
@@ -8136,11 +8507,13 @@ datatr.com
 datatrans.ch
 datavail.com
 datavault.com.pk
+dataveltro.com
 datavoip.com.ve
 dataways.gr
 datawebglobal.com
 datawise.com.ar
 dataworks-solutions.com
+dataxport.net
 dataxprs.com.eg
 datazyx.ro
 datcosoluciones.com.ar
@@ -8160,10 +8533,12 @@ datmit.com
 datonet.co.za
 datonet.cz
 datosdrive.com
+datosnet.com
 datum.net
 davaso.de
 davasolutions.ro
 davef.org
+davelbostoncoach.com
 davenpro.com
 davidjones.com.au
 davidscochran.com
@@ -8176,6 +8551,7 @@ dawis-it.pl
 dawn.tech
 dawnfoods.com
 dawnmeats.com
+dayliff.com
 daylily.network
 daypitney.com
 daystar.com
@@ -8196,11 +8572,13 @@ dbi7.net
 dbisp.net
 dbkl.gov.my
 dblc.it
+dbmteam.com
 dbolical.com
 dbqschools.org
 dbrt.hu
 dbs-africa.com
 dbs.si
+dbschenker-romtrans.com
 dbschenker.com
 dbselettronica.it
 dbsnetwork.net
@@ -8229,6 +8607,7 @@ dcn.net.id
 dcnov.ru
 dconekte.com.br
 dcpnetworks.com
+dcptech.com
 dcpud.org
 dcs.ru
 dcs.se
@@ -8251,6 +8630,7 @@ ddcpl.com
 ddecor.com
 ddgi.cat
 ddii.network
+ddiworld.com
 ddnbd.com
 ddosward.com
 ddpo.be
@@ -8272,6 +8652,7 @@ debacom.pl
 debee.net
 debeka.de
 debevoise.com
+deborahcareers.org
 dec.gov.bf
 decaresystems.ie
 decathlon.com
@@ -8355,8 +8736,10 @@ dekra.com
 del.ac.id
 delagelanden.com
 delavska-hranilnica.si
+delaware.coop
 delawarenorth.com
 delcampillocoop.com.ar
+delekus.com
 deletec.fr
 delfa.net
 delfi.lt
@@ -8373,6 +8756,7 @@ deliquesce.shop
 delix.in
 dell.com.cn
 delltelco.com
+delmontephil.com
 delo.si
 deloitte.at
 deloitte.com.au
@@ -8411,13 +8795,16 @@ delti.com
 deluxe.com
 deluxhost.net
 delwebb.com
+demabg.com
 dematic.com
+demax.bg
 demenin.net
 demirorenpetrol.com.tr
 democompunera.com
 demonware.net
 demos2clients.com
 dena.jp
+dendreon.com
 denet.se
 denga.ru
 dengisrazy.ru
@@ -8454,8 +8841,11 @@ depo-computers.com
 depogazploiesti.ro
 depozitarulcentral.ro
 deps.ua
+der.net.pl
 derak.cloud
+derco.cl
 deribit.com
+derivatives.com
 derivco.com
 derstandard.at
 dertour-suisse.com
@@ -8503,6 +8893,7 @@ devaharamassage.com
 devantis.com
 devboks.com
 devchandtelesoft.in
+devel.group
 develentcorp.com
 develia.pl
 developmentlogics.com
@@ -8535,6 +8926,7 @@ dextoolse.net
 dexwetholding.com
 dfafrica.co.zw
 dfccil.com
+dfckc.com
 dfcom.com.ar
 dfds.dk
 dfg.de
@@ -8545,6 +8937,7 @@ dfm.md
 dfmc.org
 dfri.net
 dfs.de
+dft.com
 dfw.ru
 dfz.bg
 dfz.zone
@@ -8565,6 +8958,7 @@ dgnservice.de
 dgp49.ru
 dgs.ru
 dgsnet.id
+dgssi.gov.ma
 dgtelworld.com
 dgtl.tech
 dgtt.pt
@@ -8590,6 +8984,7 @@ di.dk
 di.lv
 di.org
 dia.govt.nz
+diaconia.bo
 diadem-tech.com
 diag.ch
 diag.pl
@@ -8603,7 +8998,10 @@ dialwave.com
 diamedic.net
 diamond.co.id
 diamondinformatics.com
+diamondoffshore.com
 diamondresorts.com
+diamondsb.com
+diamwall.com
 dian.gov.co
 dianel.com
 diarads.net
@@ -8615,6 +9013,7 @@ dickerdata.com.au
 dickhannah.com
 dickkinglabs.top
 dickssportinggoods.com
+dicomgrid.com
 dicomgroup.com
 dics.com.ua
 didarit.com
@@ -8653,6 +9052,7 @@ digicom-al.net
 digicom.mn
 digicom.net.au
 digicontrol.com.br
+digicore.co.za
 digided.com
 digidesert.net
 digifinance.agency
@@ -8709,6 +9109,7 @@ digitalmoney.direct
 digitalnetcom.co.id
 digitalnetwork.com.np
 digitalo2.com.au
+digitalpaytech.com
 digitalprez.com
 digitalproserver.com
 digitalresources.net
@@ -8716,10 +9117,12 @@ digitalriverton.com
 digitalsatinternet.com.br
 digitalsea.in
 digitalsign.pt
+digitalsigncertificadora.com.br
 digitalsima.gr
 digitalstakeout.com
 digitaltelecom.net.br
 digitalvalue.es
+digitalventur.es
 digitalvirgo.com
 digitalvirt.com
 digitalvirtual.com.br
@@ -8727,6 +9130,7 @@ digitalvirtual.net.br
 digitalworldlink.com
 digitec.com.pg
 digitech.ru
+digitechcomputer.com
 digitel.ph
 digitiminimi.com
 digitro.com.br
@@ -8740,6 +9144,7 @@ digmedia.ch
 digmia.com
 dignusdata.com
 digora.com
+digris.net
 digta.net
 digtec.net.br
 digteltech.co.id
@@ -8759,6 +9164,7 @@ dima.hu
 dimar.it
 dimatica.es
 dimcomputers.com
+dimelonetwork.com
 dimensional.com
 dimensionesrl.eu
 dimex.mx
@@ -8782,6 +9188,7 @@ dinoex.de
 dinofelis.cn
 dinoki.id
 dinova.one
+diocesan.school.nz
 diocesidiroma.it
 diogenius.com
 dip-alicante.es
@@ -8800,6 +9207,7 @@ directcom.com
 directcore.com
 directcursuscst.com
 directdevelopment.com
+directgroup.com.au
 directlan.net.br
 directnet7star.com
 directone.ro
@@ -8848,6 +9256,7 @@ ditechonline.it
 ditek.dn.ua
 ditl5.ro
 ditonet.com.br
+divergentnetworks.co.uk
 diversa.ar
 diverse.services
 divingbell.dev
@@ -8869,6 +9278,7 @@ dlcga.com
 dldservicio.com
 dlfi.com
 dlg.im
+dlimonetnusantara.net
 dlink.com.au
 dlink.ru
 dlinternet.com.br
@@ -8882,6 +9292,7 @@ dm100.net
 dma.nl
 dmainc.com
 dmartindia.com
+dmba.com
 dmbasis.ru
 dmc.or.kr
 dmc24-marketing.de
@@ -8896,11 +9307,14 @@ dmgtic.com
 dmlot.com
 dmnetpe.com.br
 dmntr.es
+dmos.com
 dmrc.org
+dmsas.com
 dmt.com.pl
 dna.net.id
 dnb.com
 dncc.de
+dncp.gov.py
 dndconnections.ca
 dndnordic.se
 dnetce.com.br
@@ -8911,12 +9325,14 @@ dnexpress.info
 dnhost.gr
 dnic.gov.tl
 dniprorada.gov.ua
+dnk.co.id
 dnpnetworks.net
 dns-nac-zone.com
 dns-net.ch
 dns-oarc.net
 dns-oid.com
 dns-shop.ru
+dns.jp
 dns.net.id
 dns.nic.in
 dns.pl
@@ -8959,6 +9375,7 @@ doc.govt.nz
 docaposte.fr
 docentris.ro
 docker.ru
+doco.com.tr
 docomointertouch.com
 docoschools.org
 doctorswithoutborders.org
@@ -8997,6 +9414,7 @@ dolphnet.lv
 dom-seti.ru
 dom.de
 domain-robot.org
+domain.me
 domain247.fi
 domainbridge.net
 domainnoc.de
@@ -9047,6 +9465,7 @@ dorfner-gruppe.de
 dormakaba.com
 dormantrading.com
 dornanet.ca
+dornbirn.at
 dorontobd.com
 dorsa.cloud
 doscredobank.kg
@@ -9058,6 +9477,7 @@ dot.ph
 dotcomm.org
 doterra.com
 dotfoods.com
+dothan.org
 dothousedigitalclients.com
 dotidea.ca
 dotin.ir
@@ -9066,6 +9486,8 @@ dotnet-ks.com
 dotnet.com.pk
 dotpay.pl
 dotsrc.org
+douala-ix.net
+doubledogadventures.com
 doublektech.com
 doubleverify.com
 doubrava.net
@@ -9097,6 +9519,7 @@ dpd.co.uk
 dpd.com
 dpd.com.pl
 dpd.ie
+dpd.lt
 dpd.lv
 dpd.ru
 dpdc.gov.bd
@@ -9165,6 +9588,7 @@ drovia.sh
 drpa.org
 drpbd.cn
 drplombir.ru
+drreddys.com
 drs.com
 drserver.net
 drsk.ru
@@ -9180,6 +9604,7 @@ ds.network
 dsau.co
 dsb.dk
 dsbn.org
+dscbg.com
 dscicorp.com
 dscsrl.it
 dscw.io
@@ -9189,6 +9614,7 @@ dsi.com.do
 dsi.ru
 dsisystems.com
 dsk-kielce.pl
+dskytech.id
 dsl.net
 dsldhomes.com
 dsmairport.com
@@ -9296,6 +9722,7 @@ dwb.pl
 dwe.de
 dwebs.uk
 dwelle.de
+dwihn.org
 dwlcka.com
 dws.rip
 dwsistemas.com
@@ -9307,7 +9734,9 @@ dyandraborneonetwork.com
 dyckerhoff.com
 dyckerhoff.pl
 dyfedit.co.uk
+dylt.com
 dyn-intl.com
+dynacomcenter.com
 dynacon.pl
 dynamic-wiretel.in
 dynamicanalojix.net.bd
@@ -9319,6 +9748,7 @@ dynascale.com
 dynawebfoundation.org
 dyne-tx.com
 dynetics.com
+dynfi.com
 dyntcorp.com
 dynu.com
 dyon-network.ro
@@ -9345,6 +9775,7 @@ e-gov.bg
 e-ins.net
 e-interra.ru
 e-intidata.com
+e-jejubank.com
 e-jogajog.com
 e-kancelaria.com
 e-mcit.gov.mm
@@ -9373,7 +9804,9 @@ e3webmail.com
 e4connect.com
 eac.com.cy
 eacs.k12.in.us
+eadsnorthamerica.com
 eafit.edu.co
+eagle.co.nz
 eagle.org
 eaglenet.net.lb
 eagleredes.net.br
@@ -9384,6 +9817,8 @@ eaglets.co.il
 eaglezip.com
 eaiti.com
 eam-netz.de
+eamc.org
+ean.edu.co
 eancenter.com
 eangkong.com
 eans.ee
@@ -9413,6 +9848,7 @@ easycable.com.au
 easycare.com
 easycash.de
 easycloud.com.my
+easycompute.co.uk
 easycredit.bg
 easydatahost.com
 easyfiber.net.br
@@ -9442,12 +9878,15 @@ eblissinfosys.com
 eblxon.com
 ebmpapst.com
 ebner.cc
+ebocom.net
 ebox.pl
 eboxwise.com
 ebp.ch
 ebrokernet.com
+ebrso.org
 ebrz.at
 ebs-integrator.com
+ebs.ie
 ebswien.at
 ebttikar.com
 ebu.ch
@@ -9457,6 +9896,7 @@ ebuyer.com
 ebv.com
 ebx.pl
 eca-vaud.ch
+ecadlabs.com
 ecakognanan.com
 ecall-messaging.com
 ecall.ua
@@ -9472,6 +9912,7 @@ ecdaoductsservi-com.icu
 ecentric.co.za
 ecentry.com
 ecfiber.net
+ecfmg.org
 echd.org
 echidnainc.com
 echo.com
@@ -9527,17 +9968,22 @@ ecozum.com.tr
 ecpi.com
 ecs.be
 ecs.gov.bd
+ecsanet.net
 ecsfinancial.com
 ecstuning.com
 ectrading.at
 ecu.com
 ecu.org
 ecuahosting.net
+ecuared.ec
 ecuatek.net
 ecutechnology.com
 ecx.co.za
+ecxsystems.com
 eczacibasi.com.tr
+ed-3.org
 ed-partner.ru
+eda-on.ca
 edainfo.com.br
 edata.com.vn
 edb.com
@@ -9562,6 +10008,7 @@ edfman.com
 edftrading.com
 edgarhighspeed.com
 edge-net.net
+edge.network
 edge4m.com
 edgeam.am
 edgecast.io
@@ -9587,6 +10034,7 @@ edicom.es
 edigital.co.in
 edin.ua
 edinaschools.org
+edinburghhacklab.com
 edinros.ru
 edison-bd.com
 edisongn.com
@@ -9596,6 +10044,7 @@ edit.ne.jp
 editnet.ad.jp
 ediweb.com
 edizanet.com.br
+edl.com.la
 edm.co.mz
 edmamericas.com
 edmclain.com
@@ -9603,6 +10052,7 @@ edmi.co.nz
 edmond-de-rothschild.com
 edmond-de-rothschild.fr
 edmondok.com
+edmunds.com
 ednet-telecom.com.br
 ednt.de
 edora.dk
@@ -9611,6 +10061,8 @@ edp.com
 edp.com.br
 edp.pt
 edpnet.com
+edps.gr
+edrnet.com
 eds-group.com.ua
 edtbauer.com
 edtns.net
@@ -9661,6 +10113,7 @@ efor.es
 efs-ag.com
 eft-group.net
 eftcorp.com
+eftex.com.au
 eftsource.com
 efulife.com
 efwnow.com
@@ -9683,6 +10136,7 @@ eggie.services
 egios.com
 egis.hu
 egitdns.com
+eglobal.com.mx
 egltours.com
 egm.org.tr
 egmont.com
@@ -9698,6 +10152,7 @@ egt-bg.com
 egt-digital.com
 egusd.net
 egx.com.eg
+egyptianbanks.net
 egyptianlng.com
 ehamnet.cz
 ehealthsask.ca
@@ -9721,12 +10176,14 @@ eilopu.iki.fi
 eimskip.is
 einbecker-buergerspital.de
 einetwork.net
+eink.com
 eins-energie.de
 eips.ca
 eirevo.ie
 eirtelservices.com
 eis.co.id
 eis.it
+eis.net.au
 eisai.com
 eisenia.se
 eisenmann.tech
@@ -9790,6 +10247,7 @@ elcorteingles.es
 elcrodigital.com
 elcuk.pl
 eldata.cz
+eldoinc.com
 eleconinfotech.in
 elecsnet.ru
 elections.am
@@ -9835,7 +10293,9 @@ eleusi.com
 elevatedcomputing.com
 elevatedmsp.com
 elevatehomescriptions.com
+elevatetextiles.com
 elevateu.work
+elevationscu.com
 eleveninternet.net
 elevi.ee
 elewise.com
@@ -9878,14 +10338,18 @@ elixirzorka.xyz
 elizovotv.ru
 eljawal.mr
 elk-wue.de
+elkgrove.org
 elkhart.net
 elkman.pl
 elko.lv
 elko.ua
+elkom.at
 ellaktor.gr
+ellerstoncapital.com
 ellevio.se
 ellex.lt
 elliot-hs.org
+elliottelectric.com
 elliottmgmt.com
 ellipse.ua
 ellisphere.com
@@ -10010,6 +10474,7 @@ emsgateway.net
 emsservices.ch
 emtn.co.id
 emtorp.se
+emu.st
 emutel.com.au
 en-linc.com
 en.net.nz
@@ -10066,6 +10531,7 @@ energospb.ru
 energotransbank.com
 energymeteo.systems
 energysterling.com
+energyview.com
 enericloud.com
 enerjisauretim.com.tr
 enersa.net.ar
@@ -10115,6 +10581,7 @@ enlacewifi.net
 enloe.org
 enmail.co
 enmg.nl
+ennia.com
 enoc.com
 enormity.com.br
 enosys.com.au
@@ -10212,16 +10679,21 @@ epik.com
 epilog.net
 epiqsystems.com
 epis.or.kr
+episcopalacademy.org
 episd.org
+episerver.com
 epita.fr
 epix.net.pl
 epkstd.ru
+epl.ca
+eplinc.com
 epm.com.co
 epn.edu.ec
 epoczta.pl
 epoka.tv
 eponet.pl
 eport.gr
+epostopia.com
 epoxynetworks.company
 epresaenergia.es
 eprovider.no
@@ -10236,10 +10708,12 @@ epsnj.org
 epson.com
 epssw.com
 epte.fi
+epworth.org.au
 epylliongroup.com
 eq-s.ru
 eqipe.ch
 eqr.com
+eqt.com
 equans.nl
 equant.ch
 equate.com
@@ -10254,10 +10728,13 @@ equinox.co.nz
 equinoxcommunications.com
 equinoxpayments.com
 equinux.com
+equitable.ca
 equitableholdings.com
 equnix.asia
 equtechs.com
+equuspartners.com
 eqvilent.com
+era.ca
 era.si
 eramahaputra.co.id
 eranet.id
@@ -10265,6 +10742,7 @@ eranium.io
 eraps.ru
 erate.no
 eratraders.com.bd
+erbacom.com
 erbilairport.com
 erc-fl.ru
 erciyesanadolu.com
@@ -10280,12 +10758,15 @@ erg.kz
 ergo-versicherung.at
 ergo.com
 ergo.ee
+ergogroup.com
 ergohellas.gr
 ergohestia.pl
 ergon.ch
+ergon.com
 ergonet.pl
 ergons.ru
 ergos.com
+erickson.com
 ericom.online
 ericsson.hr
 ericwebsolutions.com
@@ -10310,6 +10791,7 @@ eroski.es
 erp.bg
 err.ee
 ersmyanmar.com
+ersteit.com
 ert.gr
 ertebanet.com
 ertebat-pardis.ir
@@ -10344,6 +10826,7 @@ esconsultinginc.com
 escuelaing.edu.co
 esd112.org
 esendex.com
+esersec.com
 eserv.net.br
 eserver.rs
 eservice.com.pl
@@ -10394,6 +10877,7 @@ esprimo.com
 esprinet.com
 espublico.com
 espyr.cloud
+esquinaimagentv.com.ar
 esquirecs.com
 ess.ro
 essarsteel.co.in
@@ -10438,6 +10922,7 @@ etarget.fr
 etc.vn
 etcsolutions.co.za
 eteccinformatica.com.br
+etecevs.com
 etechgs.com
 etel.kz
 etel.vn
@@ -10544,6 +11029,7 @@ euroline.com.ua
 eurolir.kiev.ua
 eurolog.com
 euromadi.es
+euromasterbg.com
 euromed-marseille.com
 euronet.com
 euronet.net.pl
@@ -10574,6 +11060,7 @@ eurspa.it
 eustream.sk
 eutelnv.com
 eutelsatnetworks.ru
+ev-heimstiftung.de
 ev-o-tec.de
 ev.link
 ev.lt
@@ -10591,6 +11078,7 @@ eventinfra.org
 eventkey.pt
 eveocloud.net
 everbank.com
+everbridge.com
 evercore.com
 everdata.fr
 everence.com
@@ -10669,6 +11157,8 @@ evrohimservis.ru
 evrotrust.com
 evs18.com
 evsio0n.com
+evt.com
+evtsp.com
 ewb.ch
 ewconnect.it
 eweb.org
@@ -10702,6 +11192,7 @@ exahost.ru
 exaion.com
 example.com
 exampleusercontent.com
+exandas.com.gr
 exanet.pl
 exanetix.com
 exaring.de
@@ -10711,6 +11202,7 @@ exaservers.com
 exat.co.th
 exatech.com.do
 excbase.com
+excelacom.in
 excelinc.com
 excelindo.co.id
 excelligence.com
@@ -10738,6 +11230,7 @@ exiar.ru
 exigentnetworks.ie
 exiger.com
 exigo.ch
+eximbank.com.vn
 eximtur.ro
 exin.kz
 exinity.com
@@ -10808,6 +11301,7 @@ extranet.co.in
 extranet.com.tr
 extranet.cz
 extranetsystems.com.au
+extraspace.com
 extratransport.com.au
 extreme-ix.org
 extreme.co.th
@@ -10822,6 +11316,7 @@ eycpluss.com
 eyecandyhosting.xyz
 eyecast.com
 eyeeighty.us
+eyeo.com
 eyepea.net.uk
 eyonrv.com
 ez.pro
@@ -10851,16 +11346,19 @@ f-regi.co.jp
 f-worker.co.kr
 f.st
 f1-communications.net
+f12data.com
 f1soft.com
 f24.com
 f3netze.de
 f6.ru
 f72.ru
 f9.fi
+faa.mil.ar
 faasri-net.co.id
 fab-it.dk
 fab-k.ru
 fab.mil.br
+fabasoft.com
 fabconnectprovedor.net.br
 faber-castell.de
 faberlic.com
@@ -10890,6 +11388,7 @@ fahnet.in
 fahsai-thaimassage.com
 fai.com.br
 fair.bg
+fairfaxwater.org
 fairnetzgmbh.de
 faisal.my
 faistgroup.com
@@ -10900,6 +11399,7 @@ faktura.ru
 fal-networks.com
 fal.moe
 falabella.com
+falaknet.online
 falcom.net.pl
 falcon.com.pa
 falconbandalarga.com.br
@@ -10908,6 +11408,7 @@ falconlink.net.bd
 falconplus.ru
 falcore.com.au
 falenet.com.br
+falkentire.com
 falun.se
 famaserver.com
 familydollar.com
@@ -10969,6 +11470,7 @@ fastcloudpr.net
 fastcom.in
 fastcon.it
 fastconnect.id
+fastenal.com
 fastenterprises.com
 faster.com.br
 faster.id
@@ -11015,6 +11517,7 @@ fastwebnet.it
 fastwebserver.de
 fatmedia.co.uk
 fattoriaimperiale.com
+faurgs.com.br
 fawry.com
 faxage.com
 faxton-stlukes.com
@@ -11025,6 +11528,7 @@ fazznet.co.id
 fb7qfh5ukg.com
 fba.ba
 fbase.co.uk
+fbbrands.com
 fbc-tele.com
 fbc.co.zw
 fbd.al
@@ -11042,6 +11546,8 @@ fcboe.org
 fcbv.vn
 fcdl-sc.org.br
 fcec.coop
+fceinc.com
+fci.com
 fci.ru
 fciit.ru
 fcl.com.br
@@ -11062,6 +11568,7 @@ fecrwy.com
 federacionnet.com.ar
 federalcartridge.com
 federatedinsurance.com
+federatedinv.com
 fedexfreight.com
 fedorov.net
 feedbackinfra.com
@@ -11105,6 +11612,7 @@ fernheim.com.py
 ferrarausa.com
 ferrero.com
 ferrexpo.ua
+fes.org
 fesco.com
 festfoods.com
 fetchtv.com.au
@@ -11124,6 +11632,7 @@ ffuessl.com
 fg.gov.ua
 fgdb.ro
 fghrsh.net
+fgiltd.com
 fginformaticatupan.com.br
 fglife.com
 fgov.be
@@ -11190,7 +11699,9 @@ fibroidinfo.com
 fibron.br
 ficarnettelecom.com.br
 ficial.net
+ficoh.com
 ficosa.com
+fictionpress.com
 fidelidade.pt
 fidelisinsurance.com
 fidelitylife.co.nz
@@ -11202,6 +11713,7 @@ fiege.de
 fieldii.com
 fiery.com
 fiescnet.com.br
+fifa.com
 fifacorp.co.id
 fijiairports.com.fj
 fil.com
@@ -11215,6 +11727,7 @@ filmon.com
 filnet.es
 filproducts-cyg.com
 filproductsnegros.net
+filtered.net
 filtiwan.com
 fimap.com
 fin-crime.com
@@ -11242,6 +11755,7 @@ finchsolucoes.com.br
 finclearservices.com.au
 fincors.org
 findea.ch
+findernet.work
 finderpumps.com
 findsns.net
 finecobank.com
@@ -11251,6 +11765,7 @@ fingrid.fi
 finieris.lv
 finint.com
 finisar.com
+finite-soft.com
 finkzeit.at
 finnacloud.com
 finra.org
@@ -11274,6 +11789,8 @@ firecredit.eu
 firedogssc.com
 firefightersfirstcu.org
 firefly-solution.com
+firelands.com
+fireminds.com
 firemountaingems.com
 fireserve.com
 fireserver.ir
@@ -11295,6 +11812,7 @@ firstbyte.club
 firstcarbonsolutions.com
 firstcomcu.org
 firstcomeurope.dk
+firstcommand.com
 firstdata.com
 firstdata.com.au
 firstdata.pl
@@ -11350,6 +11868,7 @@ fivendro.com
 fiveneins.com
 fivenet.mk
 fivestar.net.id
+fivestarcallcenters.com
 fixcloud.com.tr
 fixedmea.com
 fixflyer.com
@@ -11368,6 +11887,7 @@ fju.edu.tw
 fk.dk
 flag.org
 flaglerhospital.com
+flairdata.com
 flamehost.com.br
 flanco.ro
 flannel-pajamas.shop
@@ -11387,6 +11907,7 @@ flashstart.com
 flashtalking.com
 flashwifi.com.br
 flatlandsbelgians.com
+flatnet.gen.nz
 flatplanetphone.com
 flcancer.com
 flclerks.com
@@ -11421,16 +11942,19 @@ flextech.com
 flextel.com
 flextrade.com
 flexyz.com
+flhealth.org
 flickswitch.co.za
 flightaware.com
 flightcentre.com.au
 flightradar24.com
 flightsafety.com
 flink.uz
+flintmail.com
 flipconnect.com.au
 flirble.org
 flix.psi.br
 flixout.com
+flmarine.com
 flo-networks.com
 flokk.com
 floknet.id
@@ -11455,9 +11979,11 @@ flowhardware.ch
 flowlinetechnologies.com
 flowmailer.com
 flowmon.com
+floworkspvf.com
 flowretail.no
 flowspec.net.br
 flowtraders.com
+floydmedicalcenter.com
 flsmidth.com
 fluctus.at
 flughafen-linz.at
@@ -11481,6 +12007,7 @@ flyinggoosesystems.com
 flyjacksonville.com
 flylcpa.com
 flylifecuador.com
+flynas.com
 flynashville.com
 flynet-isp.com
 flynet.com.py
@@ -11512,6 +12039,7 @@ fmins.com
 fmis.gov.kh
 fml.co.za
 fmnetworks.net
+fmnplc.com
 fmo-solutions.nl
 fmo.de
 fmr.co.il
@@ -11540,7 +12068,9 @@ fnxtelecom.net.br
 fnysllc.com
 fnz.co.uk
 fnz.com
+foa.org.br
 foamline.com
+foconis-payment.com
 focusbrands.com
 focusmt.com
 focusnet.de
@@ -11554,6 +12084,7 @@ foleyhoag.com
 folkanimals.com
 folksfestival.com
 follettcontent.com
+followmont.com.au
 fon.co.ke
 foncor.ru
 fonecloud.io
@@ -11575,6 +12106,7 @@ foodcare.pl
 foodcoop.com
 foodlion.com
 foodmaster.kz
+foodstuffs-si.co.nz
 foodtodonate.com
 foodunion.lv
 foodworks.com.au
@@ -11597,6 +12129,7 @@ forestracks.com
 forestriverinc.com
 forestsnet.com
 foreverliving.com
+forfarmerscorporateservices.eu
 forinicom.it
 forksystems.net
 format-c.pro
@@ -11623,6 +12156,7 @@ fortex.com
 forthepeople.com
 forthports.co.uk
 fortion.cz
+fortisalberta.com
 fortisbc.com
 fortiva.net.id
 fortlab.us
@@ -11635,12 +12169,15 @@ forttechnologies.com
 fortum.ru
 fortuna-dv.ru
 fortunat.kiev.ua
+fortwayne.com
 fortytwo.nl
 forum-auto.ru
 forum.cl
 forum.org.ng
 forumcu.com
 fosdem.org
+fosdickcorp.com
+fostercity.org
 fosterfarms.com
 fosterheap.com
 fotexnet.info
@@ -11668,6 +12205,7 @@ foxconn.com
 foxconnectfiber.com.br
 foxcorporation.com
 foxfiber.net.br
+foxguardsolutions.com
 foxitsign.com
 foxline.net.id
 foxnet.net.br
@@ -11681,8 +12219,10 @@ foxthermalinstruments.com
 fozzy.ua
 fpg.com.tw
 fpg.ru
+fpj.com.py
 fpnet.net.br
 fppressa.ru
+fprs.com
 fptcloud.com
 fpte.br
 fr89.uk
@@ -11702,7 +12242,9 @@ francetelevisions.fr
 franciliens.net
 franco-nord.ca
 frankcrum.com
+franklin-electric.com
 franklin-ky.net
+franklin.oh.us
 franklinresources.com
 fransabank.com
 franz-net.hr
@@ -11757,6 +12299,7 @@ freifunk-kitzingen.de
 freifunk-rheinland.net
 freifunk-stuttgart.de
 freifunk.net
+freightways.co.nz
 freitag.ch
 frejaeid.com
 fremaks.de
@@ -11772,6 +12315,7 @@ fresenius.com.pl
 fresenius.de
 freseniusmedicalcare.us
 freshcodeac.com
+freshdata.eu
 freshdirect.com
 freshperf.fr
 freshplanners.pl
@@ -11780,14 +12324,17 @@ freshtel.my
 fresnosheriff.org
 freudenberg.com
 frg-rad.com
+frhs.org
 friedfrank.com
 friendit.net
 friendowment.us
 frinet.pl
 frings-solutions.de
+frisia.coop.br
 fritz.com
 fritz.us.com
 fritzlab.net
+fritzware.com.ar
 frk.com
 frode-laursen.dk
 frogmo.com
@@ -11810,14 +12357,19 @@ frprf.ru
 fryslan.frl
 fryzl.net
 fs-itsysteme.de
+fs.com.pk
 fs.net.br
 fsc.ua
 fscu.com
+fsf.org
+fshl.com
+fsimilares.com
 fsk.ru
 fsksz.ru
 fsoft.com.vn
 fsrar.ru
 fsresidential.com
+fsst.org
 fst.gs
 fstravel.com
 ft-wayne.in.us
@@ -11845,6 +12397,7 @@ ftsi.com
 ftstoday.com
 ftthtelecom.com.br
 ftz.dk
+fubonhyundai.com
 fuburg.com
 fugro.com
 fujifilm.com
@@ -11855,6 +12408,7 @@ fulair.com
 fulfillmentamerica.com
 fulgentgenetics.com
 fullconection.cl
+fuller.com.mx
 fullertonindia.com
 fullflavour.nz
 fullnet.com.ar
@@ -11928,6 +12482,8 @@ fynskemedier.dk
 fz.k12.mo.us
 fz.sk
 fzo.org.mk
+g-able.com
+g-direct.de
 g-ho.st
 g-service.ru
 g-star.com
@@ -11947,6 +12503,7 @@ gab.com
 gabrielcares.com
 gadens.com
 gadsdenschools.org
+gaf.com
 gagnaveitan.is
 gagosian.com
 gaharu.co.id
@@ -11983,6 +12540,7 @@ galeranerdfibra.com.br
 galexis.com
 galiciaseguros.com.ar
 gallagherbassett.com.au
+gallatinsteel.com
 gallery-chizhov.com
 gallery.kg
 gallup.com
@@ -12027,6 +12585,7 @@ ganeshadatanusantara.com
 gangbild.net
 gangeskar.com
 ganjingworld.com
+gantner.com
 ganzrund.com
 gap.com
 gap.im
@@ -12036,6 +12595,7 @@ garage12.id
 garak.co.kr
 garant.by
 garantibbva.com.tr
+garberauto.com
 garbinc.com
 gardamor.net
 gardencity.games
@@ -12056,6 +12616,7 @@ gartnerkg.com
 garuda-cement.com
 garuda.network
 garudanet.com
+garvoo.com
 gascade.de
 gasconnect.at
 gaserviceinternet.com.br
@@ -12070,11 +12631,13 @@ gateit.net
 gates.com
 gatesfoundation.org
 gatet1.it
+gatewayairport.com
 gatewayinfocomm.com
 gatewayteleport.com
 gati.com
 gatiman.net
 gatineau.ca
+gatx.com
 gausus.net
 gavdavison.com
 gaveainvest.com.br
@@ -12085,6 +12648,7 @@ gaya.sk
 gayatri.net.id
 gaylordhotels.com
 gaysino.net
+gaz-system.pl
 gazal.com.au
 gazin.com.br
 gazon.in
@@ -12190,6 +12754,7 @@ gelbergroup.com
 gelephudigitalnetwork.com
 gelicon.ru
 gelkanet.hu
+gellerco.com
 gelsen-automaten.de
 gemaaccess.com
 gemeente.it
@@ -12206,6 +12771,7 @@ gen-i.si
 gen-net.com.sg
 gena.host
 genap.id
+genbank.ru
 genc.net.tr
 gendalf.ru
 gendigital.com
@@ -12288,6 +12854,7 @@ geotelecom.ru
 geox.com
 gepard.dn.ua
 geracaonet.com.br
+gerbangnusantarasakti.net
 gerbers.com
 gergihalo.hu
 gerichte-zh.ch
@@ -12296,11 +12863,13 @@ germaniasport.hr
 germantownfriends.org
 geroldsgruen.net
 gerrit.nl
+gerryweber.de
 ges.com.ro
 ges.net.pk
 gesa.com
 gesbg.com
 gespag.at
+gestamp.com
 gestelcom.es
 gestreeremoval.com
 gesundheitnord.de
@@ -12332,10 +12901,12 @@ geusgruppen.se
 gewapecloud.com
 gfail.net
 gfbankas.lt
+gfbinsurance.com
 gfi.world
 gfk.com
 gfkl.com
 gfn-olfen.de
+gfnet.com
 gfo-online.de
 gfs.ge
 gftelecom.com.br
@@ -12470,8 +13041,11 @@ gir-orel.ru
 giradia.id
 girardi-rs.com.br
 girdharicomp.in
+gire.com
+giregional.org
 girey.net
 giridatasolusindo.com
+giro.sk
 girosol.com
 gis.net
 gisa.de
@@ -12496,6 +13070,7 @@ giztech.co.id
 gjames.com
 gjcity.org
 gjovik.kommune.no
+gjuss.zp.ua
 gk-is.ru
 gk-network.net
 gk-osnova.ru
@@ -12541,6 +13116,7 @@ glezspectrum.com
 glg.it
 glhnetsolutions.fi
 glhomes.com
+glic.com
 glidesystems.lat
 glidewelldental.com
 glinetele.com
@@ -12565,9 +13141,11 @@ global-ua.com
 global-x.ru
 global.com
 global.com.pg
+global.com.tr
 global.komatsu
 globalagilitysolutions.com
 globalai.com
+globalair.com
 globalasta.id
 globalbilgi.com.tr
 globalbilgi.com.ua
@@ -12583,6 +13161,7 @@ globaldigitalcore.com
 globalexperts.pk
 globalforway.com
 globalfoundries.com
+globalgate.net.ar
 globalglennpartners.com
 globalgridcarrier.com
 globalhostingsolutionsinc.com
@@ -12673,6 +13252,7 @@ glostrup.dk
 gloucester.nj.us
 glovis.net
 glowingtechsecurity.net
+glpropinc.com
 gls-group.eu
 gls-itservices.com
 gls-poland.com
@@ -12683,6 +13263,7 @@ gm.st
 gmaxbd.com
 gmaxconnect.com
 gmbx.asia
+gmcr.com
 gmfinancial.com
 gmg.biz
 gmhost.com.ua
@@ -12735,6 +13316,7 @@ go.vn
 go2cloud.in
 go2matrix.net
 goagex.net
+goalnowtech.com
 goannanetworks.com.au
 gobba.me
 gobiernodecanarias.org
@@ -12744,6 +13326,7 @@ gocenet.net
 gocode.it
 gocontact.pt
 gocurb.com
+godfreyhirst.com
 godlike.host
 godmanamgerpa.com
 godoyle.com
@@ -12767,6 +13350,7 @@ goinet.com
 goipglobalnet.com
 gol.net.gy
 goldapple.ru
+goldbergkohn.com
 goldconnect.com
 golden.net.id
 golden1.com
@@ -12775,6 +13359,7 @@ goldendragon2000.com
 goldenlines.net.il
 goldenlink.com.br
 goldennewsitestradess.live
+goldenvm.com
 goldergeophysics.com
 goldfiber.com.br
 goldfields.com
@@ -12826,8 +13411,10 @@ gorodigitalnusantara.net
 gorodok1.ru
 gorodskie-seti.ru
 gorrissenfederspiel.com
+gorzow.pl
 gosb.com.tr
 goshairhatonlinenetwork.com
+goshenhealth.com
 gosun.com
 gosyennet.id
 goterramfg.com
@@ -12852,11 +13439,13 @@ gov35.ru
 gov39.ru
 government.ru
 governo.it
+govfaciltecnologia.com.br
 govista.com.bo
 govkorea.co.kr
 govoffice.com
 govorit.ru
 goway.net
+gowisercorporation.com
 gowtechno.com
 goyapr.com
 gozfly.com
@@ -12866,6 +13455,7 @@ gozunga.com
 gp-net.bg
 gpb.org
 gpcl.com.au
+gpec.pl
 gpee.com.ua
 gphealth.org
 gpih.ge
@@ -12878,6 +13468,7 @@ gpm.gov.tl
 gponperu.com
 gpost.ge
 gpr.com.br
+gpreinc.com
 gps.bg
 gpsconnection.com
 gpspd.ru
@@ -12897,6 +13488,7 @@ grafixgalore.com
 graha.net.id
 grahafatta.com
 grahamcapital.com
+grahamhospital.org
 grahamtechnology.net
 graian.ch
 grajaunettelecom.com.br
@@ -12911,6 +13503,7 @@ grand-capital.pro
 grand-central.net
 grand-rapids.mi.us
 grandandtoy.com
+grandbesancon.fr
 grandbo.com.ph
 grandconsult.ru
 grandenet.com.br
@@ -12967,6 +13560,7 @@ greataccess.com
 greatcircus.ru
 greatestworldnews.com
 greathealthworks.com
+greatland.com
 greatpeanuttour.com
 greatplains.net
 greciandelight.com
@@ -12985,6 +13579,7 @@ greendata.fr
 greendotcorp.com
 greenedge.cloud
 greenet.nl
+greenfiber.net.br
 greeng.co.za
 greenheck.com
 greenhousing.cz
@@ -12992,6 +13587,7 @@ greenlightcapital.com
 greenlightcrm.com
 greenlinetech.com
 greenmini.nl
+greenmountaintechnology.com
 greennet.vn
 greennetworks.ge
 greennutritioncare.com
@@ -13002,6 +13598,7 @@ greenstate.org
 greentech.ro
 greentube.com
 greentv.ge
+greenvillelibrary.org
 greenvillewater.com
 greenwebsoftwaredevelopment.com
 greenwingtechnology.com
@@ -13045,7 +13642,9 @@ grmml.net
 grn.cat
 grn.es
 grnet365.gr
+groceryoutlets.com
 gronext.com
+grootop.in
 grooveshark.com
 groovetherapyam.com
 groovyhoax.info
@@ -13076,6 +13675,7 @@ grt.net.id
 grtgaz.com
 grudnik.pl
 grundfos.com
+grundyiptransport.com
 grunenthal.de
 gruop-miki.cam
 grupa-sbs.pl
@@ -13141,6 +13741,7 @@ grzeszczuk.net
 gs-bates.com
 gs-wd.de
 gs.ru
+gs1.ro
 gs2e.ci
 gsacapital.com
 gsb.or.th
@@ -13151,9 +13752,11 @@ gscs.ca
 gse.com.do
 gse.com.ge
 gsgh.cn
+gshealth.org
 gshleb.org
 gsjztech.top
 gsk.com
+gsksmo.org
 gsline.am
 gsmnet.id
 gsnet.cz
@@ -13173,6 +13776,7 @@ gstn.org.in
 gstsoft.in
 gsy.it
 gtaa.com
+gtbindians.org
 gtcnetworking.com
 gtec.net
 gtech.com
@@ -13188,7 +13792,9 @@ gtncpl.com
 gtnet.net.br
 gtnetrd.net.br
 gtp.or.kr
+gtplimited.com
 gtrustsec.ro
+gts.nl
 gtsbrasil.com.br
 gtsc.vn
 gtsi.com
@@ -13200,6 +13806,7 @@ guaraciaba.net.br
 guaradigital.com.br
 guaranteedrate.com
 guaratiba.net.br
+guard.com
 guardant.ru
 guardey.com
 guardfox.com
@@ -13269,6 +13876,7 @@ gvb.ch
 gvb.nl
 gvcgroup.com
 gvd.dk
+gvea.com
 gvv.me
 gw-gwa.com
 gw-world.com
@@ -13327,12 +13935,15 @@ hachettebookgroup.com
 hackdv.com
 hackspace.com
 hackthebox.com
+hacon.de
 hactl.com
 hadassah.org.il
+haddad.com
 haderslev.dk
 hadoopsky.xyz
 haedefpartners.com
 haemimont.com
+haesungds.co.kr
 hafslund.no
 hager.com
 hagerty.com
@@ -13398,6 +14009,7 @@ hankinstech.com
 hanming.com
 hannabrophy.com
 hannay.id.au
+hannet.net
 hanover.com
 hansaluftbild.de
 hanse.com
@@ -13444,6 +14056,7 @@ hardworkinghuman.co
 harel-group.co.il
 harlancohealth.org
 harlandclarke.com
+harlandfinancialsolutions.com
 harlanonline.net
 harley-davidson.com
 harman.com
@@ -13463,7 +14076,9 @@ harriscollect.com
 harrismadatacitta.id
 harstad.kommune.no
 hartinc.com
+hartsoftware.com
 hartsystems.com
+harvest.com
 harvestr.ru
 harvestvintage.ca
 harvey.lib.il.us
@@ -13471,6 +14086,7 @@ harveynorman.com
 has-net.ru
 hasbro.com
 hasd.com.vn
+haseco.vn
 hasgard.net
 hashit.space
 hashpal.net
@@ -13506,11 +14122,13 @@ hawaiipacifichealth.org
 hawkaccess.com
 hawkesbay.health.nz
 hawknetlabs.au
+haworth.com
 hawthorneatleesburg.com
 hayashimo.net
 hayat.com.tr
 haykalsolutionstechnology.id
 haykcom.am
+haynesfurniture.com
 haynet.co.id
 haypem.net
 hays.com.au
@@ -13526,6 +14144,7 @@ hbeark.com
 hbgelec.com
 hbglaw.com
 hbh.dk
+hbham.com
 hbi.net
 hbisserbia.rs
 hbk.com
@@ -13560,6 +14179,7 @@ hctc.com
 hd.hu
 hdbfs.com
 hdc.govt.nz
+hdce.ca
 hdec.co.kr
 hderit.com
 hdesd.org
@@ -13594,13 +14214,16 @@ healthypeoplesclub.top
 heartbeat-it.com
 heartflow.com
 heartlandexpress.com
+heartlandregionalmedicalcenter.com
 heartlandremc.com
 heartnetwork.jp
 heathrow.com
+heavensystem.com.br
 heavyduty-us.cc
 heb.com
 hebergtonserv.com
 hebit.id
+hebmex.com
 heckmann-bau.de
 hedefbank.com.tr
 hedefgrup.com.tr
@@ -13678,6 +14301,7 @@ henryscheinone.com
 henselphelps.com
 hensglobalnetwork.net
 henz.nl
+hepn.com
 hepra.id
 hepsiburada.com
 heptabit.at
@@ -13686,6 +14310,7 @@ heraldpalladium.com
 herbalife.com
 hereintown.net
 herflor.com
+heritage.org
 heritagecoin.com
 heritagecpl.net
 heritagehealthsolutions.com
@@ -13739,9 +14364,11 @@ hgdata.sk
 hgnbroken.us.com
 hh.ru
 hhcorp.org
+hhcs.org
 hhla.de
 hhost.eg
 hi-ag.com
+hi-am.com
 hi-link.ru
 hi-load.biz
 hi-net.it
@@ -13762,6 +14389,7 @@ high5.nl
 highjump.com
 highland-networks.com
 highlanderrd.site
+highlineschools.org
 highpt.com
 highrise.ai
 highspeedbb.bn
@@ -13790,6 +14418,7 @@ hillsboroughcounty.org
 hillsclerk.com
 hillsidenewmedia.com
 hillsong.com
+hillstax.org
 hilltop.net
 hilton.com
 hiltons.co.nz
@@ -13856,6 +14485,7 @@ hkex.com.hk
 hkfree.org
 hkgateway.com
 hkicl.com.hk
+hkis.edu.hk
 hkjc.org.hk
 hkjs.com
 hkl-baumaschinen.de
@@ -13868,6 +14498,7 @@ hlcompany.com
 hlcvn.vn
 hlebnitca.ru
 hlebprom.ru
+hlhvjoc.com.vn
 hlnetworks.com
 hlogin.net
 hm.com
@@ -13904,7 +14535,9 @@ hoba.net
 hobarton.co.im
 hobby-caravan.de
 hobim.com
+hochbahn.de
 hochtief-polska.pl
+hodgepodge.dev
 hodgsonruss.com
 hoelzl.co.at
 hoene-it.net
@@ -13940,6 +14573,7 @@ holoceneadvisors.com
 hologic.com
 holon.bzh
 holstebro.dk
+holter.at
 holzer.org
 holznet.com.br
 homax.pl
@@ -13963,6 +14597,7 @@ homeschoolheartbeat.com
 homeserveusa.com
 homesite.com
 homestart.com.au
+homestreet.com
 homesystemsnet.com
 hometelecom.com.br
 hometownwifi.net
@@ -13971,6 +14606,7 @@ homura.network
 honda-eu.com
 honda.ca
 honda.co.jp
+honda.co.nz
 hondacarindia.com
 hondafcu.org
 hondroplc.shop
@@ -13978,6 +14614,7 @@ honduvision.hn
 honelspire.shop
 honestinsite.com
 honestventures.biz
+honeybankstudios.com
 hongchenggco.pro
 hongkongairport.com
 hongkongtaxi.co
@@ -13989,6 +14626,7 @@ hoopeston.k12.il.us
 hoor.ir
 hooray.solutions
 hoosierpc.com
+hootsuite.com
 hop179.net
 hopcount.ca
 hope-ec.org
@@ -14013,6 +14651,7 @@ horizon.com.bd
 horizoncapadvisors.com
 horizondcs.net
 horizonmedia.com
+horizonpower.com.au
 horizontcomunicazioni.com
 hormel.com
 hormoznet.com
@@ -14024,6 +14663,7 @@ hosco.ir
 hospedajeydominios.com
 hospicecareinc.com
 hospital.nagano.nagano.jp
+host-dot.net
 host-engine.com
 host-h.net
 host-my-website.com
@@ -14075,6 +14715,7 @@ hostflyby.net
 hostghost.nl
 hostgnome.com
 hosthavoc.com
+hosthotels.com
 hostida.com
 hostidadns.com
 hostin.cc
@@ -14168,6 +14809,7 @@ howardmarek.com
 hoyer-group.com
 hoyts.com.au
 hpb.hr
+hpcl.co.in
 hpdns.net
 hpi.de
 hpl.com.bd
@@ -14192,6 +14834,7 @@ hrk.aero
 hrl.com
 hrm-systems.ch
 hrmc.com
+hrrmc.net
 hrs.com
 hrsd.com
 hrt.hr
@@ -14215,11 +14858,13 @@ hsnfoundation.com
 hsoberoibuildtech.com
 hsp.net
 hsp.net.id
+hst.de
 hstsoft.com
 hsw.pl
 hsx.vn
 ht-group.com
 ht3vn.com
+htb.com.au
 htcinc.com
 htel.cc
 htfcu.org
@@ -14246,6 +14891,7 @@ hubersuhner.com
 hubert-burda-media.de
 hubgets.com
 hublogistics.fi
+hubsix.sn
 hubtelecom.com.br
 hubteltelecom.net.br
 hubynet.cl
@@ -14257,6 +14903,7 @@ hufvudstaden.se
 huge-networks.com
 hugeconnect.co.za
 hugel.co.kr
+hughesfcu.org
 hugoboss.com
 hugoregibo.be
 hugy.ch
@@ -14282,12 +14929,14 @@ hunariokiknj.net
 hungarocontrol.hu
 hungthinhcorp.com.vn
 hunriokinmuim.net
+hunter-web.net
 hunter.com
 hunterdonhealthcare.org
 hunterdouglas.com
 hunters.pl
 hunterwater.com.au
 huntington-beach.ca.us
+huntingtonplacedetroit.com
 huntndogsestates.com
 hunton.com
 hurleyspace.net
@@ -14297,6 +14946,7 @@ husco.com
 husd.org
 husky.co
 husqvarna.com
+husseyseating.com
 hvalerbredband.no
 hvfcu.org
 hvfree.net
@@ -14332,6 +14982,7 @@ hyland.com
 hylife.com
 hynfratech.com
 hyocloud.com
+hyp.co.il
 hypefox.net
 hyperapp.cloud
 hyperbit.it
@@ -14350,6 +15001,7 @@ hypermedia.net.id
 hypermediasystems.com
 hypermetrica.com
 hyperneph.com
+hypernet.am
 hypernet.co.id
 hypernet.com.au
 hypernet.mx
@@ -14398,12 +15050,14 @@ i-nn.ru
 i-npz.ru
 i-pc.biz
 i-saku.com
+i-se.co.kr
 i-seven.net
 i-sh.co.kr
 i-skill.com
 i-smart.ru
 i-teco.ru
 i-tic.com
+i-viewnow.com
 i.cz
 i22.de
 i2basque.eus
@@ -14456,6 +15110,7 @@ ib3tv.com
 iba-worldwide.com
 iba.by
 ibagroup.eu
+ibank.bg
 ibank2.ru
 ibanpay.com
 ibarra.sv
@@ -14466,6 +15121,7 @@ ibch.info
 ibedc.com
 iberdrola.es
 iberia.es
+ibermutua.es
 ibertic.es
 ibexglobal.com
 ibf.dk
@@ -14473,10 +15129,12 @@ ibi.co.il
 ibiunet.com.br
 ibks.com
 iblock.net
+ibml.com
 ibntech.com
 ibo.fr
 ibrae.ru
 ibrexres.com
+ibri-kobe.org
 ibs.bg
 ibsa.com
 ibselektronics.pl
@@ -14495,6 +15153,7 @@ ical.com.br
 icanconnect.com
 icao.int
 icap-outsourcing.com
+icap.com.au
 icap.com.sa
 icap.gr
 icard.com
@@ -14516,6 +15175,7 @@ icdas.com.tr
 ice.com
 icehotels.is
 icelandair.is
+icemiller.com
 icenet5.ru
 icentral.com.mx
 icepronav.ro
@@ -14525,6 +15185,7 @@ icewood.net
 icf.com
 icfo.eu
 icg.ie
+icg.ro
 ich-4.com
 ichatua.com.ua
 ichilton.co.uk
@@ -14623,7 +15284,9 @@ idf.net.br
 idfbins.com
 idigitalcamp.com
 idigs.net.au
+idirect.net
 idiscoverglobal.com
+idispowertel.com
 idlogic.com
 idm-suedtirol.com
 idmsukses.com
@@ -14649,6 +15312,7 @@ ids.al
 ids.bg
 idsil.com
 idsirtii.or.id
+idssite.com
 idstartegy.com.ua
 idstrategy.com.ua
 idsunitelm.it
@@ -14669,6 +15333,7 @@ ies-co.com
 iesb.br
 ietf.org
 iewc.co.za
+iewc.com
 iexindia.com
 if.ee
 if.se
@@ -14712,6 +15377,7 @@ igamma.ru
 igdas.com.tr
 igene.tw
 igg.com
+iginsure.com
 iglao.com
 iglobalnet.com.ar
 igloo.to
@@ -14745,6 +15411,7 @@ ihned.cz
 ihome.com.bd
 ihome.ru
 ihopkc.org
+ihsamericas.com
 ihsmarkit.com
 ii.co.uk
 iibx.co.in
@@ -14765,6 +15432,7 @@ ikac.ir
 ikarus.at
 ikb.hr
 ikea.com
+ikejaelectric.com
 ikexpress.com
 ikfac.com
 iknowit.pro
@@ -14811,6 +15479,7 @@ ilogisticbd.net
 ilol.si
 iloth.net
 ilpanda.net
+ilshealth.com
 ilsmart.com
 ilsole24ore.com
 iltechgroup.com
@@ -14818,11 +15487,14 @@ iluka.com
 ilva.lv
 ilz.info
 im-technology.pl
+im.pl
+ima.eu
 imac-italia.it
 imad.pl
 imafex.sk
 imagar.com
 image1tech.net
+imagemaster.com
 imagemnettelecom.com.br
 imagestour.com
 imagica-imageworks.co.jp
@@ -14890,6 +15562,7 @@ impatt.net
 imperanet.com.br
 impercomm.ru
 imperial-tobacco.pl
+imperial.cl
 imperiostelecom.com.br
 imperium.ca
 imperva.com
@@ -14959,6 +15632,7 @@ incentre.net
 inception.com.tr
 inceptiontech.ltd
 incito.co.uk
+incm.gov.mz
 incm.pt
 incnets.com
 incom-technologies.hu
@@ -15021,10 +15695,12 @@ indra.vn
 inds.pl
 indsalelimited.com
 indsoft.ro
+indue.com.au
 indulgent-holistic.com
 indus-cloud.com
 indusos.com
 industechint.org
+industowers.com
 industrienspension.dk
 industrservice.ru
 industry123.com
@@ -15032,6 +15708,7 @@ indusys.de
 indweb.ro
 ine.pt
 inea.com.pl
+inebraska.com
 ineco.com
 inecobank.am
 inedus.com.mx
@@ -15039,6 +15716,7 @@ ineedhelpalliance.org
 inel.com
 inel.mk
 inel.net.mk
+inelo.pl
 inera.cz
 inerps.eu
 inescop.es
@@ -15071,6 +15749,7 @@ inetz.com
 inexogy.com
 inext.net.mx
 infanet.ru
+infarmbureau.com
 infcdn.com
 inffonet.com.br
 infiber.in
@@ -15101,6 +15780,7 @@ infinitycapital.ro
 infinitycds.co.za
 infinityisp.com.br
 infinitylink.com
+infinityonlinebd.com
 infinitysrv.com
 infiumhost.com
 infl.co.uk
@@ -15125,11 +15805,14 @@ infocenter.net.br
 infocert.it
 infocision.com
 infocloud.su
+infocom.bg
 infocom.co.id
+infocom.cr
 infocom.if.ua
 infocom.poltava.ua
 infocom.uk
 infocomltd.net
+infocus.company
 infodec.ru
 infodev.com.np
 infodexsolutions.com
@@ -15148,6 +15831,7 @@ infomain.com.ar
 infomedia.co.id
 infomedics.nl
 infomex.pl
+infon.ru
 infonal.com.my
 infonet.com.br
 infonet.es
@@ -15169,6 +15853,7 @@ inforlinkba.net.br
 inforlinkce.com.br
 inform-svyaz.ru
 informasjonssikring.no
+informat.be
 informaten.com
 informatica.com
 informatica95.net
@@ -15247,6 +15932,7 @@ infrastruktur.ms
 infratel.co.zm
 infratel.pl
 infront.sport
+infsalesgroup.com
 inftelecom.com.br
 ing-diba.de
 ing-servis.com
@@ -15301,6 +15987,7 @@ inmobi.com
 inn-energie.de
 innc.cz
 inneo.de
+inner.net
 innercloud.io
 innernetmarketing.com
 innet.com.br
@@ -15311,6 +15998,7 @@ innetpr.com
 innetra.com
 innettech.com.my
 innflow.com
+inngest.com
 innit.no
 innklinikum.de
 inno.ch
@@ -15382,6 +16070,7 @@ insigma.de
 insigniafinancial.com.au
 insistnet.gm
 insiteone.com
+insitu.com
 insoft-edv.com
 insoft.net.pl
 insolikhnet.co.id
@@ -15402,6 +16091,7 @@ instatel.com.br
 instatel.net.br
 insteel.com
 instra.com
+instructure.com
 insular.com.ph
 insulet.com
 insumak.mk
@@ -15438,6 +16128,7 @@ integranet.ph
 integranetsa.com
 integrasia.id
 integratedindia.in
+integrisok.com
 integrity-learning.com
 integrity.hu
 intehral.com
@@ -15452,6 +16143,7 @@ intelecom.tv
 intelegro.com
 intelepeer.com
 intelexpress.ge
+intelinet.com.ar
 intelion.cloud
 intelite.com.au
 intelium.com
@@ -15460,7 +16152,9 @@ intellectdesign.com
 intellectica.com
 intellectica.in
 intellectmoney.ru
+intellectualventures.com
 intelletrace.com
+intellicomm.com
 intelligentonline.net
 intellihome.hu
 intellin-tech.ru
@@ -15508,11 +16202,14 @@ intercableguatemala.com
 intercablelzc.com.mx
 intercal.com.ar
 intercard.de
+intercare.be
 intercars.com.pl
 intercel.online
 interceres.com.ar
+interchange.vu
 interchurch-center.org
 intercity.net.ar
+intercity.pl
 intercity.technology
 intercloud.com
 intercoding.net
@@ -15581,6 +16278,7 @@ interluz.cl
 intermanaged.com
 intermatica.it
 intermatik.eu
+intermax.co
 intermax.pe
 intermedia-bs.com.ar
 intermedia.id
@@ -15654,6 +16352,7 @@ interswitchgroup.com
 intersysservices.pl
 intersystems.ro
 intertech.com.tr
+intertech.pro
 intertek.com
 intertele.pl
 intertelecom.ua
@@ -15702,6 +16401,7 @@ intrakom.co.id
 intralinks.com
 intranusa.com
 intrarom.ro
+intraserv.pl
 intrasoft-intl.com
 intratel.pl
 intraweb.cz
@@ -15728,6 +16428,7 @@ invensysnetworks.com
 inventos.ru
 inventum.net
 inventx.ch
+invera.com
 inverdigm.ca
 invers.com
 inversionescredicorp.com.bo
@@ -15738,7 +16439,9 @@ investimento.mx
 investing.com
 investnovascotia.ca
 investors.pl
+investpalata.ru
 investpr.ru
+invinn.ru
 invisioninc.com
 invisionitbd.com
 invisiontech.eu
@@ -15764,11 +16467,14 @@ iopex.com
 iops.sk
 ioresearch.io
 iosaz.net
+iosocket.com
 ioss.ro
 iosys.net.id
 iot-unlimited.com
+iotamine.com
 iotech.co.za
 iovation.com
+iowa-city.org
 iowarad.com
 ip-147-135-37.us
 ip-15-204-35.us
@@ -15848,6 +16554,7 @@ ipeva.fr
 ipexpress.com.ng
 ipfix.fr
 ipfs.com
+ipfs.io
 ipgalaxyservices.com
 ipgarde.com
 ipglobal.es
@@ -15867,6 +16574,7 @@ iplusnetworks.com
 ipm.com.br
 ipm.id
 ipm.lviv.ua
+ipmac.com.ua
 ipmedia.net.pl
 ipmedia.net.ua
 ipmi-gc.com
@@ -15932,6 +16640,7 @@ iqlusion.io
 iqm.ro
 iqmen.ru
 iqnet.com
+iqnet.com.ar
 iqonline.net
 iqoption.com
 iqor.com
@@ -16052,9 +16761,11 @@ iskra.eu
 iskrauraltel.ru
 island.io
 island.net.au
+islandhealth.org
 islandits.com
 islandnetjm.com
 islandsbanki.is
+islc.net
 islg.ru
 ismartframe.com
 ismgroups.com
@@ -16122,6 +16833,7 @@ istsat.com.mx
 isttelkom.com.tr
 istts.ac.id
 istvc.com.tw
+isuzu.co.ke
 iswhatpercent.com
 isx.net.nz
 isyatirim.com.tr
@@ -16213,6 +16925,7 @@ itcnet.ro
 itcng.net
 itcoloexchange.com
 itcom.al
+itcomgk.ru
 itconnectbd.com
 itconsortiumgh.com
 itconsult.net
@@ -16244,11 +16957,13 @@ itel.com.ni
 itelbd.com
 itelcel.com
 iteliig.com
+itelligencegroup.com
 itelma.su
 itelsa.com.ar
 item24.de
 items-muenster.de
 itenas.ac.id
+iter.com.ua
 itera.ac.id
 iteraconsulting.com
 iteranet.com
@@ -16299,6 +17014,8 @@ itns.net
 itnsglobal.eu
 itnsglobal.net
 itny.ac.id
+ito.org.tr
+itochu.com.pa
 itocr.com
 itogether.com
 itoolabs.com
@@ -16308,6 +17025,7 @@ itp.ac.id
 itp.bg
 itp.es
 itpartner.no
+itpartners.com.hk
 itpays.net
 itpintar.co.id
 itpoint.ch
@@ -16316,9 +17034,12 @@ itprosteer.com
 itproximus.com
 itq.eu
 itransition.com
+itrb.org
 itreg.ru
 itrna.com
 itron.com
+itrservices.eu
+itrweb.com
 its-ks.net
 its.ac.id
 its.com.tr
@@ -16341,6 +17062,7 @@ itshosted.nl
 itsidc.com
 itsistem.md
 itslearning.com
+itsmanagement.net
 itsmedia.de
 itsnn.ru
 itsns.pl
@@ -16402,6 +17124,7 @@ ivatel.com.br
 ivb-services.nl
 ivendo.pl
 iventuresolutions.com
+iveri.com
 ivi.ru
 ivistaltd.co.uk
 ivitelecom.net.br
@@ -16430,6 +17153,7 @@ iwt.ru
 ix-denver.org
 ix-host.ru
 ix-layers.com
+ix.gd
 ix.gu
 ix.if.ua
 ix.kg
@@ -16465,8 +17189,11 @@ izmir.bel.tr
 izo.ro
 izone.az
 izone.net.np
+izzi.lv
+izzinet.id
 j-parc.jp
 j2global.com
+j2sw.com
 j3is.in
 j99corp.com
 jaaftecnologia.com.br
@@ -16474,6 +17201,7 @@ jabarnet.net.id
 jaber.net.id
 jabikha.net
 jabil.com
+jackedwireless.com
 jackentertainment.com
 jackies.com.au
 jackmx.net.ua
@@ -16511,6 +17239,7 @@ jallatelecom.com.br
 jallesmachadosa.com.br
 jalur.net
 jamasoftware.com
+jambopay.com
 jamersdigital.com
 jamesavery.com
 jamescampbell.com
@@ -16543,6 +17272,7 @@ japet.si
 jaranet.pl
 jaratelindo.co.id
 jarindo.net.id
+jaring.my
 jaringanlintasmaritim.net
 jarmp.id
 jarmuloviktazone.com
@@ -16620,6 +17350,7 @@ jeffco.k12.co.us
 jeffco.us
 jefferson-afe.com
 jefferson.wi.us
+jeffersonradiology.com
 jeffnet.org
 jeffnetwork.id
 jefo.ca
@@ -16628,12 +17359,14 @@ jejuair.net
 jelajahdata.co.id
 jeldwen.com
 jelecos.com
+jellybelly.com
 jemezpueblo.org
 jemnetworks.net
 jendelatransfer.com
 jendralinomasanetwork.com
 jenetworks.co.ke
 jenexusholding.com
+jennison.com
 jenoptik.com
 jensenhart.com
 jensenresearch.com
@@ -16641,6 +17374,7 @@ jentec.hk
 jentre.net
 jenysas.bj
 jeppesen.com
+jerampl.com
 jerich.com
 jernih.net.id
 jerome.id.us
@@ -16662,6 +17396,8 @@ jetemail.com
 jetlan.com
 jetnet.rs
 jetnetwork.net.br
+jetpay.com
+jetsetnetworks.com
 jetsistemas.com
 jetsnetworks.com
 jetstar.com
@@ -16676,9 +17412,11 @@ jfal.jus.br
 jfbc.org
 jfce.jus.br
 jfhillebrand.com
+jfpr.jus.br
 jfrn.jus.br
 jfrs.jus.br
 jfsc.jus.br
+jgm.gov.ar
 jgp.name
 jgt.co.id
 jhcomp.cz
@@ -16748,6 +17486,7 @@ jobnetworks.com.mx
 jobs.bg
 jobup.ch
 jocdn.co.jp
+jockey.com
 jockeyclub.org.ar
 jocogov.org
 joemc.com
@@ -16806,6 +17545,7 @@ jpfibra.com.br
 jpkomputer.com
 jppol.dk
 jprs.co.jp
+jprs.jp
 jpru.de
 jrboldrini.com.br
 jrcda.com
@@ -16845,6 +17585,7 @@ juampynet.com
 juaranet.id
 jub.eu
 jubanetwork.com
+jubileedata.com
 jubileelife.com
 jubl.com
 jublfood.com
@@ -16864,6 +17605,7 @@ jumpnet.com.br
 jumptrading.com
 jumyk.com
 junairanetwork.com
+juneau.org
 junet.edu.jo
 jungheinrich.de
 juni.net.br
@@ -16895,6 +17637,7 @@ jutra.pl
 juwentus.pl
 juxto.com
 jvgcomputer.in
+jvodan.com
 jwtdigital.co.uk
 jy.net.ua
 jysanbank.kz
@@ -16934,6 +17677,7 @@ kabsi.at
 kabulsupplychain.com
 kacelinternet.com.br
 kacosystems.ca
+kaczmarski.pl
 kadastr.ru
 kadfire.com
 kadimconnect.com.br
@@ -16977,6 +17721,7 @@ kalbe.co.id
 kalbenutritionals.com
 kaleidescape.com
 kalevakonserni.fi
+kalgold.com.au
 kalibroao.ru
 kalimasada.id
 kalingastone.com
@@ -16993,6 +17738,7 @@ kamar.nz
 kamayo.id
 kamaz.org
 kambi.com
+kamco.or.kr
 kamdex.pl
 kamel.network
 kameta.net.ua
@@ -17013,6 +17759,7 @@ kancom.kiev.ua
 kandy.io
 kane.il.us
 kanelnetwork.co.id
+kanewarehousing.com
 kang.fr
 kangen.net.id
 kanhalabs.in
@@ -17024,12 +17771,14 @@ kansuiun.com
 kanta.enterprises
 kantar.com
 kantime.com
+kaolin.bg
 kaopuyun.com
 kaora.cz
 kapanet.net.br
 kapelan.com
 kapitalsv.ru
 kaplan.com
+kaplanprofessional.com
 kaplife.ru
 kappa.com.pl
 kappalys.com
@@ -17068,6 +17817,7 @@ kasb.com
 kasd.org
 kase.gov.lv
 kase.kz
+kasfo.or.kr
 kasi.re.kr
 kasikornasset.com
 kasikornbank.com
@@ -17080,6 +17830,7 @@ kaspol.pl
 kassex.cz
 kassir.ru
 kastechbd.com
+kastel.com.au
 katastar.gov.mk
 katespade.com
 katharsis.ru
@@ -17140,6 +17891,7 @@ kcmc.jp
 kcn.com.pk
 kco.com.br
 kcopa.or.kr
+kcs.com
 kcsms.com.mx
 kcsouthern.com
 kct.fr
@@ -17158,6 +17910,7 @@ kdsi.net
 kdvm.ru
 kdvz.nrw
 ke.com.pk
+kead.or.kr
 kearneyregional.com
 kec.net
 keco.or.kr
@@ -17188,14 +17941,18 @@ kelway.co.uk
 kemira.com
 kemofarmacija.si
 kemoms.ru
+kemperdc.com
 kempnet.pl
 kemri-rctp.org
 kemz.org
 kenic.or.ke
 kenkids.com
 kennametal.com
+kennedy-center.org
 kennport.com
 kenobianresearch.com
+kenosha.wi.us
+kenpro.com.au
 kensingtonmortgages.co.uk
 kentisd.org
 kentrade.go.ke
@@ -17243,6 +18000,7 @@ keynit.net
 keyrunon.com
 keysight.com
 keysim.co.uk
+keystart.com.au
 keystonecollects.com
 keystonefirstpa.com
 keystoneren.org
@@ -17294,6 +18052,7 @@ khulnaonline.net
 khust.net
 khwebsolutions.co.uk
 khz.se
+ki.com
 kia.com
 kia.com.au
 kia.gov.kw
@@ -17301,6 +18060,7 @@ kia.sk
 kiaakses.net
 kiaindia.net
 kiatnakin.co.th
+kibo.or.kr
 kibs.mk
 kica21.com
 kicc.co.kr
@@ -17320,6 +18080,8 @@ kihnabil.id
 kihy.theworkpc.com
 killeenisd.org
 kilroy.eu
+kim.co.kr
+kimball.com
 kimberly-clark.com
 kimbro.org
 kimchang.com
@@ -17353,6 +18115,7 @@ kingston.com
 kingston.com.tw
 kingstonhsc.ca
 kingstreet.com
+kingsway.k12.nj.us
 kingviews-hk.com
 kinnet.ru
 kinu-p.co.jp
@@ -17390,7 +18153,9 @@ kivra.com
 kiwazo.com
 kiwibank.co.nz
 kiwinetworks.com
+kiwoom.com
 kixmedia.ca
+kiyavia.com
 kiynet.id
 kizainternet.com
 kizilay.org.tr
@@ -17480,6 +18245,7 @@ knet.com.kw
 knetfibra10.com.br
 knetpro.gr
 knf.gov.pl
+knfc.co.kr
 kng.gov.kw
 knh.com.ua
 knid.co.id
@@ -17521,6 +18287,7 @@ kodit.co.kr
 kodmyran.se
 koeln-bonn-airport.de
 koelsa.or.kr
+koenergy.kr
 koerber.com
 kofax.com
 kofia.or.kr
@@ -17582,6 +18349,7 @@ komtele.com
 komunikasiprofesional.com
 komus.ru
 komutasavunma.com.tr
+kon.co.th
 konai.com
 konamigaming.com
 konar.ru
@@ -17627,6 +18395,7 @@ koodee.net
 kookiejar.net
 koop.cz
 koopbank.com
+koopjeserver.nl
 koopman.nl
 kopavogur.is
 kopernik.org.pl
@@ -17640,6 +18409,7 @@ koreainvestment.com
 koreanair.com
 koredigital.com
 korex.sk
+korgrid.com
 korisp.com
 koronapay.com
 korsi-tele.com
@@ -17689,6 +18459,7 @@ kprm.gov.pl
 kps.co.kr
 kps.com
 kptbam.com
+kpx.or.kr
 kqed.org
 kr-olomoucky.cz
 kr-plzensky.cz
@@ -17706,6 +18477,7 @@ krakow.pl
 krakra.net
 kralj.io
 kram.ua
+kramerlevin.com
 kramerundcrew.de
 krasavia.ru
 krasn.ru
@@ -17737,6 +18509,7 @@ krg.ca
 krhfund.org
 kri-us.com
 krieknetworks.nl
+krifa.dk
 krillaglass.com
 kringvarp.fo
 krios.ch
@@ -17768,6 +18541,9 @@ ksbc.kg
 ksc.co.th
 ksd.or.kr
 kse.com.pk
+ksf.kiev.ua
+ksfc.co.kr
+ksfcu.org
 ksgr.ch
 ksinergi.co.id
 ksinet.ru
@@ -17799,6 +18575,7 @@ ktmc.com
 ktmt.co.id
 ktng.com
 kto34.ru
+ktp.net.id
 ktportfoy.com.tr
 ktr.or.kr
 ktv-ravne.net
@@ -17848,6 +18625,7 @@ kuuh.co.za
 kuusamo.fi
 kuuskaista.com
 kuveytturk.com.tr
+kuveytturkyatirim.com.tr
 kuwaitairways.com
 kuxueyun.com
 kuzbassenergo.ru
@@ -17864,6 +18642,7 @@ kvmka.com
 kvmka.ru
 kvno.de
 kvy.fi
+kw-corp.com
 kwai.com
 kwattel.com
 kwb.net
@@ -17880,11 +18659,13 @@ kyivcity.gov.ua
 kyivstar.net
 kyka.pw
 kyndrylarg.com.ar
+kyobo.co.kr
 kyoboaxa-im.co.kr
 kyobobook.co.kr
 kyocera-avx.com
 kyocera.com
 kyonix.com
+kyoto.lg.jp
 kyouma.net
 kyuden.co.jp
 kyushu-u.ac.jp
@@ -17921,6 +18702,7 @@ labitat.dk
 labixe.host
 labone.com
 labor-muenster.de
+laborex-kenya.com
 labusov.ru
 labvantage.com
 lac.co.jp
@@ -17929,9 +18711,12 @@ lacesira.com.ar
 lachan.vn
 lackawannacounty.org
 lacnic.net.uy
+lacomer.com.mx
 lacourt.org
 lactalis.com
 lactalis.ru
+lactld.org
+lacuracao.com
 lad.gov.lv
 ladadi.de
 ladamedia.ru
@@ -17987,6 +18772,7 @@ lamis.net.ua
 lamoda.ru
 lampyris.ru
 lams.co.id
+lamtec.com
 lamtel.net
 lan-advice.com
 lan-servis.ru
@@ -18015,6 +18801,7 @@ landsend.com
 landstar.com
 landsvirkjun.is
 landtech.com.pl
+lanepress.com
 lanestel.fr
 lanet.com.py
 lanetcie.com
@@ -18049,6 +18836,7 @@ lantip.co.id
 lantmateriet.se
 lantrace.com.ua
 lanultra.net
+lanvera.com
 lanworks.com
 lanworx.co.nz
 lanxess.de
@@ -18063,7 +18851,9 @@ lapit.fi
 lapl.org
 laposte.fr
 laprocessing.top
+lar.coop
 laranstech.com
+laredo.tx.us
 laredobiz.com
 laredoisd.org
 largecarmag.com
@@ -18072,6 +18862,7 @@ larisinvestments.com.pl
 laritex.md
 larmitgtop.com
 laroiasnet.ro
+larrainvial.com
 larsentoubro.com
 laru.lu
 larynet.com.br
@@ -18110,6 +18901,7 @@ latvijasradio.lv
 latvijastikli.lv
 laudert.de
 launchvps.com
+laurenselectric.com
 laurintapp.com
 laurioncap.com
 lautorite.qc.ca
@@ -18137,6 +18929,7 @@ layerswitch.com
 layne.com
 lazada.co.th
 lazard.com
+lazawan.net
 lazco.tw
 lazentis.com
 lazurde.com
@@ -18170,6 +18963,7 @@ lcnet.jp
 lcnetfibra.com.br
 lcom.it
 lcps.k12.nm.us
+lcps.k12.va.us
 lcpud.org
 lcra.org
 lcrc.info
@@ -18177,6 +18971,7 @@ lcs.com
 lcs.com.vn
 lcs.net.pl
 lcsd.gov.hk
+lcsedu.net
 lctv.com.ar
 lcubeddataservices.com
 lcwaikiki.com
@@ -18185,6 +18980,7 @@ lcxhk.com
 ld.sa
 ldata.id
 ldcc.vn
+ldcom.com.br
 lddc.ru
 ldgroups.com
 ldl.net
@@ -18209,6 +19005,7 @@ lease.net
 leasingoptions.co.uk
 leatyon.org
 lebanon-utilities.com
+lebanontn.org
 lebaocloud.com
 lebara.com
 lebarmy.gov.lb
@@ -18217,6 +19014,8 @@ leboncoin.fr
 lecos.ua
 lecrintv.com
 ledfordia.space
+ledvance.com
+leeclerk.org
 leeequity.com
 leegomerycomputers.com
 leegov.com
@@ -18224,6 +19023,7 @@ leekie.com
 leeko.com
 leememorial.org
 leeon.vn
+leetc.com
 leeuwarden.nl
 leewaysofttech.com
 lefigaro.fr
@@ -18244,6 +19044,7 @@ legrand.com
 legrand.us
 leibold-it.de
 leica-geosystems.com
+leicabiosystems.com
 leichen.live
 leier.ro
 leipziger-messe.de
@@ -18257,6 +19058,7 @@ lektorklett.com.pl
 lello.ao
 lelystad-airport.nl
 lemanapro.ru
+lemanikgroup.com
 lemarit.com
 lemnet.com.br
 lemonplay.es
@@ -18274,14 +19076,17 @@ lenvendo.ru
 lenzeder.at
 leoben.at
 leonardocosta.com.br
+leonardodrs.com
 leonhosting.net
 leoni.com
+leonisa.com
 leosinfo.com.br
 leotel.com.ua
 leowisp.com
 lepas.net.id
 lepida.it
 leprinofoods.com
+lepsor.com
 lepszyinternet.pl
 leptonglobal.com
 leradata.ru
@@ -18296,6 +19101,7 @@ lesauzines.com
 lescom.com.ar
 lesproekt.ru
 lesschwab.com
+lessismore.asia
 lessor.dk
 lesta.ru
 lestetronics.com.br
@@ -18322,11 +19128,13 @@ levertechcentre.com
 levi.com
 levi9.com
 leviahub.com
+levinlevy.com
 levira.com
 levitasrl.it
 levokumka.net
 levonet.sk
 levotel.in
+levyrestaurants.com
 lewisroca.com
 lewtel.com.ar
 lewutech.vn
@@ -18348,6 +19156,7 @@ lfdj.com
 lffibra.com.br
 lfsbrokers.com
 lg-idc.com
+lg.com
 lgblp.com
 lgctechrd.com
 lge-ku.com
@@ -18358,6 +19167,7 @@ lgim.com
 lgt.com
 lh.org.au
 lhisp.com
+lhmauto.com
 lhnetfibra.com.br
 lhost.net.id
 lhost.no
@@ -18369,10 +19179,12 @@ lhytechnologies.com
 li-life.li
 li-ning.com.cn
 liara.ir
+lib.de.us
 libalink.com
 libancom.com
 libanpost.com
 libatech.net.lb
+libbey.com
 liber.pe
 liberally.network
 liberatormedical.com
@@ -18382,6 +19194,7 @@ libernet.nl
 libertychristian.com
 libertyczestochowa.pl
 libertydentalplan.com
+libertyhcare.com
 libertymedia.com
 libertysecurityservices.com
 libertytechnology.com.do
@@ -18410,6 +19223,7 @@ liehne.net
 life-pay.ru
 life-stream.tv
 life.com.br
+lifealert.com
 lifebridgehealth.org
 lifeclass.net
 lifeinternet.net.br
@@ -18419,12 +19233,14 @@ lifelinedatacenters.com
 lifemedia.id
 lifenetems.org
 lifepc.sk
+lifescan.com
 lifetime.com
 lifetime.life
 lifeviewgroup.org
 lifewave.com
 lifi.net.ng
 lifsnetwork.com
+liftfund.com
 liga.dn.ua
 liga.net
 ligadeneg.ru
@@ -18444,7 +19260,9 @@ lightmooncloud.com
 lightnet.al
 lightpath.net
 lightport.com
+lightsource.ca
 lightspeedvoice.com
+lightsquared.com
 lightstackglobal.net
 lightstorm.services
 lightstorm.sk
@@ -18480,7 +19298,10 @@ limrafiber.com
 linageisp.com
 linarestechnology.com.do
 lincare.com
+lincolncenter.org
+lincolnelectric.com
 lincolnelectric.nl
+lincolninvestment.com
 lincolnshiremgmt.com
 lindbak.no
 linde-mh.it
@@ -18603,13 +19424,16 @@ lisd.net
 lisec.com
 lisek.pl
 lishanonline.com
+lisluanda.com
 listertermoformadoa.com
+listerventures.com
 listopad.tj
 lit.de
 litasco.com
 litchfieldcavo.com
 litech.net
 litegroup.ru
+litfiber.org
 litgrid.eu
 lith.com
 lithia.com
@@ -18704,6 +19528,7 @@ loandepot.com
 loanscience.com
 loansigningsolutions.com
 lobato.eu
+lobelfinancial.com
 lobi.net
 lobosnetworking.com
 loc8it.com.na
@@ -18738,6 +19563,7 @@ lodzkie.pl
 loeberlozano.com
 loewen.com
 loewenfels.ch
+loews.com
 loewshotels.com
 logan.org
 logic.online
@@ -18788,6 +19614,8 @@ lon.si
 lonap.net
 londionrtim.net
 londondigitalsystems.com
+londondrugs.com
+londonhydro.com
 londonstockexchange.com
 lonepinecapital.com
 lonestardataranch.com
@@ -18817,6 +19645,7 @@ loosetelecom.com.br
 lopenkuitu.fi
 lopnet.se
 lord.com
+lordabbett.com
 lordvps.net
 loreal.fr
 lorealusa.com
@@ -18834,6 +19663,7 @@ lotharedon.org
 loticbige.com
 loto.ro
 lotoquebec.com
+lottebiologics.com
 lotterien.at
 lotto24-ag.de
 lottomaticacorporate.com
@@ -18861,14 +19691,17 @@ loylegal.com
 lpbi.com.vn
 lpdb.id
 lpg.lv
+lpga.com
 lpghc.com
 lpl.com
 lpltd.ru
 lpnt.net
 lpo.net.id
+lpp.com.pl
 lppi.or.id
 lpr.com.pl
 lrc.ninja
+lrcnet.net
 lrdata.ph
 lrfconection.com.br
 lrisp.com
@@ -18895,13 +19728,16 @@ lta.gov.sg
 ltab.lv
 ltcctel.com
 ltcpartners.com
+ltimindtree.com
 ltisdschools.org
 ltisolutions.com
 ltk.dk
 ltmd.net
 ltn.net.id
 ltsbilisim.com.tr
+ltschools.org
 ltsh.de
+lttnet.com
 ltus.ru
 lu-cix.lu
 lu.ch
@@ -18921,6 +19757,7 @@ lucera.com
 lucertgroup.co.za
 lucesem.at
 luciad.com
+lucid.net.au
 lucidmotors.com
 lucky-towntv.jp
 lucky7powersports.com
@@ -18928,6 +19765,7 @@ luckycloud.de
 luckyconnect.co.za
 luckysrv.de
 lucushost.com
+ludia.com
 lugano.ch
 luglink.net
 lugos.fr
@@ -18939,6 +19777,7 @@ lukegb.com
 lukestar.in
 lukka.tech
 lukoil-international.com
+lukoil.com
 lukoil.com.tr
 luks.ch
 lulu-tech.com
@@ -18980,6 +19819,7 @@ lupo.com.br
 luque.coop
 lureit.ru
 luronet.com.ar
+lursoft.lv
 lusd.org
 lushu.io
 lusoaloja.pt
@@ -19005,6 +19845,7 @@ luyani.com
 luys.io
 luz.si
 luz2.com
+luzernecounty.org
 luzhki.com
 lv-informatique.com
 lv3.it
@@ -19029,6 +19870,7 @@ lxc.lu
 lxn.co.kr
 lxxix.net
 lybertynet.com.br
+lycamobile.com
 lycamobile.in.ua
 lycamobile.us
 lyceum1.net
@@ -19045,9 +19887,11 @@ lynx.net.id
 lynx.net.lb
 lynxnet.pl
 lynxwv.com
+lyoncsd.org
 lyondellbasell.com
 lypy.com
 lyra-network.com
+lyreco.com
 lyreg3.fr
 lyricopera.com
 lysafree.net
@@ -19100,6 +19944,7 @@ m9com.ru
 ma.ru
 maaden.com.sa
 maaltijdservice.nl
+mabe.com.mx
 mabesad.mil.id
 mabnacloud.com
 mabnadp.com
@@ -19109,7 +19954,9 @@ mac.org.il
 macarne.com
 macarrltd.com
 macconnection.com
+macdon.com
 machaikapps.net
+machetazo.com
 macho-ster.com
 mackenzie.br
 mackenzieinvestments.com
@@ -19121,6 +19968,7 @@ macmillan.com
 macomp.com
 macosoft.ro
 macpapers.com
+macpractice.com
 macrois.com
 macromex.ro
 macromind.net
@@ -19163,6 +20011,7 @@ magehost.com
 magellan-net.de
 magellanlp.com
 magellanset.com
+magex.hu
 maggiesselfcatering.com
 maggioli.it
 maggiolicloud.it
@@ -19196,10 +20045,12 @@ magnitudegameplay.com
 magnoliasoccerclub.com
 magnum.lv
 magnumgo.uz
+magnumtc.com
 magoods.org
 magosi.co.id
 magpi.net
 magset.net
+magsnet.net
 magtek.com
 maguay.ro
 mahalaxminetprivatelimited.in
@@ -19225,6 +20076,7 @@ mail.bg
 mail.kg
 mail.lviv.ua
 mail.wf
+mail24.pro
 mail2last.com
 mail2world.net
 maila.net.br
@@ -19234,6 +20086,7 @@ mailkit.com
 mailmanager.net
 mailobj.net
 mailpoalim.co.il
+mailreef.com
 mailscompute.com
 mailset.cn
 main.pl
@@ -19268,6 +20121,7 @@ majanet.id
 majasol.com
 majesco.com
 majesticdata.co.za
+majorcineplex.com
 majuwijaya.net
 makaramas.com
 makasasun.com
@@ -19316,10 +20170,13 @@ managedserviceprovider.com
 manageit.ir
 manageserver.in
 manakarra.net
+manatt.com
 manche.fr
 manchenum-op.fr
+manconinc.com
 mandalarmandalay.com
 mandaonline.net.bd
+mandariteknologi.co.id
 mandg.co.uk
 mandiriglobal.co.id
 mandirisek.co.id
@@ -19341,6 +20198,7 @@ manipaltechnologies.com
 manishinfocom.in
 manitou.fr
 manitowoc.com
+mankinmedia.com
 manlab.com
 mannai.com.qa
 mannatech-inc.com
@@ -19353,6 +20211,7 @@ mansfieldrealestateagent.com
 mansion.com
 manteca.ca.us
 mantech.com
+manteno5.org
 manthannetsol.com
 mantracgroup.com
 mantragroup.com.au
@@ -19371,10 +20230,12 @@ mapfre.com.tr
 maplenet.com.bo
 mapleridge.ca
 mapleton.org
+mapleton.us
 mapminas.com.br
 mapmyindia.com
 mapn.ro
 mapnamd1.com
+mapnaom.com
 mapnasts.ir
 mappy.com
 mapreri.org
@@ -19393,6 +20254,7 @@ marbeltel.com.ph
 marcatel.net.mx
 marcaymercado.org
 marcfisherfootwearcorp.com
+marchnet.com.au
 marcionet.com.br
 marcom-eko.cz
 marcumllp.com
@@ -19408,20 +20270,24 @@ margaritesretreat.com
 mariadb.com
 mariapps.com
 marica-iztok.com
+marietta-city.k12.ga.us
 marignan-immobilier.com
 mariinsky.ru
 marina.gov.ph
 marinabaysands.com
 marinbank.com.tr
+mariners.com
 marinit.com
 marinschools.org
 mario-kurz.de
 marion.or.us
+mariongeneral.com
 mariposanet.es
 marisolsa.com.br
 maritik.com
 mariu.online
 mariyaonline.net
+markanthony.com
 markel.com
 markerstudy.com
 market-fa.ru
@@ -19457,6 +20323,7 @@ marochost.com
 maronelectric.com
 marpoint.gr
 marqeta.com
+marquaille.fr
 marquesinfo.com.br
 marsat.ru
 marsatas.lt
@@ -19472,6 +20339,7 @@ martin.fl.us
 martinagency.com
 martinbrower.com.br
 martincorp.net
+martindom.com
 martinline.ru
 martinmarietta.com
 martinspoint.org
@@ -19479,6 +20347,7 @@ martun.net
 maru.co.jp
 marufonlinebd.net
 marullcoop.com.ar
+marusan-sec.co.jp
 marvell.com
 marvelwebhost.com.bd
 marya.ru
@@ -19491,6 +20360,7 @@ mascode.com
 mashreq.com
 masinternet.net
 masinternet.tv
+masisa.com
 masisnet.net
 maskom.co.id
 maskyoo.co.il
@@ -19501,6 +20371,7 @@ masoncompaniesinc.com
 masonicare.org
 masonite.com
 masonpud3.org
+masoutis.gr
 maspex.com.pl
 massandra.su
 massars.net
@@ -19521,6 +20392,7 @@ masteritsupport.com
 masterkey.ua
 masterlinknet.com.br
 masterlock.com
+mastermarts.com
 masternaut.com
 masternet.net.br
 masternetbd.net
@@ -19537,11 +20409,13 @@ matawa.on.ca
 match.com
 matchtechgroupplc.com
 matchtv.ru
+matcotools.com
 matek.inf.br
 mater.org.au
 material-apps.com
 materom.ro
 mathematica-mpr.com
+matheson-trigas.com
 mathost.eu
 matinnet.af
 mativith.cc
@@ -19551,6 +20425,7 @@ matooma.com
 matracomp.hu
 matrainfotek.com
 matreon.nl
+matrikon.com
 matrix-lb.com
 matrix.nl
 matrixapps.com
@@ -19563,7 +20438,10 @@ matrixtechlabs.com
 matroguel.cam
 mattel.com
 mattel.mr
+matterloom.com
 mattersight.com
+matthewsbooks.com
+matthewsbronze.com
 mattpeterman.com
 mattressfirm.com
 matzanet.com
@@ -19601,6 +20479,7 @@ maxia.pl
 maxicom.cz
 maxiline.net
 maxima.best
+maxima.com.au
 maximpactipo.com
 maximumcontrol.nz
 maximus.com
@@ -19608,6 +20487,7 @@ maximusinf.com.br
 maximusinfoware.in
 maximusnet.ru
 maxinetartik.am
+maxionwheels.com
 maxiplace.ru
 maxitel.ec
 maxitinfocomm.com
@@ -19627,6 +20507,7 @@ maxserver.com
 maxsolutions.com.au
 maxtechgroup.in
 maxtechsangamner.in
+maxtel-usa.com
 maxto.pl
 maxus.com.ua
 maxweb.in
@@ -19653,6 +20534,7 @@ mayfieldews.com
 maymobility.com
 maynet.id
 maysoc.net
+maystreet.com
 maz.es
 mazda.com.au
 mazdausa.com
@@ -19676,6 +20558,7 @@ mbits.com.au
 mbixions.com
 mbiz.co.id
 mbk-networks.com
+mbl.in
 mbl.is
 mblife.vn
 mblinktx.net
@@ -19688,6 +20571,7 @@ mbox.net
 mboxit.com
 mbs.com.vn
 mbs763.kz
+mbsbooks.com
 mbshipbrokers.com
 mbsm.com.bd
 mbsportsweb.ca
@@ -19699,6 +20583,7 @@ mc-node.net
 mc21.ru
 mcaa.gov.mn
 mcafee.com
+mcallenisd.org
 mcap.com
 mcarbon.com
 mcbah.com
@@ -19711,6 +20596,7 @@ mccme.ru
 mccno.com
 mcconaghygroup.com
 mcconnect.ru
+mccormick.com
 mccrackenfs.com
 mccsokinawa.com
 mccullough.com.au
@@ -19728,6 +20614,8 @@ mcfarlane-associates.com
 mcg.pl
 mcgenergy.com
 mcgmbh.net
+mcgrathnorth.com
+mcheese.com
 mchenry.il.us
 mci.gov.sa
 mci.net.id
@@ -19746,6 +20634,7 @@ mcmillin.com
 mcmsys.net
 mcn.al
 mcn.org
+mcnet.co.mz
 mcnet.net.br
 mcnetsolutions.net
 mcnichols.com
@@ -19754,6 +20643,7 @@ mcom.gi
 mcom.sk
 mcompondoluoma.com
 mconline.com.br
+mcpc.com
 mcplat.ru
 mcps.k12.mt.us
 mcraepropertypartners.com
@@ -19772,6 +20662,7 @@ mctower.ru
 mctv.co.tz
 mcubedigital.com
 mcvean.com
+mcwane.com
 mcx-sx.com
 mcxindia.com
 mcxserwis.pl
@@ -19785,6 +20676,7 @@ mdchap.dev
 mdm-solutions.ro
 mdmh.org
 mdnetrp.com.br
+mdnettelecom.net.br
 mdp.co.id
 mdpa.mu
 mdpsrl.it
@@ -19904,9 +20796,11 @@ medkirov.ru
 medma.su
 medmutual.com
 medocit.com
+medpace.com
 medrickfze.com
 medsi.ru
 medsoft.su
+meest-it.com
 meetscale.com
 meetunearthed.de
 meetyoo.de
@@ -19928,6 +20822,7 @@ megacipta.id
 megacom-ec.com
 megacom.it
 megadata.by
+megadata.ro
 megadatta.com
 megafastnetworks.com
 megagroup.ru
@@ -19957,6 +20852,7 @@ meganetscm.com.br
 meganetscm.net.br
 meganetturbo.com.br
 meganuv.com
+megapaca.com
 megapage.ru
 megaprostir.net
 megaprovider.ru
@@ -19974,6 +20870,7 @@ megaspeed.ph
 megaspeednet.com
 megasrv.de
 megastore.pl
+megatc.ru
 megatek.com.tr
 megatelnet.com
 megatelnetworks.in
@@ -19994,6 +20891,7 @@ mehrava.net
 mehrfcp.ir
 mehvarmachine.net
 mei.co.jp
+meiah.com
 meilleurtaux.com
 meinsystem.at
 meitar.com
@@ -20098,12 +20996,15 @@ merkazia.com
 merkle.com
 merkleinc.com
 merkli.org
+merkur.si
 merlin.com.ua
 merlot.digital
 merredinwireless.net.au
 mersinc.org
+mertandhouse.com
 merventerprises.com
 mesawater.org
+mescairo.com
 meshnet.ltd
 meshnet.su
 meshtelecom.net
@@ -20132,6 +21033,7 @@ metallprofil.ru
 metallumgroup.com
 metalmanagement.net
 metalor.com
+metalsa.com
 metalzbyt.com
 metamedia.ac.id
 metamerg.xyz
@@ -20163,6 +21065,7 @@ metissrl.it
 metka.gr
 metlife.co.kr
 metlife.com
+metlifestadium.com
 metmuseum.org
 metpit.co
 metr1.com.ua
@@ -20178,6 +21081,7 @@ metroairports.org
 metrobanksa.com
 metrocom.ru
 metrodish.com
+metroengines.jp
 metrogr.org
 metroip.com
 metrolightspeed.my
@@ -20204,6 +21108,7 @@ metrotvnews.com
 metrouniv.ac.id
 metrovancouver.org
 metrowagonmash.ru
+metservice.com
 metso.com
 mettauniversal.id
 metwashairports.com
@@ -20212,6 +21117,7 @@ meuip.tv.br
 meusburger.com
 mevis.de
 mew.gov.kw
+mewa.de
 mexem.com.pl
 mexis.net
 mexline.com
@@ -20237,6 +21143,7 @@ mfinante.ro
 mfisoft.ru
 mfms.ru
 mfn24.eu
+mfnerc.com
 mfnso.ru
 mfps.com
 mfs.com
@@ -20251,10 +21158,12 @@ mgenetwork.com.br
 mghgroup.com
 mghosting.nl
 mghpcc.org
+mghs.org
 mgic.com
 mgid.com
 mginfo.co.kr
 mgm-tp.com
+mgmc.com
 mgmnet.com
 mgn.ru
 mgnetipa.com.br
@@ -20270,6 +21179,7 @@ mgts.by
 mhbroadband.com
 mhcom.eu
 mhg.com
+mhhcc.org
 mhi.net
 mhost.by
 mhost.ee
@@ -20293,9 +21203,11 @@ micarmita.net
 micglobalservices.com
 michaelfoods.com
 michaels.com
+michcom-ix.net
 michcom.sl
 michels.us
 michigandigital.com
+michiganvirtual.org
 michowifi.com
 michwave.com
 micom.com.ar
@@ -20339,6 +21251,7 @@ microsattelecom.com.br
 microsec.hu
 microsemi.com
 microstrategy.com
+microsula.com
 microtec.se
 microteck.co.bw
 microteltechnology.com
@@ -20368,6 +21281,7 @@ midlandco.com
 midlandcompany.com
 midlothian-isd.net
 midlothian.tx.us
+midmichigan.net
 midn.in
 midnet.tv
 midnetinc.com
@@ -20412,6 +21326,7 @@ mikro-tek.ru
 mikrobit.pl
 mikrocom.com.ar
 mikrocop.com
+mikrodatta.com
 mikrogate.net
 mikrografija.si
 mikrolink.id
@@ -20447,10 +21362,13 @@ millenniumbcp.pt
 millenniumdm.pl
 millenniumhealth.com
 miller-networks.com
+milleraa.com
 millercanfield.com
 millerknoll.com
 millersatwork.com
+millerse.com
 millersinsurance.com
+millerwelds.com
 milliman.com
 millionwebservice.com
 millistream.com
@@ -20461,6 +21379,7 @@ milpanativa.com.mx
 milsped.com
 miltelecom.com.br
 miltenyibiotec.com
+miltoncat.com
 milwaukeetool.com
 mimillers.com
 mimonlinebd.com
@@ -20501,6 +21420,7 @@ mintcom.ms
 mintel.com.hk
 mintly.fi
 mintz.com
+miopartners.com
 miottawa.org
 mipih.fr
 mips.net.ua
@@ -20545,12 +21465,14 @@ misorpresa.com
 misqotsejahteraindonesia.id
 missani33.shop
 missioncisd.org
+missioncloud.com
 missionhills.org
 missouribotanicalgarden.org
 mist-net.com
 misterbianco.ct.it
 misterlink.com.br
 misticom.com
+mistral.ai
 mistreaky.net
 mitac.com.tw
 mitan.it
@@ -20561,6 +21483,7 @@ mitchellemc.com
 mitchellplastics.com
 miteflux.co.uk
 mitel-inter.net
+mitelcom.com
 mitelefono.com
 mitelis.net
 mitgr81.com
@@ -20616,6 +21539,7 @@ mk.co.kr
 mk2.com.pl
 mkb.kz
 mkbwebhoster.com
+mkcl.org
 mkegs.shop
 mkidn.gov.pl
 mkk.com.tr
@@ -20633,6 +21557,7 @@ mksys.org
 mkt-hyundai.com.br
 mktel.com.do
 mku.dp.ua
+mkz.si
 ml.cloud
 mlgw.com
 mlink.id
@@ -20670,6 +21595,7 @@ mmtc.ac.id
 mmts9.ru
 mnbctv.mn
 mncgroup.com
+mncppc.org
 mndigital.com
 mndpt.gov.mg
 mnemonic.no
@@ -20697,6 +21623,7 @@ mobi.ch
 mobi.com
 mobi.uz
 mobiasbanca.md
+mobiclip.com
 mobicom.mn
 mobielwerkt.nl
 mobilbd.com
@@ -20709,7 +21636,9 @@ mobiletechcommunications.us
 mobiletvgroup.com
 mobilexusa.com
 mobileye.com
+mobilisim.com.tr
 mobillan.hu
+mobiltel.bg
 mobinet.bg
 mobis.com
 mobis.com.au
@@ -20733,9 +21662,11 @@ modell-aachen.de
 modelonettelecom.com.br
 modem.ru
 modern-woodmen.org
+modernterminals.com
 moderntradingnews.com
 moderntv.eu
 modest.so
+modestogov.com
 modicon.com
 modine.com
 modirum.com
@@ -20763,6 +21694,7 @@ mof.gov.sa
 mof.gov.vn
 mofa.gov.kw
 mofa.gov.sa
+mofa.gov.vn
 mofo.com
 moghbazar.net
 mognet.com.br
@@ -20786,6 +21718,7 @@ mojyo.net
 mokadi.pl
 mokaunited.com
 mokk.hu
+mol.com.mk
 mol.ru
 molagers.org
 molcom.ru
@@ -20793,6 +21726,7 @@ molderly.world
 moldescoop.com.ar
 moldex.com
 molecullesoft.com
+molex.com
 mollasoft.net
 molndal.se
 molonglogroup.com.au
@@ -20806,6 +21740,7 @@ momotabd.net
 mon.bg
 mona-media.com
 monarch17.com
+monarchindustries.com
 mondex.ro
 mondo-byte.ro
 mondohi-tech.it
@@ -20828,12 +21763,14 @@ monitor.se
 monitoring.co.uk
 monitoringamerica.com
 monitornz.co.nz
+monmouth.nj.us
 monnaiegroup.com
 monocera.co
 monogon.tech
 monolit.si
 monolith.net.ua
 monolithicpower.com
+mononaterrace.com
 monopolizeright.com
 monopoly.su
 monorom.com.kh
@@ -20876,6 +21813,7 @@ moravany.cz
 moravia-it.com
 more.com.ua
 moretesb.com
+morganandmorgan.com
 morgansites.net
 morganstanley.co.jp
 morganwhite.com
@@ -20897,6 +21835,7 @@ mortgagelaw.com
 mortin.pl
 mortnerhof.com
 morva.net
+mos.org
 mos5tel.com
 mosaic-al23-dhcp.190
 mosaicdataservices.com
@@ -20936,6 +21875,7 @@ motionapplied.com
 motionindustries.com
 motionpicturesolutions.com
 motivationpotion.com
+moto-profil.pl
 motoristsgroup.com
 motorolasolutions.com
 mottanet.net.br
@@ -20968,6 +21908,7 @@ movitel.tv
 movtelecom.net.br
 movys.sk
 moyers32.ca
+mozabanco.co.mz
 mozilla.com
 mozilla.org
 mozinet.pl
@@ -20986,6 +21927,7 @@ mphasis.com
 mpi314.com
 mpinfotelecom.net.br
 mpirelease.com
+mplatform.com
 mplocker.com
 mpls.co.id
 mplusgroup.hr
@@ -20999,12 +21941,14 @@ mppinc.com
 mpr.com
 mpr.org
 mprinfonet.com
+mprr.mp.br
 mps.com.br
 mps.cr
 mpsc.mp.br
 mpse.mp.br
 mpsedc.com
 mpsv.cz
+mpten.org.gn
 mpu.mp.br
 mpvwifi.com
 mpwik.com.pl
@@ -21027,6 +21971,7 @@ mrisecuresign.com
 mrisoftware-email.com
 mrisoftware.com
 mrl.com.au
+mrlsolutions.com
 mrocza.net
 mrpricegroup.com
 mrr.gov.pl
@@ -21059,13 +22004,16 @@ msdevelopment.pl
 msdigital.net
 msdp1.com
 mse.net.my
+msfa.com
 msg-gruppe.de
 msg-systems.com
 msg.com
+msgafrica.com
 msh.net.uk
 msi-nord.fr
 msi.com
 msinfoweb.in
+msistone.com
 msiunix.com
 msk-garant.ru
 msk-olymp.ru
@@ -21075,6 +22023,7 @@ msk910.ru
 mskads.com
 mslink.ru
 mslive.com.br
+msmc.com
 msmonline.com.br
 msndr.net
 msolinternet.com.br
@@ -21099,6 +22048,7 @@ mstr.cz
 msumcbd.com
 msw.gov.pl
 mswia.gov.pl
+msxi.com
 msys.ch
 msz.gov.pl
 mt.com
@@ -21112,6 +22062,7 @@ mtecom.com
 mtecom.net
 mtel.at
 mtel.gr
+mtel.mk
 mtelnetworks.com
 mtemc.com
 mtf.ch
@@ -21139,6 +22090,7 @@ mtnetworks.mn
 mtnid.net
 mtp.pl
 mtr.com.hk
+mtrtml.com
 mts-nn.ru
 mts.ie
 mtsinergi.biz.id
@@ -21209,6 +22161,7 @@ multimega.net.ar
 multimidiatv.com.br
 multinationalpr.com
 multinet-zuromin.pl
+multinet.com.tr
 multinetbd.com
 multinetcabletv.com
 multinetcorp.net
@@ -21243,6 +22196,7 @@ municarrillo.go.cr
 mup.hr
 mur.at
 murathanaraz.com
+murator.com.pl
 muriadata.co.id
 muriaglobalnetwork.id
 muricinet.com.br
@@ -21277,6 +22231,7 @@ mvmi.hu
 mvmnet.com
 mvntelenet.com
 mvphealthplan.com
+mvpone.com
 mvprovedor.com.br
 mvr.bg
 mvs.co.il
@@ -21326,6 +22281,7 @@ myanmarcountry.net
 myanmarnetwork.com.mm
 myanmaronlinecreations.com
 myanti.cloud
+myasd.com
 myasiacloud.com.my
 myasnov.ru
 mybati.com
@@ -21347,6 +22303,7 @@ mycvtech.com
 mycwt.com
 myddls.com
 mydemoulas.net
+mydigitalmonks.com
 mydukaan.io
 myeg.com.my
 myescambia.com
@@ -21360,6 +22317,7 @@ mygalaxianet.com
 mygaru.com
 mygb.eu
 mygefo.in
+myguardiangroup.com
 myheritage.com
 myip.gr
 myisp.co.ke
@@ -21393,6 +22351,7 @@ myomnidata.com
 myonepaper.com
 myown.eu
 myphone.ge
+mypoints.com
 mypos.com
 mypowercloud.net
 myprepaidcenter.com
@@ -21447,6 +22406,7 @@ n-ix.com
 n-ix.net
 n-l-e.ru
 n-space.pl
+n0e.net
 n1mbus.eu
 n2nconnect.com
 n2ntech.com
@@ -21461,6 +22421,8 @@ nabors.com
 nabp.net
 nac.gov.pl
 naca.ro
+nacargo.com
+nacha.org
 nacionservicios.com.ar
 nada.org
 nadadventist.org
@@ -21481,6 +22443,7 @@ nagisasushi.com
 nagra.com
 nagravision.com
 nagumo.com.br
+nahb.com
 nahor.io
 naic.org
 naicom.com
@@ -21509,6 +22472,7 @@ namethatserver.com
 nameunit.com
 namex.it
 namirial.com
+nampower.com.na
 namsa.com
 namyangi.com
 nan.com
@@ -21521,10 +22485,12 @@ nanshenqfurniture.com
 nantworks.com
 naoborot.net
 naomiaurora.com
+nap.net.id
 nap.pe
 napanet.net
 napas.com.vn
 napdelcaribe.net.do
+napervilleparkdst.il.us
 napls.us
 napr.gov.ge
 napri.sk
@@ -21541,6 +22507,7 @@ nariaonline.com.bd
 narl.org.tw
 narrowband.net.au
 narutocloud.com
+nasalt.com
 nascar.com
 nasdaqomx.com
 nasertic.es
@@ -21616,6 +22583,7 @@ navinet.net
 navis.com
 navitaire.com
 navo.pl
+navtech.aero
 navy.mil.bd
 navybluesky.com
 navyfcu.org
@@ -21660,6 +22628,7 @@ ncbj.gov.pl
 ncc.co.za
 ncc.re.kr
 nccc.com.tw
+ncci.com
 ncck.com
 nccourts.org
 nccw.nl
@@ -21766,6 +22735,7 @@ neighbourfibre.top
 neill.com
 neimanmarcus.com
 neirelocation.com
+neisd.net
 nek.bg
 nek.si
 nekoclaw.moe
@@ -21795,6 +22765,7 @@ neogen.biz
 neogov.com
 neokarm.com
 neoleap.com.sa
+neolink-group.ru
 neolink.com
 neolink.com.np
 neologic.com.ua
@@ -21807,6 +22778,7 @@ neonetpl.pl
 neonetporto.com.br
 neopay.ae
 neopollard.com
+neopostinc.com
 neoprotect.net
 neora.com
 neoris.com
@@ -21839,6 +22811,7 @@ neptuneretailsolutions.com
 neracom.bg
 nerdherrschaft.com
 nerdie.net
+nerdnet.nl
 nerdnetwork.us
 nerdscave.de
 nero.com
@@ -21854,8 +22827,11 @@ ness.com
 nessla.se
 nestbank.pl
 nestleusa.com
+nestro.org
+nestro.ru
 net-art.cz
 net-bg.net
+net-cat.at
 net-connect.pl
 net-flet.ba
 net-g.com.ar
@@ -21879,6 +22855,7 @@ net15.co.za
 net2atlanta.com
 net2bdisp.com
 net2home.net
+net2net.com.pa
 net2you.net.br
 net35.ru
 net360.net.lb
@@ -21892,6 +22869,7 @@ net9online.in
 netability.ie
 netaccessint.com
 netacom.com
+netadmins.ca
 netafim.co.il
 netafraz.com
 netalia.it
@@ -22088,6 +23066,7 @@ netlink.id
 netlinkbl.com.br
 netlinkce.com.br
 netlinkdominicana.com
+netlinkgroup.com.au
 netlinkma.com.br
 netlinksolucoes.com.br
 netlinux.ca
@@ -22115,6 +23094,7 @@ netncr.com
 netnew.com.br
 netnext.nl
 netnic.com.cn
+netnite.pl
 netnoerden.dk
 netnova.global
 netnovotempo.com.br
@@ -22123,6 +23103,7 @@ netnz.com.br
 netocean.de
 netone.co.zm
 netone.nl
+netoneintl.com
 netonline.ru
 netop.com
 netopen.cz
@@ -22136,6 +23117,7 @@ netpage.info
 netpara.net.br
 netpatagon.net
 netpatagonia.com.ar
+netperfect.fr
 netpilot.cc
 netpipe.com.ua
 netplanety.com.br
@@ -22297,6 +23279,7 @@ networxhost.com
 netwrks.com
 netx.am
 netx.as
+netx.com.tr
 netx.dp.ua
 netx.net.bd
 netx.org.pl
@@ -22324,6 +23307,7 @@ neuralsoft.com
 neuroland.ru
 neurones-it.com
 neurongroup.net
+neuropace.com
 neuropublic.gr
 neurosoft.pl
 neuteck.com
@@ -22343,11 +23327,13 @@ new-tel.net
 newabilitiesot.com
 newagelan.net
 newave.al
+newbank.ru
 newbay.com
 newbelgium.com
 newbreakcommunications.com
 newbridgehealth.org
 newbuyphilippines.com
+newcaneyisd.org
 newcastle.co.uk
 newcastlepermanent.com.au
 newcomm.it
@@ -22360,6 +23346,8 @@ newedge.com
 newegg.com
 newellco.com
 newerait.co.nz
+neweratechnologies.net
+newfoundlandpower.com
 newfront.com.br
 newglasgow.ca
 newhost.com.ua
@@ -22371,6 +23359,7 @@ newkopel.ro
 newlifeinformatica.com.br
 newline.in.ua
 newlinkconnect.com.br
+newmexicomutual.com
 newnet.ua
 newnetprovedor.net.br
 newnix.it
@@ -22379,10 +23368,12 @@ neworiental.org
 newport.com
 newreal.ru
 newsandmedia.sk
+newsbank.com
 newsday.com
 newsolutionnet.com.br
 newstarmax.ps
 newsv.jp
+newswire18.com
 newtech.fr
 newtek-hn.com
 newtoplink.net
@@ -22400,8 +23391,10 @@ nexanet.ch
 nexaroot.in
 nexat.be
 nexavo.io
+nexbank.com
 nexcus.com
 nexdecade.com
+nexelogy.com
 nexet.hk
 nexg.com
 nexgenaccess.com
@@ -22491,6 +23484,7 @@ nexxtra.de
 nexylan.com
 nezperce.org
 nfb.pl
+nfc.bank
 nfi.net.id
 nfiindustries.com
 nfk.no
@@ -22501,6 +23495,8 @@ nfoe.net
 nfon.com
 nforto.com
 nfoservers.com
+nfta.com
+nftconsult.com
 nfumutual.co.uk
 nfz.gov.pl
 ngahr.com
@@ -22534,8 +23530,10 @@ ngv.com.au
 ngvcv.cn
 ngx.net.id
 nh.org.au
+nhc.co.tz
 nhh.hu
 nhic.or.kr
+nhif.or.tz
 nhksolutions.eu
 nhn.com
 nhpc.nic.in
@@ -22575,8 +23573,11 @@ nidix.net
 nielsen.com
 nieuwedagnetwerk.net
 niewels.de
+niewerth.it
 nif.hu
 nifco.com
+nift.pk
+nigerianports.org
 nigerianstockexchange.com
 nightingale.org
 nii-vektor.ru
@@ -22596,6 +23597,7 @@ nilmage.com
 nim.net.id
 nimaws.com
 nimblenepal.com
+nimblestorage.com
 nimblynet.com
 nimbusitsolutions.com
 nimbussolutions.net
@@ -22613,8 +23615,10 @@ ninja-ix.net
 ninja-ix.org
 ninjanetworkonline.net
 nintendo.com
+ninthcircuit.org
 ninux.org
 niobeweb.net
+niobrara.com
 nioc.com
 nioc.ir
 niopdc.ir
@@ -22700,6 +23704,7 @@ nlr.ru
 nlscanme.com
 nlstiam.info
 nlwa.ms
+nm-g.ru
 nmax.net
 nmc.or.kr
 nmccentral.com
@@ -22707,9 +23712,11 @@ nmdp.org
 nmedia.net.pl
 nmefcu.org
 nmeuh.cn
+nmhs.net
 nmhs.org
 nmi.com
 nmica.net
+nmortho.net
 nmparibas.com
 nms-bd.com
 nmt.ne.jp
@@ -22789,6 +23796,7 @@ nokenmuliatama.co.id
 nokiantyres.com
 nokiantyres.ru
 nokissing.shop
+nolalibrary.org
 nolan.lv
 nolimit.pl
 nolimithost.cc
@@ -22819,6 +23827,7 @@ noorsoft.org
 nopkt.com
 nora.se
 noraina.cloud
+norcom.org
 norcorp.com
 nord-com.it
 nord-ovest.it
@@ -22828,6 +23837,7 @@ nordam.com
 nordconnect.com
 nordfiber.no
 nordfjordnett.no
+nordicfighter.com
 nordicservers.no
 nordklett.com
 nordlights.net
@@ -22848,6 +23858,7 @@ norsk-tipping.no
 norta.com
 nortech.com.ar
 nortenet.com.py
+northamericanbancard.net
 northamericanstainless.com
 northbayle.xyz
 northcloud.co.nz
@@ -22861,6 +23872,7 @@ northeyphotography.com
 northmemorial.com
 northnet.ru
 northpointservices.in
+northpower.co.nz
 northrim.com
 northrivermidstream.com
 northrockllc.com
@@ -22879,6 +23891,7 @@ northwestmls.com
 nortis.pl
 nortonrosefulbright.com
 norttel.sk
+norwichpublicutilities.com
 noscito.network
 nosi.cv
 nosignal.org
@@ -22969,6 +23982,7 @@ nowaera.pl
 nowcom.com
 noweda.de
 nowinynet.pl
+nowire.gr
 nowitsolutions.com.au
 nowogrod.net
 nowystyl.com
@@ -22983,10 +23997,13 @@ npci.org.in
 npcmedia.com.au
 npcprom.ru
 npct1.co.id
+npd.com
 npff.ru
 npfsberbanka.ru
 npgco.com
+nph.com
 npk-va.com
+npki.com
 npn-network.id
 npods.ru
 npp-insoft.ru
@@ -23013,6 +24030,7 @@ nren.net.np
 nrf.re.kr
 nrg.com
 nrg.ro
+nrggos.com.au
 nrgroup-bd.com
 nrp-network.com
 nrp.net.tr
@@ -23088,6 +24106,7 @@ ntk64.ru
 ntktv.ua
 ntm.net.br
 ntmk.ru
+ntmwd.com
 ntpc.co.in
 ntq.com.au
 ntrc.gd
@@ -23106,6 +24125,7 @@ nttsw.com
 ntua.com
 ntup.net
 nturnet.com
+ntv.bg
 ntv.ru
 ntvplus.com
 nty.ro
@@ -23116,6 +24136,7 @@ nubacloud.com
 nubaip.nl
 nubank.com.br
 nubenet.com.ar
+nubesec.com
 nubihost.cloud
 nubip.com
 nubirdz.com
@@ -23129,6 +24150,7 @@ nucor.com
 nuendel.de
 nuevanetsanjavier.com.ar
 nuevoshorizontes.com
+nuevoshoteles.com
 nuevosiglo.com.uy
 nuflayer.com
 nuggetmarket.com
@@ -23144,6 +24166,7 @@ numberly.com
 numedy.com
 numerator.com
 numerex.com
+numeric.com
 numia.com
 numintec.com
 numplus.com
@@ -23190,11 +24213,13 @@ nv7telecom.net.br
 nventify.com
 nvrsline.org
 nvsni.com
+nvusd.k12.ca.us
 nw-team.de
 nw18.com
 nwatom.ru
 nwc.com.co
 nwdamme.co.za
+nwf.org
 nwfcu.org
 nwip.co.uk
 nwl.co.uk
@@ -23204,6 +24229,8 @@ nwnit.com
 nwo.giize.com
 nwoca.org
 nwonkac.com
+nwrsturgeonrefinery.com
+nwsc.co.ug
 nwsgmbh.de
 nwth.ru
 nwtime.org
@@ -23227,6 +24254,7 @@ nychdc.com
 nycmesh.net
 nycro.de
 nyct.com
+nydj.com
 nyfoundling.org
 nygenome.org
 nyiso.com
@@ -23234,6 +24262,7 @@ nynas.com
 nynjhidta.org
 nypl.org
 nyproton.com
+nypublicradio.org
 nysanet.pl
 nysolutions.com
 nyss.ca
@@ -23260,6 +24289,7 @@ o-net.com.ua
 o-net.id
 o.kg
 o2.pl
+o2nexus.com.my
 o3.ua
 o3consultoria.com.br
 o4it.com
@@ -23286,6 +24316,7 @@ obercom.com.ar
 obercom.net.ar
 obi.com
 obilink.com
+obis.co.jp
 obiz.co.il
 objetivoinformatica.com.br
 objx.net
@@ -23312,6 +24343,7 @@ oceanbluecloud.com
 oceancoyacht.com
 oceaneering.com
 oceanlinknet.com
+oceantelecom.ru
 ocei.gov.bd
 ocellustech.com
 ocfl.net
@@ -23338,7 +24370,9 @@ octoheberg.fr
 octopismart.co.za
 octopuscs.com
 octosinfra.com
+oculartechnologies.com
 oculon.ai
+ocwen.com
 od.gov.ua
 odant.ru
 odas.jp
@@ -23371,12 +24405,14 @@ oec.gov.ws
 oecgraphics.com
 oecu.org
 oediv.de
+oefi.org
 oeko.net
 oelis.fr
 oemcontrols.com
 oemji.co.id
 oesia.com
 oestenet.net
+oexebusiness.com
 of.pl
 ofac.ch
 ofc.com.pg
@@ -23402,12 +24438,14 @@ ofi-am.fr
 oficialnet.com
 oficinadocartucho.com.br
 oficinapyme.co
+ofina.on.ca
 ofis24.net
 oforo.ru
 ofsbrands.com
 oge.com
 ogi.co.id
 ogicom.net
+oglasnik.hr
 ogmios.lt
 ogreserve.com
 ogroup.net.ua
@@ -23427,9 +24465,11 @@ oiv.hr
 oixio.ee
 ok.dk
 ok.ru
+ok360.pl
 okanoganpud.org
 okazii.ro
 okbprogress.ru
+okcconventioncenter.com
 okcs.com
 oke.net.id
 okean.odessa.ua
@@ -23451,10 +24491,12 @@ okweb3.jp
 ol.dp.ua
 ol.fr
 olanchonet.com
+olatheks.org
 olatheschools.org
 olb-access.net
 olbitx.network
 olcx.net
+oldmutual.co.ke
 oldmutual.co.za
 oldmutual.com
 oldnational.com
@@ -23478,6 +24520,7 @@ ollatelecom.net.br
 ollie.com.ua
 ology.com
 ololos.space
+olostech.com.br
 ols-br.com
 olshanlaw.com
 olson-network.com
@@ -23486,11 +24529,13 @@ olsztyn.eu
 olyclub.com
 olympic-casino.com
 olympic.org
+omahasteaks.com
 omakase.jp
 omandatapark.com
 omaticon.com
 omax.rs
 omc.com
+omd.com
 omd.ru
 omega-connect.net
 omega.page
@@ -23515,9 +24560,11 @@ omniateknologi.com
 omnicloud.io
 omnifibernet.net
 omnihotels.com
+omnilife.com
 omnimodetrade.com
 omnissa.com
 omnisync.net
+omnitec.net
 omnitec.pl
 omnitouchns.com
 omniva.com
@@ -23569,6 +24616,7 @@ onecentral.nl
 onechronos.com
 oneclickmedia.com.au
 onecom.ua
+onecore.ro
 onecubic.com
 onecubit.net
 onegas.com
@@ -23621,6 +24669,7 @@ oni.co.uk
 oni.net.br
 onidel.com
 onionring.co.uk
+onit.gt
 onitas.no
 onito.pl
 onix.net.pe
@@ -23629,6 +24678,7 @@ onji.net
 onlanta.ru
 onlime.mn
 online-inc.com
+online.com.au
 online.net.br
 online.sumy.ua
 online50.net
@@ -23652,6 +24702,7 @@ onnethn.com
 onnisys.fi
 onnonetworks.com
 onpointcu.com
+onqoc.com
 onquee.com
 onradinc.com
 onrela.ru
@@ -23660,6 +24711,7 @@ onsemi.com
 onset.pl
 onsever.ru
 onsite.co.ke
+onsitetm.com
 ontarioeast.net
 ontarionet.net
 onthe.net.au
@@ -23683,6 +24735,8 @@ opap.gr
 opapisa.it
 opaqnetworks.com
 oparina4.ru
+opb.ca
+opb.org
 opcaonet.com.br
 opco.com
 opcom.ro
@@ -23715,6 +24769,7 @@ opennet.hu
 openpop.eu
 openseanet.com.br
 opensent.com
+opensystems.com.au
 opentable.com
 opentech.ru
 opentel.co.za
@@ -23725,6 +24780,7 @@ openway.pl
 openxs.de
 operadors.cat
 operatorwss.pl
+opers.org
 opexustech.com
 opfm.ru
 opgroeien.be
@@ -23751,6 +24807,7 @@ opteam.pl
 opteamax.de
 optet.cz
 optexco.ru
+opti.su
 optibet.lv
 optic-com.bg
 opticallink.net
@@ -23823,6 +24880,7 @@ orangerca.com
 orangeusd.org
 orangeville.ca
 oranta.ua
+orascom.com
 oravask.sk
 orb.no
 orbico.hr
@@ -23830,6 +24888,7 @@ orbicom.kz
 orbicom.net.id
 orbigroup.net
 orbimed.com
+orbis-corp.com
 orbis.com
 orbis.de
 orbis.pl
@@ -23847,6 +24906,7 @@ orbitnetworks.net.pk
 orbitonline.com
 orbotech.com
 orbyt-global.com
+orc.com
 orcas.net
 orcs.ie
 ordbogen.com
@@ -23877,6 +24937,7 @@ oriensoft.com
 orientalspot.com
 orientaltrading.com
 orientbell.com
+orientexpressldi.com
 orientgroup.uz
 oriflame.com
 oriflame.ru
@@ -23893,13 +24954,16 @@ orionshost.net
 oriontop.ru
 orisdental.no
 orix.com
+orkla.lv
 orl.co.il
+orlandoairports.net
 orlandonet.net
 orlen.hu
 orlen.pl
 orlenoil.pl
 ormat.com
 ormilon.com
+ormutual.com
 ornskoldsvik.se
 oroscom.hu
 ors.aero
@@ -23926,8 +24990,10 @@ osce.org
 osceola.de
 osceola.eu
 osceola.org
+osde.com.ar
 osel.pl
 oserver.net
+osg.com
 osgcloud.co.uk
 oshkoshcorp.com
 oshnogroup.tj
@@ -23955,8 +25021,10 @@ oss-core.net
 oss-tambov.ru
 ossds.com
 osselle.no
+osseoschools.org
 osservatorionessuno.org
 ossini.net
+ossnet.lv
 ostankino.ru
 ostec.com
 ostecit.com
@@ -23967,6 +25035,7 @@ ostrowski.pl
 osuan.com
 osv.com
 osw.waw.pl
+osygroup.com
 osystems.ru
 ot.ru
 otavanet.cz
@@ -23993,6 +25062,7 @@ ottis.com.co
 otto.de
 ottogi.co.kr
 ottohost.net
+ou.org
 oudu.cc
 ouest-consulting.net
 oulunenergia.fi
@@ -24016,8 +25086,10 @@ outlook.sg
 outofbox.cloud
 outofwall.com
 outpost24.com
+outsideinc.com
 outsidences.com
 outsource-philippines.com
+outsourcingnetwork.com
 ouva.net
 ovaapart.com
 ovaltinalization.co
@@ -24041,6 +25113,7 @@ owc.net
 owenscorning.com
 owexxhosting.com
 owgelsgroup.com
+owh.de
 owl.net
 owlcreeklp.com
 owliance.com
@@ -24055,6 +25128,7 @@ oxam.com
 oxbow.com
 oxente.net
 oxfordcounty.ca
+oxfordinc.com
 oxide.computer
 oxitgen.de
 oxletech.com
@@ -24082,7 +25156,9 @@ p10.kz
 p1fcu.org
 p24.network
 p66.com
+pabmc.net
 pac.ru
+pacb.com
 pacbell.net
 paccar.com
 pacebus.com
@@ -24098,9 +25174,11 @@ pacificorp.com
 pacificpress.com
 pacifictechsol.com
 pacificterrace.com
+pacificwave.net
 paciolan.com
 pacira.com
 packagingcorp.com
+packetexchange.net
 packetfeed.com
 packetforensics.com
 packetgear.com
@@ -24112,6 +25190,7 @@ packetsanctuary.com
 packetworx.com
 paclightwave.com
 paconvention.com
+pacounties.org
 pacourts.us
 pacs.ee
 pacsun.com
@@ -24136,6 +25215,7 @@ pagi.pl
 pagic.net
 paginasamarillasdeutah.com
 paglo.co.id
+pagoexpress.com.py
 pah.kr
 pahaip.fi
 pahc.com
@@ -24150,6 +25230,7 @@ pakqatar.com.pk
 paks2.hu
 pakt.ru
 paktel.net.id
+palaceentertainment.com
 paladium-pvp.fr
 paladyne.com
 palaindians.com
@@ -24168,6 +25249,7 @@ palma-group.com
 palmahost.sh
 palmasnet.com.br
 palnets.com
+palomapartners.com
 palomarhealth.org
 palos-garza.com
 palpay.ps
@@ -24207,6 +25289,7 @@ panduit.com
 panelre.us
 panelweb54363.online
 paneoutyre.online
+panerabread.com
 pangaea.us
 pankerl-media.de
 pankl.com
@@ -24225,6 +25308,7 @@ pap.com.pl
 papatel.co.id
 pape.com
 papelprint.online
+papelsanfrancisco.com
 papiliohost.com
 paps.net
 papyrus.vip
@@ -24256,6 +25340,7 @@ paridata.com
 parimas.co.id
 parinc.com
 paris.fr
+parisaccessories.com
 paritetbank.by
 parkcity.org
 parke.eus
@@ -24266,8 +25351,11 @@ parking-servis.co.rs
 parknationalbank.com
 parknet.dk
 parks.com.br
+parkviewmc.com
 parl.gc.ca
 parliament.gov.bd
+parliament.govt.nz
+parliament.gr
 parliament.uk
 parmatel.ru
 parmin.cloud
@@ -24313,6 +25401,7 @@ passionatesmiles.com
 passmail.net
 passport.gov.bd
 passthrutechnologies.com
+pastazatv.com
 pasti.net.id
 pasts.lv
 pasty.com
@@ -24327,9 +25416,11 @@ path.net
 pathaopay.com
 pathe.com
 pathix.com
+pathline-emerge.com
 pathward.com
 pathways.com
 pathways.in
+patio-minsk.by
 patramail.com
 patrick.com.au
 patrika.com
@@ -24371,6 +25462,7 @@ paylogic.com
 paymark.co.nz
 payme.uz
 paymentpass.com
+paynet.co.ke
 paynet.md
 paynet.my
 payone.de
@@ -24410,6 +25502,7 @@ pccp.ar
 pcdsi.ph
 pcel.com
 pcesystems.com
+pch.com
 pcinternet.com.br
 pcis.ng
 pcldata.se
@@ -24460,6 +25553,7 @@ peabody.io
 peabodyenergy.com
 peacemaketer.com
 peak6.com
+peakcoms.net
 peakcu.org
 peakfactory.com
 peakhour.io
@@ -24491,6 +25585,7 @@ peer2.com.br
 peer39.com
 peerexnetworks.com
 peerless-clothing.com
+peerlessproducts.com
 peerobyte.com
 peerpointinternet.co.uk
 peets.com
@@ -24504,9 +25599,11 @@ pegaso.eu
 pegasus-gmbh.de
 pegasus.ag
 pegasusgateway.com
+pegasustechnologies.co.ug
 pegasuswave.com
 pegatroncorp.com
 pei.de
+peirce.com
 pej.pl
 pejvaknetco.ir
 pekao-fs.com.pl
@@ -24570,6 +25667,7 @@ pepb.net
 pepkorit.com
 pepowo.net
 pepper.com.au
+peppermillcasinos.com
 pequinet.com.br
 peradaban.ac.id
 percepta.ai
@@ -24588,11 +25686,13 @@ perfectworx.com
 perfettivanmelle.com
 performancehorizon.com
 performanceplants.com
+performanceteam.net
 peri.de
 perimetercenter.net
 perke.net
 perkinscoie.com
 permanentscreen.com
+permarsecurity.com
 permasteellisagroup.com
 permatadata.id
 permenergo.ru
@@ -24647,6 +25747,7 @@ peter-hurtenbach.de
 peterboroughutilities.ca
 peterhost.ru
 peterpotvin.com
+petersburg.k12.va.us
 peterson.org
 peterwarren.com.au
 petiak.com
@@ -24667,6 +25768,7 @@ petromine-energy.com
 petron.ca
 petronas.com.my
 petrosoft.pl
+petrosys.com.au
 petroviser.ru
 petsafe.net
 petsmart.com
@@ -24679,11 +25781,14 @@ pfarm1.com
 pfcu.com
 pffcu.org
 pfgc.com
+pfm.org
 pforzheim.de
 pfsc.com
 pfsweb.com
+pfu-ossc.jp
 pg8global.com
 pgal.com
+pgatour.com
 pgeenergiaciepla.pl
 pgegiek.pl
 pgg.pl
@@ -24692,6 +25797,7 @@ pghub.cz
 pglesports.com
 pgnet.com.br
 pgnetprovedor.com.br
+pgnig.pl
 pgsoft.ro
 ph8ltwdi12o.com
 phantasy.life
@@ -24715,6 +25821,7 @@ philgregorylaw.us
 philipmorrisusa.com
 philkern.de
 phillip.co.id
+phillipcapital.in
 phillipian.org
 phillipsdata.com
 phillyfoos.com
@@ -24722,6 +25829,7 @@ philunet.de
 phirephly.design
 phjw.com
 phl.org
+phmc.org
 phn.net.id
 phoenix-it.ro
 phoenixchildrens.org
@@ -24761,9 +25869,12 @@ pic.es
 picanoc.net
 pichet.com
 pichincha.com
+pickens.k12.sc.us
 pico.global
 pico.net
 picopublic.cloud
+picotrading.com
+pictometry.com
 picture.com.br
 pidginhost.com
 piensanet.com
@@ -24826,6 +25937,7 @@ pioneeritbd.com
 pioneernet.ru
 pioneernrc.com
 pioneernusatama.net
+pioneertechnology.com
 pionet.pl
 piotrkow.pl
 pip-semarang.ac.id
@@ -24836,6 +25948,7 @@ pipefittingsindia.com
 pipenet.hu
 piper-mail.de
 pipersandler.com
+pipeworksinc.com
 pipics.hu
 piraeus-sec.gr
 piraeusbank.gr
@@ -24861,6 +25974,8 @@ piteenergi.se
 piter-ix.ru
 pithonduras.hn
 pitline.net
+pittohio.com
+pittsburghpenguins.com
 pivot5daily.com
 pivotalelements.com
 pixagility.com
@@ -24870,6 +25985,7 @@ pixelfactorydc.com
 pixelfederation.com
 pixoof.com
 pixtel.fr
+pj.pt
 pjm.com
 pjmedia.ca
 pjn.gov.ar
@@ -24880,12 +25996,15 @@ pkoleasing.pl
 pkoubezpieczenia.pl
 pkp-informatyka.pl
 pkpcargo.com
+pkpenergetyka.pl
 pkpik.pl
 pkwy.k12.mo.us
 pla.net.py
 placedesarts.com
+placeiq.com
 placetel.de
 pladi.bg
+plamex.com.mx
 planb.de
 planb.uk.com
 planet-digital.com
@@ -24911,13 +26030,16 @@ planoweb.com.br
 plansee.com
 planurevents.com
 plarium.com
+plassertheurer.com
 plasticangarsk.ru
+plasticsurgery.org
 plastor.ro
 plat-n.com
 plateaugroup.com
 plateautel.net
 platesonline.net
 platform.co.za
+platforma.id
 platformaofd.ru
 platformasoft.ru
 platinum.net.id
@@ -24927,6 +26049,7 @@ platkom.pl
 platon.sk
 playags.com
 playamedia.io
+playapointe.com
 playboxinformatica.com.br
 playboxneo.com
 playcomla.com.ar
@@ -25008,6 +26131,7 @@ pngnwtl.com
 pnj.ac.id
 pnj.com.vn
 pnl.ac.id
+pnl.co.ke
 pnm-net.id
 pnm.ac.id
 pnm.co.id
@@ -25017,6 +26141,7 @@ pnprovedor.com.br
 pns.com.ve
 pnt.opole.pl
 po-trade.com
+poba.or.kr
 pocca.com
 poczta-polska.pl
 pod.tv
@@ -25084,6 +26209,7 @@ polish-airports.com
 polist.org
 politeknikpu.ac.id
 politi.dk
+politico.com
 politie.nl
 poliwangi.ac.id
 polk.k12.ga.us
@@ -25095,6 +26221,7 @@ polnet24.pl
 polonet.io
 polpharma.pl
 polskapress.pl
+polskieradio.pl
 polsri.ac.id
 poltekatipdg.ac.id
 poltekbangsby.ac.id
@@ -25102,6 +26229,7 @@ poltekkes-pdg.ac.id
 poltekkes-solo.ac.id
 poltekkesdepkes-sby.ac.id
 poltekkesjogja.ac.id
+poltekkespalembang.ac.id
 poltekparmakassar.ac.id
 poltekpel-sby.ac.id
 poltekpelsumbar.ac.id
@@ -25159,6 +26287,8 @@ portal.com
 portalcom.net.br
 portalconexao.com.br
 portalctf.com.br
+portaldaindustria.com.br
+portaldedocumentos.com.br
 portalfast.net
 portalm7.com.br
 portalma.com.br
@@ -25168,6 +26298,7 @@ portalnetworki.com.br
 portalqueops.net.br
 portalrrinformatica.com.br
 portaone.com
+portauthoritynsw.com.au
 portbris.com.au
 portcanaveral.com
 porterhealth.com
@@ -25178,8 +26309,11 @@ portgdansk.pl
 portmadisonenterprises.com
 portmone.me
 portoalegre-airport.com.br
+portobello.com.br
 portodigital.pt
 portoeditora.pt
+portofhouston.com
+portoflosangeles.org
 portofportland.com
 portofrancoti.com.br
 portofrotterdam.com
@@ -25190,9 +26324,11 @@ portonet.net.br
 portonics.com
 portoseguro.com.br
 portrix-systems.de
+ports.go.tz
 ports.net
 portsamerica.com
 portseattle.org
+portvancouver.com
 portwake.com
 posco.com
 posdata.it
@@ -25268,10 +26404,13 @@ ppas.cz
 ppdbagbm.com
 ppdpp.id
 ppec.coop
+ppf.or.tz
 ppfbanka.cz
 ppfinsurance.ru
 ppi.ac.id
+ppi.coop
 ppi.net.id
+ppl.com.pk
 pplink.net.br
 pplweb.com
 ppm-manajemen.ac.id
@@ -25300,6 +26439,7 @@ praha1.net
 praha12.com
 pranet.ru
 prangroup.com
+prasetia.us
 praslavice.net
 pratesis.com
 pratidonaduzzi.com.br
@@ -25308,6 +26448,7 @@ pravnagroup-m.pl
 praweda.id
 praxis.pl
 prb.bg
+prccustomresearch.com
 prcdirect.com.au
 prconnect.net.br
 pre.cz
@@ -25317,10 +26458,12 @@ precast.com
 precedence.co.uk
 precisely.com
 precisenetworksinc.com
+preciseparklink.com
 precisionaccountingservices.com
 precisiongroup.com
 precisionplanting.com
 precisionpros.com
+precor.com
 precorp.coop
 predictedpaths.nl
 predictivetechnologies.com
@@ -25336,16 +26479,20 @@ premiercom.ru
 premiercontactpoint.com
 premierenergy.md
 premiereradio.com
+premierlottong.com
 premierplus.com.ua
 premiertech.com.au
+premium-services.bg
 premium.se
 premiumcommunications.com
 premiumpension.com
 prepa.com
+prepaidworld.co.za
 prerender.io
 prescientworldwide.com
 presencehealth.org
 presidence.bj
+presidencia.gob.pa
 presidency.gov.so
 president.bg
 president.gov.ge
@@ -25394,6 +26541,7 @@ primariacalarasi.ro
 primaryresidentialmortgage.com
 primastream.com
 primatel.sk
+primaticsfinancial.com
 primavision.id
 prime-cloud.top
 prime.net.np
@@ -25403,6 +26551,7 @@ primecredit.com.hk
 primefilter.host
 primeinc.com
 primeline-solutions.com
+primeline.net
 primend.com
 primenet.id
 primerica.com
@@ -25426,6 +26575,7 @@ prinode.com
 printec.ro
 printemps.com
 printful.com
+printmailsolutions.com
 printpack.com
 priocom.com
 priorbank.by
@@ -25463,6 +26613,7 @@ pro-network.ru
 pro-spero.ru
 proactis.com
 proactivity.group
+proassurance.com
 probank.pro
 probtp.com
 proc.ru
@@ -25493,6 +26644,7 @@ profactura.cl
 proferis.pl
 professional-it.com.au
 professionalaccess.com
+professionalplastics.com
 profexional.it
 profholod.ru
 profi.ru
@@ -25517,6 +26669,7 @@ progent.com
 progetto-sicurezza.it
 progettoarchivio.it
 progettoevo.com
+progfinance.com
 proginter.com
 progon.net
 programmed.com.au
@@ -25524,6 +26677,7 @@ progresivebd.com
 progreso.pl
 progresodigital.com.ar
 progress.com
+progressbiz.com
 progressfood.ru
 progression.com
 progressit.com.au
@@ -25591,6 +26745,9 @@ proover.net.br
 propath.com
 propel.sh
 property24.com
+propharma.co.nz
+prophetsys.com
+proponent.com
 prorail.nl
 pros-services.net
 prosaicloud.net
@@ -25612,6 +26769,7 @@ proszynskimedia.pl
 proteantech.in
 protecmedia.com
 protecnonetworks.com
+protected-networks.net
 protected.ca
 protectiv.ph
 protective.com
@@ -25630,6 +26788,7 @@ proton66.ru
 protronics.com
 protv.ro
 proudserver.com
+prov.us
 provakilaw.com
 provectio.fr
 provedorascon.com.br
@@ -25660,6 +26819,7 @@ proveinter.com.br
 provendo.no
 provequity.com
 provet.com.au
+provide.net
 provide.nl
 provident.com
 provider.pl
@@ -25668,10 +26828,12 @@ providus.rs
 providusbank.com
 provincia.padova.it
 provincia.terni.it
+provincialaerospace.com
 provincianet.com.ar
 provinsat.com.ar
 provinzial.de
 provision.ro
+provocraft.com
 provodov-net.ru
 provweb.com.br
 provynet.com.br
@@ -25702,10 +26864,12 @@ prudour.com
 prutul.ro
 prvainternetova.org
 prymas.com.pl
+pryorcashman.com
 ps.it
 ps.md
 ps.ro
 psa-antwerp.be
+psam.com
 psb-gmbh.de
 psbank.ru
 psbcoa.com.cn
@@ -25718,6 +26882,7 @@ pse.com
 pse.pl
 pseb.org.pk
 psecu.com
+pseek.fr
 pseg.com
 pseudonym.mx
 psg.com
@@ -25791,7 +26956,9 @@ pubmatic.com
 pubyun.com
 pucononline.cl
 pudlink.ru
+pueblocounty.us
 pueblolibrary.org
+puertocartagena.com
 pueschel-hh.de
 pufferfish.host
 pugetsoundnetworks.com
@@ -25803,12 +26970,14 @@ pulmuone.co.kr
 puls.net
 puls.ru
 pulsar360.com
+pulsarinformatique.ca
 pulsarnet.io
 pulseheberg.com
 pulsenet.net
 pumaservers.com
 pumpcloud.net
 punjab-zameen.gov.pk
+punjlloyd.com
 punkt.de
 punktum.dk
 puntdacces.coop
@@ -25830,11 +26999,13 @@ purple.us
 purpleit.com
 pushpkt.com
 pushrcdn.com
+pushwoosh.com
 pusindit.co.id
 puskomedia.net.id
 pusulayatirim.com.tr
 putnamschools.org
 putranetworks.net
+puzl.ee
 puzzlenet.ir
 pv-cp.net
 pvbki.com
@@ -25850,6 +27021,7 @@ pwa.co.th
 pwc.in
 pwc.lu
 pwcgov.org
+pwcs.com.au
 pwn.pl
 pwpartners.com
 pwpw.pl
@@ -25861,6 +27033,7 @@ pyhanet.fi
 pylonone.com
 pyramid.net
 pyro.host
+pyrsoftware.com
 pysio.online
 pyxya.fr
 pzena.com
@@ -25880,6 +27053,7 @@ qamtech.co.il
 qarea.com
 qatarenergy.qa
 qatarenergylng.qa
+qawolf.com
 qazcloud.kz
 qbe.com
 qbone.net
@@ -25890,6 +27064,7 @@ qelopak.com
 qematalwasat.com
 qemugen.com
 qg.com
+qgold.com
 qiagen.com
 qiandra.net.id
 qingye.org
@@ -26017,6 +27192,7 @@ quinaultindiannation.com
 quinnox.com
 quinstreet.com
 quintas.net.ar
+quintec.cl
 quintex.com
 quintiq.com
 quipu-processing.com
@@ -26045,6 +27221,7 @@ r-19.ru
 r-1bd.net
 r-ce.pl
 r-cis.com
+r-industria.ru
 r-tk.net
 r.pl
 r17.co.id
@@ -26083,6 +27260,7 @@ rackh.com
 rackmarkt.com
 racknode.net
 rackone.it
+rackorbit.com
 rackplace.com.ua
 rackroomshoes.com
 racksense.com
@@ -26128,6 +27306,7 @@ radiofrance.fr
 radiolinkplus.cz
 radiolodz.pl
 radiomayak.ru
+radiometer.com
 radionet-t.ru
 radionet.com.ua
 radionetturda.ro
@@ -26142,10 +27321,13 @@ radiotoolbox.com
 radiowroclaw.pl
 radioz.org
 radishnet.work
+radishnetworks.com
 radistr.ru
 radius.com
 radius.ph
+radiusgs.com
 radix-technologies.com
+radltd.com
 radmila.net.id
 radnet-digital.id
 radnet.com
@@ -26158,6 +27340,7 @@ rafako.com.pl
 rafatech.com.my
 rafatek.co.id
 raffcap.com
+rafimaging.com
 rafinsatellite.net
 raga.cd
 rage4.com
@@ -26207,6 +27390,7 @@ rakanponsel.co.id
 raketa-net.ru
 rakinit.com.bd
 rakomedia.id
+rakon.com
 raleighenterprises.com
 raleys.com
 ralf.ru
@@ -26216,6 +27400,7 @@ ram.nl
 rambam.org.il
 ramburs.com
 rambus.com
+ramchealth.org
 ramco.com
 ramirezco.com
 ramirezvargasabogados.com
@@ -26224,9 +27409,11 @@ ramosnetwork.ao
 rampant.com.au
 rams.com.au
 ramsay.im
+ramseysolutions.com
 ranbaxy.com
 ranchesmontana.com
 rand.org
+randallcounty.org
 randers.dk
 randgraphics.com
 random-logic.com
@@ -26323,14 +27510,17 @@ rbwmfg.com
 rcagrup.ro
 rcarre.com
 rcbc.com
+rcc-group.ru
 rccl.com
 rccomunicaciones.co
 rcdi.com.ar
 rcgdirect.com
+rcgit.com
 rchsd.org
 rcilab.in
 rcip.co.il
 rcitsakha.ru
+rcloud.ru
 rcls.org
 rcm.net.mx
 rcmi.com
@@ -26341,6 +27531,7 @@ rcntec.com
 rco.cz
 rcodezero.at
 rcp.pe
+rcpaqap.com.au
 rcps.org
 rcs-networks.com
 rcs.it
@@ -26349,6 +27540,8 @@ rcsnet.ru
 rcstech.ae
 rct.pe
 rcwilley.com
+rcz.com.br
+rd-net.ru
 rd.lv
 rdbnn24.ru
 rdc.net.ar
@@ -26366,6 +27559,7 @@ rdm.com
 rdm.io
 rdn.net.id
 rdnaks.ph
+rdnetworkbd.com
 rdns.de
 rdock.ru
 rdpnbd.com
@@ -26380,6 +27574,7 @@ re.com.na
 rea-group.com
 reach.media
 reachesbeast.com.de
+readinghealth.org
 readingsd.org
 readspeaker.com
 readyidc.com
@@ -26433,10 +27628,12 @@ red4g.net
 red5g.com
 redacted.li
 redam.lv
+redbanc.cl
 redbaronconsulting.com
 redbeemedia.com
 redboxserver.com
 redbull.at
+redbull.com
 redcall.cl
 redcat.me
 redclara.net
@@ -26447,11 +27644,14 @@ redcom.com
 redconex.pe
 redcoop.com.ar
 redcosmos.com.ar
+redcross.or.ke
 redcross.or.kr
 redcross.or.th
 redcrs.com.ar
+reddiamond.com
 reddotech.com
 rede2cr.com.br
+redeaberta.es
 redeasanet.com.br
 redebandalarga.net.br
 redebrasilrj.com.br
@@ -26539,12 +27739,14 @@ redteam.net
 redtechnology.com
 redtectllc.net
 reduno.com.mx
+redventures.com
 redvoiss.net
 redwhite.co.id
 redwicom.com
 redwisp.cl
 redwolf.com.ar
 redwood.nl
+redwoodmaterials.com
 redworks.nl
 redynet.com
 redzaclechner.at
@@ -26558,6 +27760,7 @@ reevo.fr
 refidomsa.com.do
 reflectedbestselfexercise.com
 refrig.ro
+refugems.com
 reg-kursk.ru
 reg.it.ao
 regalcinemas.com
@@ -26610,6 +27813,7 @@ regus.com
 regxa.iq
 regynet.co.id
 rehau.com
+rehnonline.com
 rei.com
 reidanet.net.br
 reiff-tp.de
@@ -26623,6 +27827,7 @@ rekayasa.co.id
 reksoft.com
 rel-ltd.com
 related.com
+relativityspace.com
 relax-gaming.com
 relaxdays.services
 relaxhouse.shop
@@ -26676,6 +27881,7 @@ renklihost.com
 renkus-hainz.com
 renlife.com
 renner.uz
+renoairport.com
 renocagroupsrl.com
 renom.in
 renopie.com
@@ -26738,6 +27944,7 @@ restartenergy.ro
 restocarpediem.com
 reston.va.us
 restoration.gov.ua
+restorationhardware.com
 restumedia.com
 resultsadpro.com
 resultsdirect.com.au
@@ -26765,6 +27972,7 @@ retsinasoftware.com
 retterm.com
 rettigicc.com
 reubenonline.com
+reueus.net
 rev.net
 rev0telecablecr.com
 reve.fr
@@ -26783,6 +27991,7 @@ revolveclothing.com
 revtelecom.net
 revton.com
 rewardsnetwork.com
+rewc.com
 rewe-digital.com
 rewe-group.at
 rewolucja-net.pl
@@ -26834,6 +28043,7 @@ rheintal-ix.net
 rhicom.ca
 rhmtecnologia.com.br
 rhonet.eu
+rhsnet.org
 rhythmic.net
 rhythmone.com
 rhyzome.ca
@@ -26861,6 +28071,7 @@ ridedart.com
 ridemetro.org
 ridgefieldgroup.com
 ridgelineintl.com
+ridgeviewmedical.org
 ridleysd.org
 ridsys.com
 rieder.net.py
@@ -26876,6 +28087,7 @@ riga.lv
 rigassatiksme.lv
 rigetti.com
 right-businesses.com
+rightascension.com
 rightconnectionstravel.com
 rightmove.co.uk
 rigilweb.nz
@@ -26887,12 +28099,14 @@ riksgalden.se
 rillcrestly.xyz
 rimatel.mr
 rimco.pl
+rimkus.com
 ring.cr
 ring.net.id
 ringanerd.co.za
 ringier.ro
 ringier.sk
 ringover.com
+ringpower.com
 rings3.com.bd
 ringsted.dk
 ringtel.rs
@@ -26952,16 +28166,19 @@ rkomi.ru
 rks-energo.ru
 rks-gov.net
 rku.it
+rkycom.com
 rlan.com.ua
 rlan.ru
 rlaninternet.hu
 rlasd.net
 rlcarriers.com
+rlrisk.com
 rls.si
 rltelecon.com.br
 rltt.net
 rlv.si
 rm.dk
+rm.vg
 rma-net.eu
 rmeniaa.net
 rmf.pl
@@ -26975,6 +28192,7 @@ rmrfibra.com.br
 rmrgroup.com
 rmrteleinformatica.com.br
 rms.loans
+rmsisc.com
 rmstelecom.net.br
 rmt-lumajangnetwork.net
 rmto.ir
@@ -26985,8 +28203,10 @@ rna.ro
 rnbo.gov.ua
 rnc.com.ua
 rndc-usa.com
+rnds.com.ph
 rnet.com.ar
 rnetbh.com.br
+rnfiservices.com
 rnic.it
 rnko.ru
 rnlink.net
@@ -27017,6 +28237,7 @@ robotics.net
 robotstxt.es
 robs-journeys.co.uk
 robtex.com
+roc-noc.com
 roca.es
 roccopugliese.com
 roche.de
@@ -27066,7 +28287,9 @@ roicallcentersolutions.com
 roitl.ru
 roka.co.id
 rokabear.com
+roki-us.com
 rokkovac-group.com
+rokogame.com
 rokunet.com
 rolanddga.com
 rolex.com
@@ -27090,6 +28313,7 @@ romprix.ro
 romsnetwork.com
 ron.mil.pl
 rona.ca
+ronalgroup.com
 rondotech.com.br
 rongdhonuonline.com
 roni.com.pl
@@ -27114,6 +28338,7 @@ ropocapital.fi
 ros-inet.ru
 rosa.ro
 rosa.ru
+rosario.gov.ar
 rosatom.ru
 rosbs.biz
 roscongress.org
@@ -27123,6 +28348,7 @@ roseltorg.tech
 rosenbergestis.com
 rosenresearch.com
 rosenthalinc.com
+roseville.mn.us
 rosignol.net
 rosim.ru
 rosinfocom.net
@@ -27139,6 +28365,7 @@ rosseti.digital
 rossetimr.ru
 rossetisk.ru
 rossetivolga.ru
+rossiya-airlines.com
 rossko.ru
 rossmann.de
 rossmann.pl
@@ -27150,7 +28377,9 @@ rostpay.ru
 rosukrep.ru
 rotarex.com
 rotary.org
+rotarycorp.com
 rotax.com
+roteskreuz-tirol.at
 roteskreuz.at
 roth.com
 rothschild.com
@@ -27182,6 +28411,7 @@ roxnet.md
 roxtec.com
 royal-gallery.com
 royal-server.ro
+royal-ua.com
 royalairmaroc.com
 royalassetindo.co.id
 royalcapitalbd.com
@@ -27206,6 +28436,7 @@ rpnnetprovedor.com.br
 rpower.energy
 rps.cz
 rpu.org
+rr64.net
 rra.gov.rw
 rrc.rs
 rrc.si
@@ -27233,9 +28464,11 @@ rsconnection.net.br
 rscs.com
 rsd.cz
 rsfjnet.com
+rsggroup.com
 rsholding.org
 rshs.web.id
 rsi-informatique.fr
+rsinetbd.com
 rsinsurance.us
 rsk.co.id
 rskariadi.co.id
@@ -27249,6 +28482,7 @@ rsmus.com
 rsna.org
 rsnet.sk
 rsonline.pl
+rsp.com.au
 rspcaqld.org.au
 rssb.rw
 rssmultimidia.com.br
@@ -27266,6 +28500,7 @@ rtat.net
 rtatel.ru
 rtbf.be
 rtbhouse.com
+rtcenter.ru
 rtcnow.com
 rtcommufa.ru
 rtd-denver.com
@@ -27307,6 +28542,7 @@ rtv.net
 rtv.rs
 rtve.es
 rtvi.com
+rtvision.com
 rtvnoord.nl
 rtvslo.si
 rtyne.net
@@ -27328,6 +28564,7 @@ rudcom.pl
 rudersdal.dk
 rudio.net
 rudis.si
+rudolphtire.com
 rudrats.in
 rudyguerra.com
 rueschconsulting.com
@@ -27382,6 +28619,7 @@ rusk.cat
 rusklimat.ru
 rusnano.com
 rusnarbank.ru
+ruspromsoft.ru
 russel-aitken.co.uk
 russell.com
 russellresearch.com
@@ -27417,8 +28655,10 @@ rwbaird.com
 rwdhosting.ca
 rwjf.org
 rwlasvegas.com
+rwnewyork.com
 rxgroup.uz
 rxliquids.com
+rxo.com
 rxtx.lv
 rychlydrat.cz
 ryder.com
@@ -27448,11 +28688,13 @@ s2grupo.es
 s3.com.co
 s3internet.com.br
 s3partners.com
+s3rdv.com
 s3work.vn
 s500host.com
 s5b.org
 s7.ru
 s810.net
+saa.com
 saartoto.de
 saasnow.com
 saastack.llc
@@ -27494,12 +28736,14 @@ sadadbahrain.com
 sadara.com
 saddle.network
 saddlecrk.com
+sadesa.com
 sadlersfurniture.com
 sadmin.eu
 sae.org
 saeima.lv
 saenger.io
 saescomedical.cam
+saesystems.com
 safaritechinc.com
 safawinet-lb.info
 safecloudbox.com
@@ -27511,15 +28755,19 @@ safegrid.net
 safeguard.com.au
 safelines.com
 safelite.com
+safenet-inc.com
 safenetpr.com
 safercities.com
 safesecurewebmail.com
 safeswisscloud.ch
 safetech.ro
 safetel.ru
+safetyinsurance.com
+safetynational.com
 safetynetaccess.com
 safevalue.pro
 safevictoryda.com
+safewayins.com
 safeweb.com.br
 safozi.com
 safran-helicopter-engines.com
@@ -27530,10 +28778,14 @@ sage.com
 sageevents.co.ke
 sagenetworks.com.br
 sagentia.com
+sagentlending.com
+sagepetroleumgh.com
 sagepub.com
 saguenay.qc.ca
 sahacker-2020.com
+sahara-group.com
 sahara.in
+saharacompute.com
 sahsuvaroglu.com.tr
 sai.co.za
 sai.org.in
@@ -27543,17 +28795,20 @@ saigonctt.com.vn
 saigonnewport.com.vn
 sailpoint.com
 saily.co
+saimunenterprise.com
 sainet.or.jp
 sainetsolution.com
 sainf.ru
 sainsburys.co.uk
 saint.co.za
+saintandrews.net
 saintlukeskc.org
 saipacorp.com
 saipayadak.org
 saisd.net
 saiseikai-hp.chuo.fukuoka.jp
 saiseikai-moriyama.jp
+saisoncard.co.jp
 saisritech.com
 saitro.com
 saiwai-pharmacy.com
@@ -27572,6 +28827,7 @@ sakhminfin.ru
 sakomta.com
 saksky.net.ua
 saktiputramandiri.net.id
+salad.com
 salam.net.id
 salb.co.kr
 salcobrand.cl
@@ -27607,11 +28863,13 @@ samantc.ir
 samaraenergo.ru
 samaritan.org
 samaritanministries.org
+samba.tv
 sambreel.com
 samenea.com
 samentor.com
 samespace.com
 samfundet.no
+samgongustofa.is
 samhealth.org
 saminsnetwork.com
 samlerhuset.no
@@ -27648,15 +28906,18 @@ sandclock.info
 sandclock.vn
 sandelman.ca
 sandeq.id
+sandersonfarms.com
 sandestininvestmentsllc.com
 sandhill.im
 sandhilldealerservices.com
 sandhills.com
 sandlercap.com
 sandoz.com
+sandridge.com
 sandy.or.us
 sandya.net.id
 sandyxsystems.co.uk
+saneago.com.br
 sanecum.de
 sanetmediatech.net
 sanetwork.net
@@ -27664,6 +28925,7 @@ sanfilnetwork.com
 sanfordhealth.org
 sanfordlab.org
 sanganco.ir
+sangfor.com
 sangfor.com.cn
 sanghviinfo.com
 sangregorio.com.ar
@@ -27769,6 +29031,7 @@ satulimanet.id
 satunet.co.id
 saturn-r.ru
 saturn.dev
+sauberf1team.com
 saucelabs.com
 sauceservers.com
 saucontech.com
@@ -27836,6 +29099,7 @@ sbicapsec.com
 sbigeneral.in
 sbimf.com
 sbkservice.com
+sbli.com
 sbline.it
 sblinknetwork.com
 sblnetwork.co.id
@@ -27866,6 +29130,7 @@ scalewithus.com
 scana.com
 scana.com.ua
 scancom.eu
+scancom.net
 scandia.ro
 scanex.ru
 scanhealthplan.com
@@ -27883,10 +29148,13 @@ scb.se
 scc.at
 sccdev.ca
 sccfcu.org
+scclmines.com
+sccmha.org
 sccnetwork.in
 scconline.nl
 sccresa.org
 sccsn.jp
+scctportsaid.com
 sccu.com
 scdgroup.com.vn
 scdplanet.com.ar
@@ -27899,10 +29167,14 @@ scfederal.org
 scgas.com.br
 scgov.net
 schaeffersresearch.com
+schaumburg.com
+schertz.com
 schiedam.nl
+schiedel.de
 schiller.ch
 schlueter-server.de
 schlueter.de
+schluter.com
 schmalz.com
 schmersal.com
 schmitz-werke.com
@@ -27925,6 +29197,7 @@ schoolsfirstfcu.org
 schoolspecialty.com
 schroders.com
 schroeder-bauzentrum.de
+schryvermedical.com
 schubergphilis.com
 schulergroup.com
 schultze-braun.de
@@ -27938,7 +29211,9 @@ sci.co.kr
 scicube.com
 sciencelogic.com
 sciencepark.org.uk
+scienceworld.ca
 sciener.ru
+scientificgames.com
 scientology.org
 scioncontacts.com
 sciondtu.dk
@@ -27995,6 +29270,7 @@ sctv.ru
 sculk.ltd
 scv.in
 scwa.com
+sd76.ab.ca
 sdcc.my
 sdccu.net
 sdconw.com
@@ -28014,6 +29290,7 @@ sdmis.fr
 sdmnet.com.br
 sdnbucks.com
 sdnetinternet.com.br
+sdnetwork.net.bd
 sdnf.org.bd
 sdnnet.ru
 sdnp.org.mw
@@ -28035,9 +29312,11 @@ seabak.net
 seabank.com.vn
 seaboardcorp.com
 seaboardmarine.com
+seabox.com
 seabreeze.az
 seadog007.me
 seagroup.com
+seakr.com
 sean.taipei
 seanet.cl
 seanet.ro
@@ -28056,6 +29335,7 @@ seb.lt
 seb.lv
 seb.se
 sebanetbd.com
+sebrands.com
 sec-well.com
 sec.or.th
 seccomglobal.com
@@ -28090,6 +29370,7 @@ securebits.com.au
 secureco.co
 secured.gg
 securednameservers.info
+securedragon.net
 securedserverspace.com
 securegroup.com
 secureidc.co.kr
@@ -28147,6 +29428,8 @@ seetickets.com
 seeton.pro
 sefa.ch
 sefin.gob.hn
+sefl.com
+seg-social.pt
 segaamerica.com
 segalnet.net
 seguridadea1.com
@@ -28154,6 +29437,7 @@ seguridadon.es
 segurosmultiples.com
 segursat.com
 segye.com
+sei-security.com
 seic.com
 seidor.com
 seidor.es
@@ -28181,10 +29465,12 @@ selectequity.com
 selective.com
 selectmedicalcorp.com
 selectsolutions.co.nz
+selectstaffing.com
 selena.com
 selenium.ao
 selfdefenseclassescypress.com
 selgros.ro
+seligdar.ru
 selinc.com
 semagroup.com.au
 semaphor.dk
@@ -28196,6 +29482,7 @@ semnetwork.net
 semplify.net
 sempraglobal.com
 semrush.com
+semtribe.com
 semuaaplikasi.id
 senac.br
 senado.cl
@@ -28204,6 +29491,7 @@ senat.fr
 senawave.com
 sendclean.email
 sender.net
+sendlane.com
 sendnet.pl
 sendo.vn
 senecasawmill.com
@@ -28215,6 +29503,8 @@ seng.si
 senkronet.com.tr
 sennheiser.com
 sensa.is
+sensata.com
+sensemakers.nl
 sensical.net
 sensio.no
 sensordynamics.com.au
@@ -28236,6 +29526,7 @@ seonet.cz
 seonity.ru
 seoulforeign.org
 seoulmetro.co.kr
+seoulmilk.co.kr
 sep.ir
 sepehrnetiranian.ir
 sepehrpay.com
@@ -28253,8 +29544,10 @@ seraconnect.id
 serasaexperian.com.br
 serayu.id
 serco-na.com
+sercom.com.br
 sercom.net
 serczer.pl
+sereducacional.com
 serenitas.com.au
 seres.es
 seres.fr
@@ -28268,6 +29561,7 @@ sernet.de
 seroweb.xyz
 serroplast.shop
 sertaovirtual.net.br
+sertasimmons.com
 serteca.com.ar
 sertex.eu
 serv.com
@@ -28311,6 +29605,7 @@ servergurus.de
 serverhoangdieu.pro
 serveri.org
 serverjet.io
+serverjuice.com
 serverjumbo.com
 serverking.io
 serverlibya.com
@@ -28337,12 +29632,14 @@ serveur-tech.fr
 serveur.com
 servg.ad.jp
 servg.net
+servibanca.cl
 service-plus-gmbh.de
 service-v.ru
 service.net.ge
 servicebox.ge
 servicecu.org
 servicedcloud.com
+servicelink.com
 servicenetpro.com.br
 servicepipe.ru
 serviceplan.com
@@ -28352,6 +29649,8 @@ servicoopsa.com.ar
 servidor2.net
 servimast-jpm.com
 servimed.com.br
+servinet.net
+servion.com
 servired.net.ar
 servit.de
 servit.net
@@ -28373,6 +29672,7 @@ sestaferia.net
 sestek.com
 sesterce.com
 set.com.mk
+set.gov.py
 set.or.th
 setacom.it
 setaiga.com
@@ -28385,6 +29685,7 @@ seteluc.com
 seti-toreza.com
 seti.by
 setiyadata.com
+setonhome.org
 setplex.com
 setservice.bg
 sevahost.com
@@ -28415,6 +29716,7 @@ sferia.cz
 sferos.com
 sfg.fr
 sfgiants.com
+sfgnetwork.com
 sficorp.com
 sfire.com
 sfires.net
@@ -28437,6 +29739,7 @@ sgholding.org
 sgi.com
 sgic.co.kr
 sgict.gov.sg
+sgix.sg
 sgk-projekt.com.pl
 sgknet.co.id
 sglcarbon.com
@@ -28504,6 +29807,7 @@ shells.com
 shelterinsurance.com
 shenlinhk.com
 shericks-bloodhounds.com
+sheriff.org
 shertelelink.com
 shetab.net
 shetaban.cloud
@@ -28513,6 +29817,7 @@ shibboleet.ltd.uk
 shibpurtechnologycare.com
 shielditsm.com
 shields.com
+shieldsguard.com
 shieldtelecom.net
 shift4.com
 shiftlan.info
@@ -28555,6 +29860,8 @@ shoprite.com
 shoptet.cz
 shopzenpanda.com
 shoreland.com
+shorememorial.org
+shorenstein.com
 shorewest.com
 shoro.kg
 shortstravel.com
@@ -28599,6 +29906,7 @@ siaknetwork.net.id
 siam.org
 siamebu.com
 siampiwat.com
+siamsport.co.th
 siamtrading.com.bd
 siapnetworks.co.id
 siav.it
@@ -28661,6 +29969,7 @@ sify.net
 sig.gov.sb
 sigacred.com.br
 sightcall.com
+sightwireless.ca
 sigiworld.com
 siglabs.com
 siglo.com
@@ -28689,6 +29998,7 @@ signallink.net.br
 signalrestoration.com
 signalx.cloud
 signetics.net
+signetjewelers.com
 signify.co.nz
 signin.com.pk
 signofthewhaleonline.com
@@ -28719,12 +30029,14 @@ silva.cl
 silver-service.com.ua
 silverchip.net
 silvercom.ru
+silverfernfarms.co.nz
 silverforda.store
 silverliningnetworks.com.au
 silvernet.fr
 silvernet.ro
 silverpointcapital.com
 silverspin.com
+silverstarbrands.com
 silversteinproperties.com
 silvertele.com
 silvervinesoftware.com
@@ -28751,6 +30063,7 @@ siminformatica.it
 siminn.dk
 simmit.com.au
 simon.com
+simon.tel
 simonedepaolis.it
 simonmed.com
 simonmosheshvili.com
@@ -28765,6 +30078,7 @@ simplediagnostics.org
 simplehuman.com
 simpleinternet.com.br
 simplepod.ai
+simplesignal.com
 simplesinternet.net.br
 simplethings.de
 simplex39.ru
@@ -28779,18 +30093,21 @@ simsalasim.net
 simset.net
 simtelecomms.com.br
 simwood.com
+sin.net
 sin.tg
 sinacofi.cl
 sinai.org
 sinal.net.br
 sinamonet.tj
 sinap-tix.com
+sinara-group.com
 sinatech.id
 sinavps.ch
 sinch.com
 sincroniza.net.br
 sindebudi.com
 sinemanage.com
+sinenomine.net
 sinergibtb.com
 sinerginet.id
 sinergise.com
@@ -28853,6 +30170,7 @@ sirsolutions.com
 sirti.it
 sis.tv
 siscom.ec
+sisecam.com.tr
 sisense.com
 sisglobalresearch.com
 sislab.ru
@@ -28890,6 +30208,7 @@ sithabile.co.za
 sitibroadband.in
 sitivision.net
 sitmp.cz
+sitrack.com
 sitronics-kt.ru
 sitrox.com
 sits-co.com
@@ -28911,8 +30230,10 @@ siycom.com
 sjccu.com
 sjcfl.us
 sjcschools.org
+sjenergy.com
 sjestyle.com
 sjhsyr.org
+sjta.com
 sk-nic.sk
 sk.ee
 sk.ru
@@ -28923,6 +30244,7 @@ skagit911.us
 skagitregionalhealth.org
 skala.network
 skalbmierz.com
+skan.ch
 skanska.com
 skanska.pl
 skarnetchile.com
@@ -28946,11 +30268,13 @@ skifgroup.com
 skillsys.fr
 skillvps.com
 skinform.ru
+skizzerz.net
 skk.com.pl
 skleporion.net
 sklodowscy.pl
 sklservices.com
 skm.com.ua
+sknix.kn
 sko.kz
 skoda-auto.com
 skoda-auto.de
@@ -28987,9 +30311,11 @@ sky47.com.pk
 skybroadband.com.ph
 skybusiness.com.bd
 skycable.com
+skycity.co.nz
 skycloud.com.tw
 skycloud.com.ua
 skyd.io
+skydance.com
 skydata.pl
 skydns.ru
 skyfinet.com
@@ -29026,6 +30352,7 @@ skynetpe.com.br
 skynetwork.id
 skynetworks.mn
 skynew.com.br
+skynews.com.au
 skyonline.co.in
 skypacket.net
 skypass.tech
@@ -29047,6 +30374,7 @@ skytelecom.com.pk
 skytelecom.gr
 skytelecom.ro
 skytoll.sk
+skytrac.ca
 skyunwired.com
 skyup.cc
 skyv.ai
@@ -29075,10 +30403,12 @@ slc.or.kr
 slc.ut.us
 sle24.de
 sleek.net
+sleepcountry.ca
 sleepnumber.com
 slglasnik.com
 slgreen.com
 slhs.org
+slib.fr
 slideinsurance.com
 slimcd.com
 slink.kiev.ua
@@ -29087,13 +30417,17 @@ slnet.com.br
 slo-zeleznice.si
 sloneczko.net
 slopa.net
+slopesidesoftware.com
 slothnetworks.net
 slowianin.pl
 slren.edu.sl
 sls-angels.com
 slsolucije.hr
 sltelecom.net.br
+slumberland.com
+slush.ca
 slvecc.com
+slvrmc.org
 slyde.dk
 sm-dac.com
 sm-komandor.ru
@@ -29119,6 +30453,7 @@ smartcityhome.net
 smartcloud.co.ke
 smartcloud.uz
 smartcom.bg
+smartconexion.com
 smartct.com
 smartdigitalbd.com
 smartechcorp.net
@@ -29180,6 +30515,7 @@ smcisd.net
 smcomunicaciones.com.ar
 smcp.com
 smcusa.com
+smeco.com
 smela.com.ua
 smestad.tech
 smetsomapp.com
@@ -29187,10 +30523,12 @@ smewell.com
 smexinast.com
 smglincoln.com
 smhi.se
+smhiplus.co.kr
 smi-inc.com
 smi.net.id
 smila.com
 smiledirectclub.com
+smilegatewest.com
 smilesystems.am
 sminex.com
 sminvestments.com
@@ -29205,6 +30543,7 @@ smkn22jakarta.sch.id
 smkn5malang.sch.id
 smktelecom.com
 sml.at
+smlines.com
 smmc.org
 smn.fi
 smn.lv
@@ -29218,6 +30557,7 @@ smpcorp.com
 smpost.ru
 smpraszka.com.pl
 smprime.com
+smrey.com
 smrn.com
 smrtadv.com
 sms-europa.com
@@ -29357,10 +30697,12 @@ softhouse.bg
 softhousenet.com.br
 softinsightpro.com
 softjourn.com
+softline.kiev.ua
 softm.tv
 softman.pl
 softmarketing.com.br
 softnet-telecom.com.br
+softnet.co.tz
 softnet.com.pl
 softnet.eu
 softnetsystems.co.ke
@@ -29368,6 +30710,7 @@ softoria.com
 softpro2.pl
 softserv.net
 softserveinc.com
+softtech.lv
 softtech.nl
 softtek.com
 softvoyage.com
@@ -29379,6 +30722,7 @@ softwarestudio.com.pl
 softway-medical.fr
 softwin.ro
 sofu.co.jp
+sogaz-med.ru
 sogaz.ru
 sogebank.com
 sogei.it
@@ -29434,11 +30778,13 @@ solixoutreach.com
 solkam.ru
 sollers-auto.com
 sollutium.com
+solnetsolutions.co.nz
 solnode.com
 solocal.com
 solone.net
 solonet.net.id
 solordp.com
+solsis.com.my
 solucija.eu
 solucionesmax.com.py
 soluciontv555.com.ve
@@ -29457,6 +30803,7 @@ solutionlan.com
 solutions-informatiques.com
 solutions-sas.com
 solutions.fi
+solutionsbycrystal.com
 solutionsinfini.com
 solutionspal.com
 soluvia-it-services.de
@@ -29484,6 +30831,7 @@ somtelfgc.com
 son.com.so
 sonabel.bf
 sonalilife.com
+sonance.com
 sonangol.co.ao
 sonatrachitalia.it
 soncraft.fr
@@ -29529,6 +30877,7 @@ sot.bg
 sot.pl
 soteng.ao
 soterahealth.com
+soteriacloud.com
 sothebys.com
 sotka.team
 sotline.ru
@@ -29541,6 +30890,7 @@ soundcloud.com
 sounditaly.com
 soundmouse.com
 soundstack.com
+soundtransit.org
 sounetmais.com.br
 sounetway.com.br
 sourcedns.com
@@ -29553,10 +30903,13 @@ southcoast.org
 southcoastmedical.com
 southcoastwebhosting12.com
 southeasternasset.com
+southeastgas.com
 southerncross.solutions
 southerndhb.govt.nz
 southernhill.nl
 southernimperial.com
+southernstates.com
+southernunion.com
 southernwater.co.uk
 southernwine.com
 southfront.io
@@ -29568,11 +30921,13 @@ southsound911.org
 southtechlimited.com
 southtechllc.com
 southwest.com
+southwestdispatch.com
 southwire.com
 souverit.de
 sovacapital.com
 sovcombank.ru
 sovcomflot.ru
+sovereign-sol.com
 sovinformtech.com
 sovos.com
 sowilo.info
@@ -29607,7 +30962,9 @@ spamh.com
 spanning.no
 spar-ics.com
 spar-nn.ru
+spar.co.za
 spar.hu
+sparcs.org
 spark.com.bd
 sparkasse.si
 sparkbusinessmail.co.nz
@@ -29656,6 +31013,7 @@ spectracompany.com
 spectraindia.com
 spectralogic.com
 spectreops.net
+spectrodata.com
 spectrumbrands.com
 spectrumit.ru
 speculations.com
@@ -29695,12 +31053,14 @@ speedtuch.com
 speedwan.com.br
 speedwavz.net
 speedwayctes.com.ar
+speedwaymotorsports.com
 speedy.bg
 speedybrasil.com.br
 speedyfi.in
 speedynet.net.br
 speedynetpr.com
 speedzone.co
+speer.co.za
 spektr-tv.su
 spencerstuart.com
 spenneberg.de
@@ -29730,6 +31090,7 @@ spidernetctg.com
 spidernetworks.com.bd
 spiderrock.net
 spie.com
+spielo.com
 spil.co.id
 spinktel.com.au
 spinoco.com
@@ -29737,6 +31098,7 @@ spire.net
 spireon.com
 spiretel.in
 spiritaero.com
+spiritair.com
 spiritbank.com
 spiritoftasmania.com.au
 spiritualtechnologies.io
@@ -29756,6 +31118,7 @@ spliced.ca
 spliethoff.com
 splinktelecom.com.br
 splio.com
+splis.com
 split-airport.hr
 splunk.com
 spmzt.net
@@ -29768,6 +31131,7 @@ spoe.at
 spokanecity.org
 spokanecounty.org
 spokanetransit.com
+spoontech.biz
 sporada.in
 sporthotelalacati.com
 sportingkc.com
@@ -29778,11 +31142,14 @@ sportmaster.ru
 sportna-loterija.si
 sportpesa.co.tz
 sportpesa.co.za
+sportpesa.com
 sportradar.com
 sports.ru
+sportsdirectinc.com
 sportsgameo.com
 sportsimpressionsonline.com
 sportsmans.com
+sportsmedia.com
 sporttime.net
 spot.net.id
 spot1mobile.com
@@ -29793,16 +31160,20 @@ spotler.nl
 spotless.com.au
 spotrix.com
 spotsylvania.k12.va.us
+spotsylvania.va.us
 spp.org
+spp.sk
 sppx.io
 spray.com
 spreadshirt.de
 sprep.org
+sprhc.org
 sprichards.com
 springbranchisd.com
 springer.com
 springfd.org
 springfieldclinic.com
+springfld.com
 springisd.org
 springo.it
 springs.bg
@@ -29845,6 +31216,7 @@ squarepoint-capital.com
 squarespace.com
 squaretrade.com
 squareup.com
+squarew.net
 squild.de
 squirrellogic.com
 squirrelnet.me
@@ -29879,6 +31251,7 @@ srvif.com
 srz.com
 ss-mobile.com
 ss-solutions.net
+ssangyongcement.co.kr
 ssb-ag.de
 ssc.com.co
 sscinc.com
@@ -29912,6 +31285,7 @@ ssmb.com.au
 ssnet.eu
 ssnetcom.co.in
 ssnetworkbd.com
+ssnit.org.gh
 ssnw.co.kr
 ssonline.com.bd
 ssprnet.net
@@ -29920,6 +31294,7 @@ ssrdi.co.id
 sss.gov.ph
 ssservicios.com.ar
 sssnet.com
+ssspr.com
 ssstpl.in
 sst.ru
 sstinfotech.com
@@ -30062,6 +31437,7 @@ stat.gov.pl
 statbyte.co
 state.la.us
 state.pa.us
+state.ri.us
 state.tx.us
 state.va.us
 state.wi.us
@@ -30083,10 +31459,13 @@ stavropolskiybroiler.com
 stayfriends.de
 staypineapple.com
 stb.com.mk
+stbank.by
 stbbt.mk
 stbernardhospital.com
+stbernards.info
 stc-spb.ru
 stcharleshealthcare.org
+stclair.org
 stcnet.ru
 stcu.org
 stdatos.mx
@@ -30109,6 +31488,7 @@ stef.com
 stefanini.com
 steffann.nl
 stegemeyer.net
+steinbach.at
 steinerstudios.com
 steinkamm.com
 steinweg.com
@@ -30132,6 +31512,7 @@ stephens.com
 stepnet.kz
 stepping-stone.ch
 steppingstonemyanmar.com
+steren.mx
 stericycle.com
 sterikkom.se
 steris.com
@@ -30156,10 +31537,12 @@ sti.sci.eg
 stibarc.com
 stieykpn.ac.id
 stifel.com
+stihl.com.au
 stihl.com.br
 stihl.de
 stihl.hu
 stihlusa.com
+stillwater.com
 stillwell.com.hk
 stime.fr
 stingers.io
@@ -30178,8 +31561,10 @@ stl-bd.net
 stl-u.ru
 stlcitysc.com
 stlghana.com
+stlouismi.com
 stltechpartners.com
 stlucieco.org
+stlzoo.org
 stmboyd.dev
 stmh.org
 stmichaelshospital.com
@@ -30251,6 +31636,7 @@ strac.org
 stradaglobal.com
 stralfors.se
 stralsakerhetsmyndigheten.se
+strandbooks.com
 strasbourg.eu
 stratacache.com
 stratacare.com
@@ -30332,11 +31718,14 @@ stwimst.at
 stwmz.at
 stylenhost.com
 stylsoft.cz
+stypr.network
 styriamedia.tech
 su.com.pk
 suardi.com.ar
 suas.cz
 sub.co
+subaruofnewengland.com
+subconscious.co
 subhodayadigital.in
 subnet.zp.ua
 subnetbd.com
@@ -30345,8 +31734,11 @@ substantile.com
 subterranean-concave.com
 subtopia.co.uk
 suburbanmarine.io
+subway.com
 subzero.com
+successacademies.org
 successenginego.com
+successionsys.com
 sucessonettelecom.com.br
 suchylas.pl
 sucrenet.com.ve
@@ -30356,6 +31748,7 @@ sudikub.com
 sudoblock.io
 sudolio.com
 suds.cz
+suec.de
 suedleasing.de
 suek.ru
 suenco.ru
@@ -30372,6 +31765,7 @@ sukabuminetwork.net
 sukatek.net
 sukmamedia.com
 suksangroup.com
+sukut.com
 sulamerica.com.br
 sulika.net
 sulinknet.com
@@ -30386,6 +31780,8 @@ summa-sci.com
 summerhosting.pl
 summit-rock.com
 summit.oh.us
+summitenergytech.com
+summitortho.com
 summitpolymers.com
 summitracing.com
 summitrad.com
@@ -30401,6 +31797,7 @@ sunbeltrentals.com
 suncast.com
 sunchemical.com
 suncitybiz.net
+suncoastcreditunion.com
 suncoastresources.com
 suncorp.co.nz
 suncorp.com.au
@@ -30435,6 +31832,7 @@ sunrisemedical.com
 suns.com
 sunsuper.com.au
 suntech.pl
+suntory-group.com
 sunucu.com
 sunucucozumleri.com
 sunucumweb.com
@@ -30446,6 +31844,7 @@ super-pharm.co.il
 super.net.id
 super.net.py
 super.org
+super99.com
 superbockgroup.com
 supercable.net.ve
 supercanal.com.ar
@@ -30453,6 +31852,7 @@ supercasino.fr
 supercell.com
 supercepat.net
 superclubs.com
+supercore.org
 supercorridor.co.id
 superdata.vn
 superdnssite.com
@@ -30465,8 +31865,10 @@ supergroup.co.za
 superhosting.rs
 superion.com
 superior-host.com
+superiorambulance.com
 superiorcentral.com
 superiorlivestock.com
+superiorplus.com
 superjob.ru
 superlink.biz.id
 superlink.net.br
@@ -30484,6 +31886,7 @@ superspace.id
 supersport.hr
 supit.org
 supplyframe.com
+supplyhq.com
 supplytechnologies.com
 supportainteractiva.com
 supportcloud.net
@@ -30492,7 +31895,9 @@ supportwebservers.com
 supremegroup.com
 supremepanel24.com
 suquamish.nsn.us
+surabaya-eproc.or.id
 suraloka.com
+suramericana.com.co
 surany.net
 surecomp.com
 surepacelogistics.com
@@ -30527,11 +31932,13 @@ sv-telecom.net
 sva.de
 svarog-distrib.ru
 svartsteinn.is
+svc.co.at
 svcomrs.com.br
 svec.coop
 svenljunga.se
 svenskaspel.se
 sverdlova.ru
+sverdrup.com
 svf.in
 sviaz-stroy.ru
 svisionnetworks.id
@@ -30577,6 +31984,7 @@ swecom.cm
 swedbank.ee
 swedbank.lv
 sweetwater.com
+sweetwatermemorial.com
 swehosting.se
 swensonhomes.com
 sweroam.se
@@ -30590,6 +31998,7 @@ swifttalk.net
 swifttrans.com
 swiftwill.com
 swineson.me
+swirecc.com
 swis.com.pk
 swisher.com
 swiss-net.com.ar
@@ -30607,6 +32016,7 @@ swissnetwork.ch
 swissnetwork.io
 swissneutral.net
 swissns.ch
+swisspro.ch
 swisssign.com
 switch.com.iq
 switch.tv
@@ -30666,10 +32076,12 @@ synburst.com
 syncbroad.com
 synchron.ua
 synchrony.com
+synchronyfinancial.com
 synchrotron.org.au
 syncitbd.com
 syncnet.tech
 synconlinebd.com
+syncreon.com
 syndicate.net.ua
 synechron.com
 synectics-solutions.com
@@ -30720,6 +32132,7 @@ syscomm.co.uk
 syscomp.de
 syscon.biz
 syscxp.com
+sysd.k12.ca.us
 sysdex.ch
 sysdyn.fr
 syselcom.ch
@@ -30792,6 +32205,7 @@ t2.sa
 t2o.es
 t2web.com.br
 t38fax.com
+t3trading.com
 ta-petro.com
 taaltech.com
 taaquinet.com.br
@@ -30800,6 +32214,7 @@ tabaarakhost.org
 tabaccai.it
 tabadul.sa
 tabcorp.com.au
+tablebound.com
 tabletoptel.com
 tablogix.ru
 tabnet.solutions
@@ -30810,6 +32225,7 @@ tachibanaya-morimasa.co.jp
 tacirler.com.tr
 tackitt.us
 tacom.tj
+tacoma.k12.wa.us
 taconiccap.com
 tactica.is
 tadawul.com.sa
@@ -30859,6 +32275,7 @@ talex.pl
 taliya.ir
 talkacloud.com
 talke.com
+talkfusion.com
 talkingplatformsusa.com
 talkiomobile.com
 talleycom.com
@@ -30882,6 +32299,7 @@ tamanet.hu
 tamarawvision.net
 tamcom.ru
 tamedia.ch
+tamilsoft.com
 tamin.ir
 tamiza.es
 tampa.fl.us
@@ -30893,6 +32311,7 @@ tana.ir
 tanaid.net.ua
 tandaa.africa
 tander.ru
+tandg.global
 tandil.gov.ar
 tanesco.co.tz
 tangedconet.org
@@ -30910,6 +32329,7 @@ tanzaniaparks.go.tz
 taosend.com
 tapairportugal.com
 taphip.com
+tapsys.net
 taqniaspace.com.sa
 taquaranet.com.br
 taquari.com
@@ -30972,6 +32392,7 @@ tax.gov.kh
 tax.gov.ma
 tax.gov.ua
 taxaudit.com
+taxbackgroup.com
 taxcom.ru
 taxhawk.com
 taxi-anji.ru
@@ -30994,6 +32415,7 @@ tbank.ru
 tbb.ee
 tbbyrtus.cz
 tbccorp.com
+tbcschools.ca
 tbilisi.gov.ge
 tbits.net
 tbkinternet.net.br
@@ -31001,6 +32423,7 @@ tbm.ru
 tbn.com.bd
 tbnet.com.br
 tbros.net
+tbs-llc.com
 tc.com.au
 tcascorp.com
 tcc.com.ua
@@ -31076,6 +32499,7 @@ teammworktechnology.com.au
 teamnet.de
 teamnet.ro
 teamnorr.se
+teamo.ru
 teamsoftware.ro
 teamsystem.com
 teamveiw.com
@@ -31084,6 +32508,7 @@ teamww.com
 teaspa.it
 teb.si
 tebilisim.com
+tec.govt.nz
 tec6.fr
 teccial.com
 teccloud.com
@@ -31117,9 +32542,11 @@ techies365.com
 techisp.com
 techit.be
 techlabitalia.it
+techland.pl
 techloq.com
 techmedia.pl
 techminds.com.np
+technet-ks.com
 technet-telecom.net.br
 technet.in.ua
 technetcare.com
@@ -31140,6 +32567,7 @@ technobudgroup.com
 technodatasolutions.bj
 technodom.kz
 technofaq.org
+technofuturtic.be
 technog.pro
 technoje.com
 technolabs.co.uk
@@ -31148,6 +32576,7 @@ technologpark.net
 technolux.com
 technomad.net
 technonext.com
+technooptic.com.ua
 technorth.ca
 technosphere.com
 technosuzuta.co.jp
@@ -31157,6 +32586,7 @@ technovaindia.com
 technovm.com
 techogs.net
 techosphere.ng
+techoutfitterusa.com
 techpaperonline.com
 techpay.ge
 techpre.net
@@ -31255,6 +32685,7 @@ teknowledge.com
 teko.com.ni
 teko.vn
 tekoc.ru
+tektera.com
 tekvizion.com
 tekwav.com
 tel-sys.ru
@@ -31392,6 +32823,7 @@ telemaster.net.br
 telemate.net
 telematis.de
 telemedellin.tv
+telemedia-cakra-nusantara.net
 telemedia.co.id
 telemedia.link
 telemedian.pl
@@ -31427,12 +32859,14 @@ teleperformance.co
 teleperformance.com.br
 teleperformance.gr
 teleplus.ro
+telepol.com
 teleport.az
 teleport.media
 teleport.net.pl
 telerakesh.in
 telerealtrillium.com
 telered.es
+telerent.com
 telery.com
 teleset-ufa.ru
 teleset.plus
@@ -31450,6 +32884,7 @@ telestream.net
 teletalk.com.bd
 teletech.com
 teletek.se
+teletelinc.com
 teletimeinc.com
 teletrans.ro
 teletresearch.com
@@ -31483,6 +32918,8 @@ telkomtelstra.co.id
 telkonekt.pl
 tell.net.ua
 tellam.com
+telli.fr
+tellier.ca
 telligen.com
 tellion.pl
 tello.com.au
@@ -31519,10 +32956,12 @@ telxer.com
 temadigi.id
 temaisargentina.com.ar
 tematelecom.ru
+temporarypark.com
 tempworks.com
 temsa.com.tr
 ten.net.pl
 ten.pe
+tenable.com
 tenacit.net
 tenaris.com
 tenaska.com
@@ -31540,6 +32979,7 @@ tenjo.co.id
 tenkids.net
 tennantco.com
 tennantsoftware.com
+tennessee-aquarium.com
 tennet.eu
 tenonet.com
 tenpage.com
@@ -31596,6 +33036,7 @@ terna.it
 ternet.com.ua
 ternium.com.mx
 teron.ro
+terra-net.id
 terra-net.ru
 terra.net.id
 terracon.com
@@ -31610,6 +33051,7 @@ terres.com.br
 terrible.llc
 tersedia.fr
 tersys.ru
+tertius.net.au
 tervisekassa.ee
 tes-media.sk
 tes.com.py
@@ -31650,6 +33092,7 @@ texaco.co.uk
 texascellnet.com
 texaschildrens.org
 texasgs.net
+texaslife.com
 texes.in
 textnow.com
 textplus.com
@@ -31694,18 +33137,22 @@ thaikinghost.com
 thailandpost.com
 thailife.com
 thaimonster.com
+thains.co.th
 thaisuzuki.co.th
 thaitobacco.or.th
 thaivivat.co.th
 thalesgroup.no
 thanachart.co.th
 thanphyothu.com
+tharancogroup.com
 thatescalatedquickly.nl
 thbank.ru
 thcdigitalsolution.com
 thcloud.info
+thda.org
 thdata.vn
 thdtel.com
+the-helm.co
 the-potato.net
 the3.eu
 theaccesspoint.co.uk
@@ -31738,8 +33185,10 @@ thedelusion.co.uk
 thedigitalhub.com
 thedoctorsclinic.com
 thedx.co.uk
+theendlessweb.com
 theeurasia.kz
 thefidelisgroup.net
+thefirehorn.com
 thefool.it
 thegeminicompanies.com
 thegeo.net
@@ -31751,10 +33200,12 @@ thegordiangroup.com
 thehallgang.co.uk
 thehandmaderose.com
 thehelpdeskllc.com
+thehill.org
 thehutgroup.com
 theimaginegroup.com
 theinfrastructure.group
 theinstillery.com
+theinstitutes.org
 theinternetstore.net
 theispco.com
 theitdept.au
@@ -31767,13 +33218,16 @@ thelotterycorporation.com
 themac.com
 themaple.com
 themarketbuilder.com
+themartincompanies.com
 themissinglink.com.au
+themountainpress.com
 thenetworkcloud.com
 thenorthalliance.com
 thenuagegroup.us
 theocc.com
 theori.io
 theos.com.br
+theparkingspot.com
 theping.net
 thepinnaclegroup.in
 theproducers.com
@@ -31790,6 +33244,7 @@ theshootingwarehouse.com
 theskytraders.com
 thesoftking.com
 thestreamingcompany.com
+thestreet.com
 thesunbridge.com
 thetopnet.com.br
 thetradedesk.com
@@ -31825,6 +33280,7 @@ thisiscyberia.com
 thmprovedor.com.br
 thnic.co.th
 thnic.or.th
+thomasgreg.com
 thomasps.com
 thomax.com.au
 thomsonreuters.com.br
@@ -31841,6 +33297,7 @@ threatoff.eu
 threatstop.com
 thredd.com
 three-fourteen.eu
+three6five.com
 threeahub.com
 threembb.co.uk
 threembb.ie
@@ -31862,6 +33319,7 @@ thvps.com
 thyssenkrupp-presta.com
 thyssenkrupp.com
 ti.ru
+tiac.com
 tiagosilvaprovedores.com.br
 tiangbersama.com
 tiangua.com.br
@@ -31875,6 +33333,7 @@ tick-ts.de
 ticketmaster.com.au
 ticketmaster.eu
 ticketnetwork.com
+ticketphiladelphia.net
 ticmate.com
 ticofiber.cr
 ticolinea.com
@@ -31904,6 +33363,7 @@ tig.co.uk
 tiga-pilar.net
 tigamediasolusi.co.id
 tigaz.hu
+tiger.ro
 tigerglobal.com
 tigernet.ru
 tigertechnologysolutions.com.au
@@ -31988,6 +33448,7 @@ tivicom.ru
 tivit.com.br
 tivo.com
 tiwag.at
+tizutech.com
 tjal.jus.br
 tjam.jus.br
 tjap.jus.br
@@ -31997,11 +33458,16 @@ tjdnetwork.com
 tjfholdings.org
 tjgo.jus.br
 tjk.org
+tjma.jus.br
 tjms.jus.br
 tjpa.jus.br
+tjpb.jus.br
 tjpr.jus.br
 tjrj.jus.br
+tjrn.jus.br
+tjro.jus.br
 tjrs.jus.br
+tjsc.jus.br
 tjse.jus.br
 tk-alpha.ru
 tk-chel.ru
@@ -32050,6 +33516,7 @@ tmlp.com
 tmnas.com
 tmndesign.com
 tmoney.co.kr
+tmoneymobility.co.kr
 tmp-system-service.de
 tmsoft.com.br
 tmspl.com
@@ -32218,6 +33685,7 @@ torp.no
 torrancememorial.org
 torreserver.com.br
 torrid.com
+tosa1.org
 tosaf.com
 tosan.com
 tosantechno.com
@@ -32232,6 +33700,7 @@ tosspaynemts.com
 totaal.net
 total-band.com
 totalbr.com
+totalcardinc.com
 totalcom.tel
 totalcomputers.co.uk
 totalconn.com
@@ -32243,6 +33712,7 @@ totalsoft.ro
 totalteam.co.nz
 totalvideo.ru
 totalwebsolutions.com
+totes.com
 totisp.net
 toto.bg
 totonline.net
@@ -32274,12 +33744,14 @@ toyota-europe.com
 toyota-industries.se
 toyota.co.th
 toyota.com
+toyota.com.ar
 toyota.com.au
 toyota.de
 toyota.ro
 toyota.ru
 toyotatr.com
 tp-sis.com
+tp.or.kr
 tpb.com.vn
 tpc-management.ro
 tpcadocs.com
@@ -32289,8 +33761,10 @@ tpchel.ru
 tpcoms.vn
 tpcx.com
 tpg.ch
+tpg.com
 tph.io
 tpicap.com
+tpix.net.tw
 tpl.no
 tplc.com.kh
 tpltrakker.com
@@ -32311,6 +33785,7 @@ tqh.ro
 tql.com
 tqt.com.my
 tr.marketing
+tra.go.tz
 trabonsolutions.com
 trabzon.bel.tr
 trac.africa
@@ -32321,6 +33796,7 @@ trackdata.com
 tracker.co.za
 trackmatic.co.za
 tracmail.com
+tractorinfor.com
 tractorpartsasap.com
 tractorsupplyco.com
 tractum.me
@@ -32354,6 +33830,7 @@ trans-system.com
 trans.eu
 trans.net
 transact.bm
+transactfutures.com
 transalta.com
 transasia.ru
 transat.com
@@ -32388,6 +33865,7 @@ transitcard.ru
 transitchicago.com
 transitnetworks.co.uk
 transitx.net
+transityard.com
 transjakarta.co.id
 transkom-vd.ru
 translink.ca
@@ -32415,15 +33893,19 @@ transunion.com
 transurban.com
 transylvaniacountytennis.com
 tranxactor.com
+trapezegroup.com.au
 trasmediterranea.es
 travelclick.com
+travelex.com.au
 traveleza.com
 travelinc.com
+travelingmailbox.com
 travelit.com.br
 travelport.co.ke
 travelwifi.com
 travenetz.de
 traviaustria.com
+traviscad.org
 traviscu.org
 travsys.com
 traware.com
@@ -32438,6 +33920,7 @@ treasureisland.com
 treasury.co.uk
 treasury.gov.ph
 treasury.govt.nz
+treasurywineestates.com
 treboradice.net
 trec.co.ir
 treelefthot.com
@@ -32477,10 +33960,12 @@ trezor.gov.rs
 trf1.jus.br
 trf3.jus.br
 trf4.jus.br
+trf5.jus.br
 tri-countyfence.com
 tri-delta.com
 tri.co.id
 tri7solutions.com
+triacom.ua
 trialcard.com
 trianglenetworks.co.uk
 triangulodecontrol.com
@@ -32508,6 +33993,7 @@ trikamedia.net.id
 triko.co.nz
 trilegiant.com
 trilliumit.com
+trimafa.net.id
 trimarkassoc.com
 trimax.in
 trimble.co.nz
@@ -32525,6 +34011,7 @@ trinity.net.id
 trinitybpm.com
 trinitycyber.com
 trinitygroup.ru
+trinityhealthmichigan.org
 trinitytechnologies.tech
 trinitythai.com
 triolab.io
@@ -32564,6 +34051,7 @@ troncal.net
 tronox.com
 tropical.com
 tropicsolutions.net
+troutman.com
 troweprice.com
 troy.k12.oh.us
 troycorp.com
@@ -32573,9 +34061,11 @@ trs.is
 trt11.jus.br
 trt12.jus.br
 trt13.jus.br
+trt14.jus.br
 trt15.jus.br
 trt16.jus.br
 trt2.jus.br
+trt20.jus.br
 trt21.jus.br
 trt22.jus.br
 trt23.jus.br
@@ -32584,6 +34074,8 @@ trt3.jus.br
 trt4.jus.br
 trt5.jus.br
 trt7.jus.br
+trt9.jus.br
+trtes.jus.br
 trtworld.com
 truckscontrol.com.br
 trucksvostok.ru
@@ -32619,8 +34111,10 @@ trustica.net
 trustinfo.fr
 trustinfo.ru
 trustmarkbenefits.com
+trustmarkins.com
 trustmotors.ro
 trustnetmedia.id
+trustonasset.com
 trustpointintl.com
 trustteam.lu
 trustwave.com
@@ -32648,10 +34142,12 @@ tsetmc.com
 tsfy.ie
 tsgid.com
 tsgn.com.my
+tsgsolutions.com
 tsi.ru
 tsimagine.com
 tsiplc.com
 tsis.co.kr
+tsisemi.com
 tskb.com.tr
 tskgv.org.tr
 tsm.tarnobrzeg.pl
@@ -32682,10 +34178,12 @@ tsyseurope.com
 tt-lobnya.ru
 tt.in.ua
 ttc.ca
+ttc.com
 ttc.net.ua
 ttc.ru
 ttcldata.net
 ttcomm.net
+ttdepot.com
 ttech.com.au
 tten.net
 ttheatexchanger.com
@@ -32700,6 +34198,7 @@ ttpcloudgroup.co.uk
 tts.ro
 ttspl.in
 ttsystems.com
+ttt.co.th
 tttech-auto.com
 ttx.com
 tty.sh
@@ -32733,6 +34232,8 @@ tullettprebon.com.br
 tullostrucking.com
 tullowoil.com
 tulsacounty.org
+tulsalibrary.org
+tumblr.com
 tumm.co.cr
 tunasmediadata.id
 tundradns.com
@@ -32765,6 +34266,7 @@ turbonetwifi.net.br
 turboonline.com.br
 turbosportis.store
 turbotech.com
+turbotechnologies.co
 turbotelecom.com.br
 turiba.lv
 turien.nl
@@ -32783,11 +34285,14 @@ turner-industries.com
 turnersautogroup.co.nz
 turnitin.com
 turnium.com
+turnkeysol.com
 turnstone.net.nz
 turtle.net
 turtlerockstudios.com
 tus.net.id
 tuscaloosacityschools.com
+tuscano.com
+tuscco.com
 tuscolaisd.org
 tut.by
 tuta.io
@@ -32818,6 +34323,7 @@ tv7.fi
 tv9.mn
 tv9.net.ua
 tvazteca.com
+tvc-ip.com
 tvc.com.ua
 tvc.org
 tvc.ru
@@ -32834,6 +34340,7 @@ tveps.net
 tverreg.ru
 tvetcdacc.go.ke
 tvfactory.ch
+tvg.com
 tvh.com
 tvha.co.uk
 tvigle.ru
@@ -32844,6 +34351,7 @@ tvk.wielun.pl
 tvkg.net
 tvkompass.de
 tvkslupsk.pl
+tvmasters.tv
 tvmpskov.ru
 tvn.cl
 tvninternet.com.br
@@ -32852,6 +34360,7 @@ tvoetv.net
 tvofiber.com.ar
 tvr.ro
 tvsecure.com
+tvsi.com.vn
 tvstart.ru
 tvsz.ru
 tvt.by
@@ -32859,6 +34368,7 @@ tvt.ne.jp
 tvtc.gov.sa
 tvtk.su
 tvtom.pl
+tvw.org
 tvweb.at
 tvzvezda.ru
 tw.waw.pl
@@ -32889,6 +34399,7 @@ twr.name
 tws.de
 twsnetworks.com
 twz.moe
+txfb-ins.com
 txlogistik.eu
 txodds.net
 txw-taishin.com
@@ -32912,6 +34423,7 @@ tyson.com
 tyumbit.ru
 tzee.pk
 tzmo-global.com
+tznic.or.tz
 tzuchi.org
 u-blox.com
 u-ikoi.co.jp
@@ -32919,6 +34431,7 @@ u-kk.ru
 u-net.co
 u-net.com.ua
 u-team.by
+u1h.com
 u5u5.com
 ua.energy
 uacity.net
@@ -32930,6 +34443,8 @@ uainet.net
 uaio.com.br
 uaiturbo.com.br
 uajy.ac.id
+uam.edu.co
+uamtcorp.com
 uania.com
 uaq.mx
 uaschools.org
@@ -32943,6 +34458,7 @@ ubaya.ac.id
 ubb-pensions.bg
 ubb.ac.id
 ubbcluj.ro
+uberduck.net
 uberfreight.com
 ubicarme.com
 ubicentrex.fr
@@ -32969,6 +34485,7 @@ uc.ac.id
 uc.se
 ucacue.edu.ec
 ucad.edu.sn
+ucaqld.com.au
 ucare.org
 ucayali.net
 ucb.com
@@ -32976,7 +34493,9 @@ ucc.com.ua
 ucci.org.ua
 uccsda.org
 uccu.com
+uchealth.org
 ucit.com.au
+ucm.cl
 ucn.org.hk
 ucndns.in
 ucnts.com.au
@@ -32989,6 +34508,7 @@ ucsystems.nl
 ucv.ro
 udaan.com
 udasha.com
+udb.edu.sv
 udcom.ru
 udenar.edu.co
 udesc.br
@@ -33030,12 +34550,14 @@ uglich-net.ru
 ugm.ac.id
 ugo.games
 ugok.com.ua
+ugrevenue.com
 ugrus.com
 ugsk.ru
 ugsworld.com
 ugt.ge
 ugtelecom.info
 ugtelset.ru
+ugv.com.ua
 uhamka.ac.id
 uhaul.com
 uhc.com.pl
@@ -33070,6 +34592,7 @@ uint8.co
 uir.ac.id
 uis.edu.co
 uiscom.ru
+uitglobal.com
 uiyum.com
 ujezd.net
 uk.com
@@ -33103,6 +34626,7 @@ ulatina.cr
 ulc.gov.pl
 ulcm.ru
 ulf.com.ua
+ulfoods.com
 ulic.com.cn
 uline.com
 uline.com.ua
@@ -33156,6 +34680,7 @@ umail.uz
 umb.ch
 umbracorp.io
 umbrellar.nz
+umbt.ca
 umc.com.ua
 umdaschgroup.com
 umeaenergi.se
@@ -33177,6 +34702,7 @@ ummetro.ac.id
 ummgl.ac.id
 umn.ac.id
 umng.edu.co
+umojo.com
 umoya.net
 ump.ac.id
 umpo.ac.id
@@ -33184,6 +34710,7 @@ umradom.pl
 ums.ac.id
 umsida.ac.id
 umsn.ru
+umtec.com
 umwd.pl
 umww.pl
 umy.ac.id
@@ -33224,6 +34751,7 @@ unext.jp
 unfcu.com
 unfi.com
 ung.ac.id
+unga.com
 ungage.net
 ungs.edu.ar
 unhas.ac.id
@@ -33237,6 +34765,7 @@ uni-tel.dk
 uni-web.ru
 uni.net.th
 uni.rest
+uniacc.cl
 unian.info
 uniasselvi.com.br
 unib.ac.id
@@ -33253,6 +34782,7 @@ unicasttech.com
 unicc.org
 unicef.org
 unicen.edu.ar
+uniceub.br
 unicomamericas.com
 unicomms.com.my
 unicomnz.com
@@ -33271,10 +34801,12 @@ unidasnet.com.br
 unido.org
 uniedgenet.com
 unifarm.it
+unifi-inc.com
 unified.services
 unifiedcore.net
 unifiedpost.com
 unifiedregistration-2026.com
+unifocus.com
 unifon.no
 unifree.com.tr
 unifyfcu.com
@@ -33328,6 +34860,7 @@ unipaknile.com
 unipart.com
 unipetrol.cz
 unipharm.com
+unipiloto.edu.co
 uniplan.it
 unipma.ac.id
 uniprime.com.br
@@ -33402,6 +34935,7 @@ universalinsuranceholdings.com
 universalleaf.com
 universalna.com
 universalorlando.com
+universalpr.com
 universalserviceswi.com
 universalwifi.co.bw
 universeaction.com
@@ -33489,6 +35023,7 @@ uoradea.ro
 uos.net.ua
 uos.ua
 up-hub.com
+up-ng.com
 up.lol
 upaz.net.id
 upbrasil.com
@@ -33529,6 +35064,7 @@ upstateniagara.com
 upstreamconnect.co.za
 upsystems.ru
 uptel.eu
+uptodate.com
 uptownmoose.com
 upu.int
 upx.com
@@ -33556,6 +35092,7 @@ urbn.com
 urc.com.ph
 urens.net
 urgentcargus.ro
+urgentit.eu
 uri.com
 url.net.au
 uropamx.icu
@@ -33573,6 +35110,7 @@ usablechat.com
 usablelife.com
 usabroad.net
 usac.edu.gt
+usac.org
 usacanadaregion.org
 usai.net
 usamv.ro
@@ -33581,11 +35119,13 @@ usana.com
 usaperform.com
 usatv1.net
 usautoparts.net
+uschamber.com
 usclaro.com
 uscm.net.br
 uscoldstorage.com
 uscsd.k12.pa.us
 usd.ac.id
+usd244ks.org
 usdigital.com
 usegroup.com
 usenetexpress.com
@@ -33617,6 +35157,7 @@ usmf.md
 usnews.com
 uspa.gov.ua
 uspeh-home.net
+uspi.com
 usradiology.com
 usrenalcare.com
 uss.gov.ua
@@ -33696,6 +35237,7 @@ v-tservices.com
 v100.com.br
 v2.pw
 v2cloud.com
+v2networks.cl
 v2secure.vn
 v4dns.net
 v4voip.com
@@ -33704,6 +35246,7 @@ v6market.com
 v6only.net
 vaalnetworking.co.za
 vaartfiber.nl
+vacationexpress.com
 vacbl.net
 vacu.org
 vadavo.com
@@ -33741,6 +35284,7 @@ valleinternet.cl
 vallenet.cl
 vallenet.com.ar
 valleyapothecary.com
+valleycrest.com
 valleymetro.org
 valleywater.org
 valli.com
@@ -33761,6 +35305,7 @@ valuelabs.com
 valuelabs.net
 valuepro.com.au
 valueserver.com.br
+valuevillage.com
 valvenetworks.com.au
 valvera.cz
 vamnet.com.ua
@@ -33831,10 +35376,12 @@ vbabich.net
 vbcploo.com
 vbgov.com
 vbiz.pl
+vbl.com.vn
 vbleasing.pl
 vbnservices.com
 vbridge.co.nz
 vbschools.com
+vbse.com
 vcareconnect.nl
 vcbs.com.vn
 vccorp.vn
@@ -33859,18 +35406,21 @@ vdsplus.ru
 vdsstore.com
 vdstelecom.com.br
 veay.de
+vecima.com
 vecloud.com
 vectant.ne.jp
 vector.com
 vector.com.pl
 vectorama.info
 vectordatasystems.com
+vectorsecurity.com
 vectortel.ru
 vectorworks.net
 vectren.com
 vectron-systems.com
 vedaadvantage.com.au
 vedekon.ua
+vedp.org
 veeam.com
 veeco.com
 veenet.africa
@@ -33881,6 +35431,7 @@ vega.com.vn
 vegagerdin.is
 vegas.com
 vegaua.net
+vegetablegroup.com
 veho.ee
 vei.ru
 veiligheidsregio-rr.nl
@@ -33920,13 +35471,17 @@ veloxzone.com.br
 veloznet.net
 velpharm.ru
 velti.ai
+veltio.com
 veltrade.ru
 veltranoplc.shop
 vemdigital.com.br
 vemserflash.com.br
 venable.com
 venadovision.com.ar
+venafi.com
+venango.pa.us
 venbest.com.ua
+venceremos.com.ve
 vendimetry.com
 vendio.ro
 venigo.fr
@@ -33934,6 +35489,7 @@ venis.it
 venite.com.gt
 venn.com
 vennet.co.ke
+vensites.com
 venta.lv
 ventivtech.com
 ventspils.lv
@@ -33946,6 +35502,7 @@ veolia.com
 veoliaes.com.au
 veone.net
 verabradley.com
+veracel.com.br
 veracitynetworks.com
 verasel.com
 verbund-rkh.de
@@ -33961,6 +35518,7 @@ vergecloud.com
 vergetel.com
 vergetelgroup.com
 vergetelnetworks.com
+verible.com.tr
 veridiancu.org
 verifier.co.za
 verifone.com
@@ -33994,6 +35552,7 @@ versabilisim.com
 versantpower.com
 verscend.com
 verscore.net
+versoaltima.com
 versonetworks.net
 vertafore.com
 vertebratus.com
@@ -34002,6 +35561,7 @@ vertexinc.com
 vertexlink.org
 vertical-horizon.net
 vertical.de
+vertitechit.com
 vertiv.com
 vertivco.com
 vertom.nl
@@ -34065,6 +35625,7 @@ viainfo.net
 viaip.ru
 vialink.com.br
 vialink.fr
+vialinkteknologidigital.id
 vialinktelecom.com.br
 viamat.com
 viamediatv.com
@@ -34105,6 +35666,7 @@ victrack.com.au
 vicusluxlink.net
 vid.dn.ua
 vid.gov.lv
+vida.id
 vidanet.com.ve
 viddy.net
 videas.com
@@ -34126,6 +35688,7 @@ vidnoe.net
 viel.com
 viennaairport.com
 viennalife.com.tr
+viesgo.com
 vietinbank.vn
 vietlott.vn
 vietnamairlines.com
@@ -34134,6 +35697,7 @@ vietnamnet.vn
 vietnix.com.vn
 vietpn.com
 vietservice.vn
+vietv.com
 viewbankrise.net.au
 viewpoint.ro
 viewsat.eu
@@ -34153,6 +35717,7 @@ vikingoffice.eu
 vikings.net
 vikmaster.ru
 vikom.com.pl
+vikomtel.ru
 vikpg.me
 vikter.kiev.ua
 vilaconecta.com.br
@@ -34190,6 +35755,7 @@ vinci-construction.com
 vinci.com
 vincitgroup.com
 vincotech.com
+vineland.org
 vinet.hu
 vineyardcolumbus.org
 vingn.com
@@ -34237,6 +35803,7 @@ virtaragroup.com.tr
 virtbase.com
 virtion.de
 virtis.cz
+virtnet.bond
 virtnet.de
 virtone.nl
 virtu.com
@@ -34260,6 +35827,7 @@ virtuasol.com
 virtuasys.us
 virtuozzo.com
 virtusa.com
+virutexilko.cl
 visa.co.uk
 visalia.ca.us
 visaops.net
@@ -34293,6 +35861,8 @@ visperad.com
 vista-technology.kz
 vista.co
 vista.gov.vn
+vistaar.com
+vistana.com
 vistaonline.net
 vistaradiology.com
 visteon.com
@@ -34309,6 +35879,7 @@ visualviet.com
 viszontelado-tarhely.hu
 vit-net.ru
 vitabank.ru
+vitac.com
 vitaexpress.ru
 vital.co.nz
 vitalativ.com
@@ -34316,6 +35887,7 @@ vitalbanet.it
 vitalgamenetwork.com
 vitalplaynet.com.br
 vitamin.com.ua
+vitamix.com
 vitec-memorix.com
 vitec.se
 vitens.nl
@@ -34426,6 +35998,7 @@ voatelecom.com.br
 voban.rs
 vocalink.com
 vocampo.com.ar
+vocinity.com
 vocphone.com
 voda.hr
 vodacombusiness.co.za
@@ -34444,6 +36017,7 @@ voicenter.com
 voiceprintdata.com.au
 voidptr.de
 voigtie.com
+voinetworksolutions.com
 voitic.com
 voitress.com
 voixnetworks.net
@@ -34456,7 +36030,9 @@ volganet.ru
 volgaspot.ru
 volhov.ru
 volkhov.online
+volkswagen.com.ar
 volkswohl-bund.de
+volma.ru
 volo.global
 volsnet.com
 volta-medical.com
@@ -34465,6 +36041,8 @@ voltaire.com
 voltar.net.pl
 volthosting.co.uk
 voltnet.us
+voltpage.com
+voltras.co.id
 voltzznode.com
 volumedrive.com
 volus.tn
@@ -34478,7 +36056,9 @@ vonettech.net.kh
 vonline.pro
 vonline.vn
 vonthadden.it
+vor.at
 vortechhosting.com
+vortexok.net
 vortexoptics.com
 vortia.com
 vorys.com
@@ -34495,6 +36075,7 @@ voxel.pl
 voxihost.pl
 voximplant.com
 voxlan.com
+voxline.com.br
 voxlink.id
 voxnet.com.tr
 voxologycarrier.com
@@ -34512,6 +36093,7 @@ vpbanks.com.vn
 vpbs.com.vn
 vpcit.ru
 vpeipics.com
+vpi-minsk.by
 vpktelecom.ru
 vpmnetworks.com
 vpn-naruzhu.website
@@ -34525,6 +36107,7 @@ vpspay.cloud
 vpsplayer.com
 vpsus.org
 vpsvault.host
+vraa.gov.lv
 vrangel.ru
 vrata.net
 vrdweb.in
@@ -34541,9 +36124,11 @@ vsi.ru
 vsix.fr
 vsk.ru
 vslink.com.br
+vsmedia.com
 vsmpo.ru
 vsoft.net
 vsoft.pl
+vsp.com
 vspace.pl
 vss-63.ru
 vss.gov.vn
@@ -34575,6 +36160,7 @@ vub.lt
 vubiquity.com
 vuela.bo
 vulcan.com
+vulcanarequipa.com
 vulcanmaterials.com
 vulterdi.edu
 vultris.cloud
@@ -34625,12 +36211,15 @@ w1o.com
 w2i.com.br
 w3networks.com.au
 w3tel.com
+waa.ca
+wabag.com
 wabcominternet.com
 wabtec.com
 wacker.com
 wacminus.com
 wacren.net
 waddellsolutions.com
+wadidegla.com
 waechter.eu
 waenre.com
 wagela.com
@@ -34644,6 +36233,7 @@ waiptelecom.com.br
 waitkeys.com
 waka-pro.ga
 wakayama.lg.jp
+wakemed.org
 waldeit.de
 waldwasser.eu
 walesi.com.fj
@@ -34654,9 +36244,12 @@ walix.co
 walkover.in
 walks.cloud
 walla.co.il
+wallacehardware.com
 wallcloud.eu
+walleyesoftware.com
 wallix.com
 wallstreetsgossip.com
+wallstreetsystems.com
 walltopia.com
 walmart.cn
 walmart.com
@@ -34667,6 +36260,7 @@ walsworth.com
 waltonbd.com
 wam.com.pl
 wamego.net
+wan2.link
 wan4u.co.za
 wan55.co.jp
 wanagain.net
@@ -34703,6 +36297,7 @@ warnet.cz
 warp.co.nz
 warpiris.com
 warpnet.xyz
+warrenaverett.com
 warriorhill.com
 warriorofzen.life
 warta.pl
@@ -34711,6 +36306,7 @@ warterfuels.pl
 wasabi.com
 waser.ch
 washington.or.us
+washington.pa.us
 washington.wi.us
 washingtoncompanies.com
 washoetribe.us
@@ -34734,7 +36330,9 @@ watermark-llc.com
 waternsw.com.au
 waters.com
 watershed.co.uk
+waterstonemortgage.com
 waterstons.com
+watsonville.ca.us
 watts.com
 waupacafoundry.com
 wausausupply.com
@@ -34782,6 +36380,10 @@ wca.com
 wcap.ca
 wcb.ab.ca
 wcb.com.ph
+wcb.mb.ca
+wcc.mb.ca
+wccls.org
+wcitv.com
 wciu.com
 wcktelecom.com.br
 wcloud.ro
@@ -34801,6 +36403,7 @@ wdbj7.com
 wdc.com
 wdepo.ru
 wdhb.org.nz
+wdhospital.com
 wdjt.cc
 wdmab.se
 wds.co.id
@@ -34814,12 +36417,14 @@ wealthbuildexperts.com
 wealthexpertisepro.com
 wealthfront.com
 weare.ie
+wearelifeline.com
 wearephaedon.com
 weareplanet.com
 wearepop.com
 wearetriple.com
 weareway.ru
 weather.com
+weathercity.com
 weatherford.com
 weathergroup.com
 weathernews.com
@@ -34867,6 +36472,7 @@ webhostingserver.nl
 webhostpulse.com
 webhs.pt
 webhuset.no
+webideh.com
 webiffi.com
 webifibra.com.br
 webigna.com
@@ -34932,6 +36538,7 @@ wedeploy.pl
 wee-technology.com
 weebly.com
 weebo.co.in
+weehooey.com
 weelax.fr
 weglokoks.com.pl
 wegmans.com
@@ -34943,6 +36550,7 @@ weilerabrasives.com
 weiligmann.net
 weingut-hans-lang.com
 weirdsneakers.de
+weiscapital.com
 weiss-druck.de
 weissman.net
 weitzlux.com
@@ -34950,6 +36558,8 @@ wekkitech.net
 welcome-as.pl
 welcomepayments.co.kr
 welcomnet.fi
+weldedtube.com
+wellington.ca
 wellingtonairport.co.nz
 welllivinghive.com
 wellmark.com
@@ -34963,6 +36573,7 @@ wellsenterprisesinc.com
 wellsky.com
 welltelgroup.com
 weloverta.org
+wem.ca
 wemed.com
 wendys.com
 wenetworksrl.it
@@ -34987,11 +36598,14 @@ westada.org
 westat.com
 westbaybeach.net
 westbrom.co.uk
+westchesterlibraries.org
 westdevllc.com
+wested.org
 westel.net
 western.af
 westernasset.com
 westerncarriers.com
+westerndental.com
 westerndigital.com
 westernpower.com.au
 westernsouthern.com
@@ -35022,6 +36636,7 @@ westparkcom.com
 westpoint.es
 westrockcoffee.com
 westsidelenses.info
+westvancouver.ca
 westwing.de
 westwoodone.com
 wetafx.co.nz
@@ -35043,8 +36658,11 @@ wfp.org
 wfscorp.com
 wfsd.k12.ny.us
 wgbh.org
+wgh.on.ca
+wghealth.org
 wginfor.com.br
 wgix.net
+wgt.com
 wh.org.au
 wh2a.com
 whakatane.govt.nz
@@ -35052,9 +36670,11 @@ whalebone.io
 whatevermobile.com
 whatif.be
 whatstools.com
+whcc.com
 whdh.com
 whdot.com
 whe.org
+wheaton.il.us
 wheehost.com
 wheelch.me
 wheelercat.com
@@ -35064,6 +36684,7 @@ whgi.net
 whimsicalsoles.com
 whistlerblackcomb.com
 whitbread.com
+white-wilson.com
 white2net.com
 whitebilisim.com
 whitecap.com
@@ -35094,6 +36715,7 @@ whpservers.com
 whro.net
 whserv.de
 whsesystems.com
+whtrading.com
 whygroup.it
 wi-connect.nl
 wi-go.eu
@@ -35151,6 +36773,7 @@ wil.com
 wil.waw.pl
 wilamarta.com
 wiland.info
+wild.com
 wild.engineering
 wildcard.it
 wilderwind.com.au
@@ -35177,6 +36800,7 @@ willinn.io
 willis.com
 willkie.com
 willnet.com.do
+willscot.com
 willsit.jp
 willux.be
 wilmschen.net
@@ -35184,8 +36808,10 @@ wilo.com
 wilogic.com
 wilohosting.com
 wilroffreitsma.nl
+wilson.com
 wilsonart.com
 wilsonparking.com.au
+wilsontool.com
 wilxite.com
 wima.ac.id
 wimas-srl.com
@@ -35200,6 +36826,8 @@ win-networks.com
 win.ch
 winamax.fr
 winartha.net.id
+winc.com.au
+wincofoods.com
 windcave.com
 windcloud.de
 winde.jp
@@ -35212,6 +36840,7 @@ windwire.net
 windwireless.net
 windyghoul.cz
 winempresas.pe
+winepos.com
 winet.co
 winet.co.in
 winet.com.ua
@@ -35289,10 +36918,12 @@ wiseinfotec.net
 wisekey.com
 wisen.co.kr
 wisepaq.com
+wisers.com
 wisesa-consulting.com
 wisetechglobal.com
 wisewealthcircle.com
 wishnet.it
+wishvps.com
 wisk.aero
 wismilak.com
 wisniowski.pl
@@ -35305,6 +36936,7 @@ wistel.co.id
 wistron.com
 wisvis.com
 wit.com
+wit.one
 witbe.net
 witham.org
 withersworldwide.com
@@ -35312,6 +36944,7 @@ withsystems.co.kr
 withtel.com.au
 witine.com
 witopia.net
+witron.de
 wittenberg-net.de
 witzenmann.de
 wiu7.org
@@ -35348,9 +36981,11 @@ wm.partners
 wmata.com
 wmax.cl
 wmbrasil.net
+wmcnt.pl
 wmeagency.com
 wmg.com
 wmgruppe.de
+wmi.com
 wmi.net.id
 wmnet.cl
 wnbhosting.dk
@@ -35367,11 +37002,13 @@ wodeniowa.com
 wody.gov.pl
 wodzislaw-slaski.pl
 wofbit.africa
+woisd.net
 wolff-mueller.de
 wolfined.com
 wolford.com
 wolfsec.com
 wolfxun.com
+wolkit.mx
 wolseley.co.uk
 wolverineworldwide.com
 wonderful.com
@@ -35397,9 +37034,11 @@ wordandbrown.com
 wordnet.com.br
 wordpresshosting.xyz
 workbetter.bg
+workcover.com
 workforcesoftware.com
 workoutchronic.com
 workplaceoptions.co.uk
+worksimple.de
 worktual.net
 world-ict.nl
 worldbus.ge
@@ -35419,6 +37058,7 @@ worldsportsbetting.co.za
 worldstrides.com
 worldvision.org
 worley.com
+worley.org.au
 wortel.co.id
 worthington.k12.oh.us
 worthingtonsteel.com
@@ -35439,6 +37079,7 @@ wpmsoftware.com
 wpnp.net
 wpp.com
 wppaunz.com
+wppisys.org
 wppmedia.com
 wpr.pl
 wpsci.com
@@ -35447,13 +37088,16 @@ wptech.co.id
 wptecnologia.com.br
 wpweb.com
 wrberkley.com
+wrec.coop
 wrenkitchens.com
+wrginsurance.com
 wrike.com
 wrist.com
 writerinformation.com
 wrix.org
 wrkpod.com
 wrlc.org
+wrlsweb.org
 wrnet.com.br
 wroclaw.sa.gov.pl
 wroclawskaedukacja.pl
@@ -35473,6 +37117,7 @@ wspfibra.com.br
 wsplink.net.id
 wsr.ac.at
 wsscwater.com
+wsse.rzeszow.pl
 wsu.com.br
 wswheboces.org
 wszz.torun.pl
@@ -35496,6 +37141,7 @@ wwe.com
 wwk.de
 wwn.net.br
 wwnet.com.br
+wwpass.com
 wwt.com
 wwwcom.ru
 wx1.de
@@ -35510,6 +37156,7 @@ wyrisnetworks.com
 wyyerd.us
 wz-kliniken.de
 wzinit.com
+wzp.pl
 x-cellent.com
 x-com.ua
 x-kom.pl
@@ -35549,6 +37196,7 @@ xecureit.id
 xecuro.de
 xefi.com
 xelion.pl
+xella.com
 xelocuto.ru
 xen1net.net
 xenia-systems.de
@@ -35593,6 +37241,7 @@ xlinkasia.com
 xlinkbd.net
 xlnet.cz
 xlpm.nc
+xlrynt.com
 xls.co.nz
 xlsrl.it
 xmradio.com
@@ -35697,6 +37346,7 @@ yamalsoft.ru
 yamatoamerica.com
 yamu.com
 yanao.ru
+yanceybros.com
 yancoal.com.au
 yandex.com.tr
 yandex.kz
@@ -35713,6 +37363,7 @@ yarurf.ru
 yarvolna.net
 yashtel.in
 yato.com
+yatra.com
 yavapai.us
 yavir2000.com
 ybp.com
@@ -35725,6 +37376,7 @@ yelles.se
 yellogynyfo.com
 yellowpage-advertising.com
 yelp.com
+yensiwireless.com
 yeoandyeo.com
 yepnet.com.br
 yesbank.in
@@ -35763,6 +37415,7 @@ yna.co.kr
 ynet.co.in
 ynet.pl
 yoafrica.com
+yoancorp.net
 yodlee.com
 yomastrategic.com
 yomura.com
@@ -35796,14 +37449,17 @@ yourfinanceforesight.com
 yourhousinggroup.co.uk
 yourinvestworkbook.com
 yourmsp.com.au
+yournet.am
 yournet24.com
 yoursmartbusinessplan.com
 yousof.com
 youthidc.com
 yovil.net
 yovole.com
+ypf.com
 ypmn.ru
 ypok.com
+ypprint.com
 ypsilon.net
 yrc.com
 yrdsb.ca
@@ -35821,6 +37477,7 @@ yuboto.com
 yuccahosting.com
 yuetau.net
 yugmob.ru
+yuhan.co.kr
 yuki.net.uk
 yukon.ca
 yukotel.com.ua
@@ -35843,10 +37500,13 @@ yusys.com.cn
 yutopia.or.jp
 yuusei.io
 yuutel.at
+yuzhno-sakh.ru
 yvfwc.com
+yvmc.org
 yvmh.org
 yvr.ca
 ywmc.or.kr
+yyc.com
 yycix.ca
 z-cert.nl
 z-it.net
@@ -35875,12 +37535,14 @@ zaifcomp.in
 zaigover.com
 zainagroup.ltd
 zaintech.com
+zaitoontech.com
 zakathouse.org.kw
 zakaty.gov.sa
 zaknetworks.com
 zalando.de
 zalaszam.hu
 zaltel.it
+zam.pl
 zambiliz.id
 zamkov.ru
 zamosc.pl
@@ -35894,6 +37556,7 @@ zapnet.pl
 zaporizhstal.com
 zapp.com
 zapping.com
+zappos.com
 zaptech.co.tz
 zarclear.com
 zari.com.pl
@@ -35905,6 +37568,7 @@ zarzew.net
 zav-sava.si
 zaz.zp.ua
 zazzinternet.com
+zbi.com
 zbs.cloud
 zcenter.pl
 zcn-c7c7app.com
@@ -35970,6 +37634,7 @@ zeronetech.in
 zerooutages.com
 zeroplex.nl
 zeropointnetworks.com
+zeroservices.eu
 zeroshell.in
 zerospace.cloud
 zerowebhosting.net
@@ -35995,6 +37660,8 @@ zeuss.id
 zextel.ru
 zeyond.com
 zfort.com
+zfsrent.net
+zfx.com
 zg.ch
 zg.pl
 zgato.dev
@@ -36042,6 +37709,7 @@ zivim.hr
 zki.net.id
 zkillu.fr
 zkv.xyz
+zl.lv
 zline.at
 zlinnet.cz
 zmaximum.ru
@@ -36093,6 +37761,7 @@ zpue.pl
 zra.org.zm
 zrf-saar.de
 zrix.com
+zsassociates.com
 zsr.sk
 zss.co.zw
 zssk-nv.ru


### PR DESCRIPTION
## Summary

The final cleanup batch — every remaining unmapped MMDB AS-domain (~2,650) has now been processed. Combined with an expanded classifier that covers all 44 README industry types and adds multilingual keyword detection across 20+ languages.

**Numbers for this batch:**
- 980 added to \`base_reverse_dns_map.csv\` (broad type distribution; ISP 193, Education 193, Finance 155, Government 109, Healthcare 93, plus 28 other types)
- 1,669 added to \`known_unknown_base_reverse_dns.txt\` (residual unfetchable / parked / non-classifiable)

**Coverage after this batch:**
- Distinct MMDB AS-domains mapped: **29,083 / 63,993 (45.45%)**
- IPv4 weight: **98.36%**
- Remaining unmapped pool: **0** (every MMDB AS-domain has been processed)

## Classifier expansion

The core change behind this batch's higher-than-typical type diversity:

- **All 44 README industry types now have body-text detectors.** Previously the classifier only handled ISP, Web Host, Education, Government, Healthcare, MSP, Finance, plus a handful of industry types added during the long-tail batches. Added detectors for the rest: Email Security, Marketing, Email Provider, Agriculture, Beauty, Construction, Consulting, Defense, Event Planning, Logistics, MSSP, News, Nonprofit, Photography, Physical Security, Print, Publishing, Religion, Science, Search Engine, Social Media, Sports, Staffing, Technology, Utilities, Industrial, IaaS, PaaS, SaaS, Government Media, Conglomerate.
- **Per-detector multilingual keyword coverage.** Every detector now has alternatives across the languages most common in long-tail ASN data: Spanish, Portuguese, French, Italian, German, Dutch, Russian, Polish, Czech, Turkish, Greek, Chinese (simplified and traditional), Japanese, Korean, Arabic, Hebrew, Hindi, Vietnamese, Indonesian, Thai.
- **Finance gap fix.** The previous classifier only matched \`bank|banca|banco|banque\` in the as_name; insurance, investment management, asset management, brokerage, and most non-bank financials went to KU. The new \`FINANCE_RE\` is a proper body-text detector recovering ~150 financial-services rows in this batch alone.
- **Real Estate gap fix.** Added property/facility management, property development, coworking variants.

## Recommended new README categories

Two industry clusters in the unclassified data don't fit well into existing categories. Proposing for follow-up:

- **Insurance** — currently bundled under Finance. Many large operators (mutual insurers, P&C, life). The new FINANCE_RE catches them but a separate type would be cleaner.
- **Energy** — non-utility energy companies (gas distributors, energy services, downstream oil & gas). The README's \`Utilities\` covers regulated power/water; \`Energy\` would cover the rest. Currently mapped to Utilities via the cascade pending README decision.

## Test plan

- [x] \`python parsedmarc/resources/maps/sortlists.py\` exits clean
- [x] disjoint invariant holds
- [x] CRLF preserved
- [x] Validated on prior batches' cached TSVs to confirm coverage gains (407 additional rows recovered from batch 12's KU pool with the new classifier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)