### PR TITLE
Fix Validate-dashboards CI: heredoc was redirecting itself to stdin

### DIFF
--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -74,9 +74,13 @@ jobs:
             -H 'kbn-xsrf: true' \
             --form file=@dashboards/opensearch/opensearch_dashboards.ndjson)
           echo "$response" | python3 -m json.tool
-          echo "$response" | python3 - <<'PY'
-          import json, sys
-          d = json.load(sys.stdin)
+          # Pass the response via env, not stdin: `python3 - <<EOF` (or bare
+          # heredoc) redirects the heredoc itself to stdin so sys.stdin is
+          # empty by the time the script runs, and json.load(sys.stdin) blows
+          # up with "Expecting value: line 1 column 1".
+          RESPONSE="$response" python3 <<'PY'
+          import json, os, sys
+          d = json.loads(os.environ["RESPONSE"])
           if not d.get("success"):
               sys.exit(f"Kibana import failed: {d}")
           if d.get("errors"):


### PR DESCRIPTION
## Summary

The Kibana 8.x ndjson-import check in `.github/workflows/dashboards.yml` has been red on every run since the workflow shipped — including master's own pushes. The OSD ndjson actually imports cleanly (`successCount: 26, success: true`), but the Python assertion step blows up with `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`.

## Root cause

```bash
echo "\$response" | python3 - <<'PY'
import json, sys
d = json.load(sys.stdin)
...
PY
```

The heredoc is redirected to `python3 -`'s stdin (which is where Python is reading the script from), so by the time the script body runs, `sys.stdin` is at EOF. The `echo "\$response" |` pipe earlier on the same line is meaningless — it's overridden by the heredoc.

## Fix

Pass the response via an environment variable instead of stdin:

```bash
RESPONSE="\$response" python3 <<'PY'
import json, os, sys
d = json.loads(os.environ["RESPONSE"])
...
PY
```

Smoke-tested both the success path (exits 0, prints "OK: 26 saved objects imported and migrated by Kibana") and the failure path (Python's `sys.exit(message)` correctly bubbles a non-zero exit code).

## Test plan

- [ ] CI runs `Verify ndjson imports into Kibana 8.x` and it passes (currently always red).