### PR TITLE
docs: note DMARC RFC support in the features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
 This project supports the following Python versions, which are either actively maintained or are the default versions
 for RHEL or Debian.
 
-| Version | Supported | Reason                                                     |
-|---------|-----------|------------------------------------------------------------|
-| < 3.6   | ❌         | End of Life (EOL)                                          |
-| 3.6     | ❌         | Used in RHEL 8, but not supported by project dependencies |
-| 3.7     | ❌         | End of Life (EOL)                                          |
-| 3.8     | ❌         | End of Life (EOL)                                          |
+| Version | Supported | Reason                                                                  |
+|---------|-----------|-------------------------------------------------------------------------|
+| < 3.6   | ❌         | End of Life (EOL)                                                       |
+| 3.6     | ❌         | Used in RHEL 8, but not supported by project dependencies               |
+| 3.7     | ❌         | End of Life (EOL)                                                       |
+| 3.8     | ❌         | End of Life (EOL)                                                       |
 | 3.9     | ❌         | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
-| 3.10    | ✅         | Actively maintained                                        |
-| 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12) |
-| 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)    |
-| 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13) |
-| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                  |
+| 3.10    | ✅         | Actively maintained                                                     |
+| 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12)              |
+| 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)                 |
+| 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13)              |
+| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                                |

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
 - Consistent data structures
 - Simple JSON and/or CSV output
 - Optionally email the results
-- Optionally send the results to Elasticsearch, OpenSearch, Splunk, or
-  PostgreSQL, for use with premade dashboards
+- Optionally send the results to Elasticsearch, OpenSearch, or Splunk, for use
+  with premade dashboards, or to PostgreSQL
 - Optionally send the results to Apache Kafka, Amazon S3, Azure Log Analytics
   (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server, or an HTTP
   webhook

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
 - Simple JSON and/or CSV output
 - Optionally email the results
 - Optionally send the results to Elasticsearch, OpenSearch, or Splunk, for use
-  with premade dashboards, or to PostgreSQL
-- Optionally send the results to Apache Kafka, Amazon S3, Azure Log Analytics
-  (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server, or an HTTP
-  webhook
+  with premade dashboards
+- Optionally send the results to PostgreSQL, Apache Kafka, Amazon S3, Azure Log
+  Analytics (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server,
+  or an HTTP webhook
 
 ## Python Compatibility
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
 
 ## Features
 
-- Parses draft and 1.0 standard aggregate/rua DMARC reports
-- Parses failure/ruf DMARC reports (formerly called forensic reports)
-- Parses reports from SMTP TLS Reporting
+- Parses aggregate/rua DMARC reports: the legacy draft and 1.0 schemas
+  (RFC 7489) and the new RFC 9990 schema for the final DMARC standard
+  (RFC 9989)
+- Parses failure/ruf DMARC reports (RFC 6591 and RFC 9991; formerly called
+  forensic reports)
+- Parses reports from SMTP TLS Reporting (TLS-RPT, RFC 8460)
 - Can parse reports from an inbox over IMAP, Microsoft Graph, or Gmail API
 - Transparently handles gzip or zip compressed reports
 - Consistent data structures

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
 This project supports the following Python versions, which are either actively maintained or are the default versions
 for RHEL or Debian.
 
-| Version | Supported | Reason                                                                  |
-|---------|-----------|-------------------------------------------------------------------------|
-| < 3.6   | ❌        | End of Life (EOL)                                                       |
-| 3.6     | ❌        | Used in RHEL 8, but not supported by project dependencies               |
-| 3.7     | ❌        | End of Life (EOL)                                                       |
-| 3.8     | ❌        | End of Life (EOL)                                                       |
-| 3.9     | ❌        | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
-| 3.10    | ✅        | Actively maintained                                                     |
-| 3.11    | ✅        | Actively maintained; supported until June 2028 (Debian 12)              |
-| 3.12    | ✅        | Actively maintained; supported until May 2035 (RHEL 10)                 |
-| 3.13    | ✅        | Actively maintained; supported until June 2030 (Debian 13)              |
-| 3.14    | ✅        | Supported (requires `imapclient>=3.1.0`)                                |
+| Version | Supported | Reason |
+| --- | --- | --- |
+| < 3.6 | ❌ | End of Life (EOL) |
+| 3.6 | ❌ | Used in RHEL 8, but not supported by project dependencies |
+| 3.7 | ❌ | End of Life (EOL) |
+| 3.8 | ❌ | End of Life (EOL) |
+| 3.9 | ❌ | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
+| 3.10 | ✅ | Actively maintained |
+| 3.11 | ✅ | Actively maintained; supported until June 2028 (Debian 12) |
+| 3.12 | ✅ | Actively maintained; supported until May 2035 (RHEL 10) |
+| 3.13 | ✅ | Actively maintained; supported until June 2030 (Debian 13) |
+| 3.14 | ✅ | Supported (requires `imapclient>=3.1.0`) |

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if
 - Consistent data structures
 - Simple JSON and/or CSV output
 - Optionally email the results
-- Optionally send the results to Elasticsearch, Opensearch, and/or Splunk, for
-  use with premade dashboards
-- Optionally send reports to Apache Kafka
+- Optionally send the results to Elasticsearch, OpenSearch, Splunk, or
+  PostgreSQL, for use with premade dashboards
+- Optionally send the results to Apache Kafka, Amazon S3, Azure Log Analytics
+  (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server, or an HTTP
+  webhook
 
 ## Python Compatibility
 
@@ -50,13 +52,13 @@ for RHEL or Debian.
 
 | Version | Supported | Reason                                                                  |
 |---------|-----------|-------------------------------------------------------------------------|
-| < 3.6   | ❌         | End of Life (EOL)                                                       |
-| 3.6     | ❌         | Used in RHEL 8, but not supported by project dependencies               |
-| 3.7     | ❌         | End of Life (EOL)                                                       |
-| 3.8     | ❌         | End of Life (EOL)                                                       |
-| 3.9     | ❌         | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
-| 3.10    | ✅         | Actively maintained                                                     |
-| 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12)              |
-| 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)                 |
-| 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13)              |
-| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                                |
+| < 3.6   | ❌        | End of Life (EOL)                                                       |
+| 3.6     | ❌        | Used in RHEL 8, but not supported by project dependencies               |
+| 3.7     | ❌        | End of Life (EOL)                                                       |
+| 3.8     | ❌        | End of Life (EOL)                                                       |
+| 3.9     | ❌        | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
+| 3.10    | ✅        | Actively maintained                                                     |
+| 3.11    | ✅        | Actively maintained; supported until June 2028 (Debian 12)              |
+| 3.12    | ✅        | Actively maintained; supported until May 2035 (RHEL 10)                 |
+| 3.13    | ✅        | Actively maintained; supported until June 2030 (Debian 13)              |
+| 3.14    | ✅        | Supported (requires `imapclient>=3.1.0`)                                |

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -41,10 +41,10 @@ and Valimail.
 - Simple JSON and/or CSV output
 - Optionally email the results
 - Optionally send the results to Elasticsearch, OpenSearch, or Splunk, for use
-  with premade dashboards, or to PostgreSQL
-- Optionally send the results to Apache Kafka, Amazon S3, Azure Log Analytics
-  (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server, or an HTTP
-  webhook
+  with premade dashboards
+- Optionally send the results to PostgreSQL, Apache Kafka, Amazon S3, Azure Log
+  Analytics (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server,
+  or an HTTP webhook
 
 ## Python Compatibility
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -29,9 +29,12 @@ and Valimail.
 
 ## Features
 
-- Parses draft and 1.0 standard aggregate/rua DMARC reports
-- Parses failure/ruf DMARC reports
-- Parses reports from SMTP TLS Reporting
+- Parses aggregate/rua DMARC reports: the legacy draft and 1.0 schemas
+  (RFC 7489) and the new RFC 9990 schema for the final DMARC standard
+  (RFC 9989)
+- Parses failure/ruf DMARC reports (RFC 6591 and RFC 9991; formerly called
+  forensic reports)
+- Parses reports from SMTP TLS Reporting (TLS-RPT, RFC 8460)
 - Can parse reports from an inbox over IMAP, Microsoft Graph, or Gmail API
 - Transparently handles gzip or zip compressed reports
 - Consistent data structures

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -40,9 +40,11 @@ and Valimail.
 - Consistent data structures
 - Simple JSON and/or CSV output
 - Optionally email the results
-- Optionally send the results to Elasticsearch, Opensearch, and/or Splunk, for use
-    with premade dashboards
-- Optionally send reports to Apache Kafka
+- Optionally send the results to Elasticsearch, OpenSearch, Splunk, or
+  PostgreSQL, for use with premade dashboards
+- Optionally send the results to Apache Kafka, Amazon S3, Azure Log Analytics
+  (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server, or an HTTP
+  webhook
 
 ## Python Compatibility
 
@@ -51,16 +53,16 @@ for RHEL or Debian.
 
 | Version | Supported | Reason                                                                  |
 |---------|-----------|-------------------------------------------------------------------------|
-| < 3.6   | ❌         | End of Life (EOL)                                                       |
-| 3.6     | ❌         | Used in RHEL 8, but not supported by project dependencies               |
-| 3.7     | ❌         | End of Life (EOL)                                                       |
-| 3.8     | ❌         | End of Life (EOL)                                                       |
-| 3.9     | ❌         | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
-| 3.10    | ✅         | Actively maintained                                                     |
-| 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12)              |
-| 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)                 |
-| 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13)              |
-| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                                |
+| < 3.6   | ❌        | End of Life (EOL)                                                       |
+| 3.6     | ❌        | Used in RHEL 8, but not supported by project dependencies               |
+| 3.7     | ❌        | End of Life (EOL)                                                       |
+| 3.8     | ❌        | End of Life (EOL)                                                       |
+| 3.9     | ❌        | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
+| 3.10    | ✅        | Actively maintained                                                     |
+| 3.11    | ✅        | Actively maintained; supported until June 2028 (Debian 12)              |
+| 3.12    | ✅        | Actively maintained; supported until May 2035 (RHEL 10)                 |
+| 3.13    | ✅        | Actively maintained; supported until June 2030 (Debian 13)              |
+| 3.14    | ✅        | Supported (requires `imapclient>=3.1.0`)                                |
 
 ```{toctree}
 :caption: 'Contents'

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -49,18 +49,18 @@ and Valimail.
 This project supports the following Python versions, which are either actively maintained or are the default versions
 for RHEL or Debian.
 
-| Version | Supported | Reason                                                     |
-|---------|-----------|------------------------------------------------------------|
-| < 3.6   | ❌         | End of Life (EOL)                                          |
-| 3.6     | ❌         | Used in RHEL 8, but not supported by project dependencies |
-| 3.7     | ❌         | End of Life (EOL)                                          |
-| 3.8     | ❌         | End of Life (EOL)                                          |
+| Version | Supported | Reason                                                                  |
+|---------|-----------|-------------------------------------------------------------------------|
+| < 3.6   | ❌         | End of Life (EOL)                                                       |
+| 3.6     | ❌         | Used in RHEL 8, but not supported by project dependencies               |
+| 3.7     | ❌         | End of Life (EOL)                                                       |
+| 3.8     | ❌         | End of Life (EOL)                                                       |
 | 3.9     | ❌         | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
-| 3.10    | ✅         | Actively maintained                                        |
-| 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12) |
-| 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)    |
-| 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13) |
-| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                  |
+| 3.10    | ✅         | Actively maintained                                                     |
+| 3.11    | ✅         | Actively maintained; supported until June 2028 (Debian 12)              |
+| 3.12    | ✅         | Actively maintained; supported until May 2035 (RHEL 10)                 |
+| 3.13    | ✅         | Actively maintained; supported until June 2030 (Debian 13)              |
+| 3.14    | ✅         | Supported (requires `imapclient>=3.1.0`)                                |
 
 ```{toctree}
 :caption: 'Contents'

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -51,18 +51,18 @@ and Valimail.
 This project supports the following Python versions, which are either actively maintained or are the default versions
 for RHEL or Debian.
 
-| Version | Supported | Reason                                                                  |
-|---------|-----------|-------------------------------------------------------------------------|
-| < 3.6   | ❌        | End of Life (EOL)                                                       |
-| 3.6     | ❌        | Used in RHEL 8, but not supported by project dependencies               |
-| 3.7     | ❌        | End of Life (EOL)                                                       |
-| 3.8     | ❌        | End of Life (EOL)                                                       |
-| 3.9     | ❌        | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
-| 3.10    | ✅        | Actively maintained                                                     |
-| 3.11    | ✅        | Actively maintained; supported until June 2028 (Debian 12)              |
-| 3.12    | ✅        | Actively maintained; supported until May 2035 (RHEL 10)                 |
-| 3.13    | ✅        | Actively maintained; supported until June 2030 (Debian 13)              |
-| 3.14    | ✅        | Supported (requires `imapclient>=3.1.0`)                                |
+| Version | Supported | Reason |
+| --- | --- | --- |
+| < 3.6 | ❌ | End of Life (EOL) |
+| 3.6 | ❌ | Used in RHEL 8, but not supported by project dependencies |
+| 3.7 | ❌ | End of Life (EOL) |
+| 3.8 | ❌ | End of Life (EOL) |
+| 3.9 | ❌ | Used in Debian 11 and RHEL 9, but not supported by project dependencies |
+| 3.10 | ✅ | Actively maintained |
+| 3.11 | ✅ | Actively maintained; supported until June 2028 (Debian 12) |
+| 3.12 | ✅ | Actively maintained; supported until May 2035 (RHEL 10) |
+| 3.13 | ✅ | Actively maintained; supported until June 2030 (Debian 13) |
+| 3.14 | ✅ | Supported (requires `imapclient>=3.1.0`) |
 
 ```{toctree}
 :caption: 'Contents'

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -40,8 +40,8 @@ and Valimail.
 - Consistent data structures
 - Simple JSON and/or CSV output
 - Optionally email the results
-- Optionally send the results to Elasticsearch, OpenSearch, Splunk, or
-  PostgreSQL, for use with premade dashboards
+- Optionally send the results to Elasticsearch, OpenSearch, or Splunk, for use
+  with premade dashboards, or to PostgreSQL
 - Optionally send the results to Apache Kafka, Amazon S3, Azure Log Analytics
   (Microsoft Sentinel), a Graylog (GELF) endpoint, a syslog server, or an HTTP
   webhook

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -714,24 +714,24 @@ then read and stored as the `credentials_file` value.
 
 For sections with underscores in the name, the full section name is used:
 
-| Section          | Env var prefix                |
-|------------------|-------------------------------|
-| `general`        | `PARSEDMARC_GENERAL_`         |
-| `mailbox`        | `PARSEDMARC_MAILBOX_`         |
-| `imap`           | `PARSEDMARC_IMAP_`            |
-| `msgraph`        | `PARSEDMARC_MSGRAPH_`         |
-| `elasticsearch`  | `PARSEDMARC_ELASTICSEARCH_`   |
-| `opensearch`     | `PARSEDMARC_OPENSEARCH_`      |
-| `splunk_hec`     | `PARSEDMARC_SPLUNK_HEC_`      |
-| `kafka`          | `PARSEDMARC_KAFKA_`           |
-| `smtp`           | `PARSEDMARC_SMTP_`            |
-| `s3`             | `PARSEDMARC_S3_`              |
-| `syslog`         | `PARSEDMARC_SYSLOG_`          |
-| `gmail_api`      | `PARSEDMARC_GMAIL_API_`       |
-| `maildir`        | `PARSEDMARC_MAILDIR_`         |
-| `log_analytics`  | `PARSEDMARC_LOG_ANALYTICS_`   |
-| `gelf`           | `PARSEDMARC_GELF_`            |
-| `webhook`        | `PARSEDMARC_WEBHOOK_`         |
+| Section | Env var prefix |
+| --- | --- |
+| `general` | `PARSEDMARC_GENERAL_` |
+| `mailbox` | `PARSEDMARC_MAILBOX_` |
+| `imap` | `PARSEDMARC_IMAP_` |
+| `msgraph` | `PARSEDMARC_MSGRAPH_` |
+| `elasticsearch` | `PARSEDMARC_ELASTICSEARCH_` |
+| `opensearch` | `PARSEDMARC_OPENSEARCH_` |
+| `splunk_hec` | `PARSEDMARC_SPLUNK_HEC_` |
+| `kafka` | `PARSEDMARC_KAFKA_` |
+| `smtp` | `PARSEDMARC_SMTP_` |
+| `s3` | `PARSEDMARC_S3_` |
+| `syslog` | `PARSEDMARC_SYSLOG_` |
+| `gmail_api` | `PARSEDMARC_GMAIL_API_` |
+| `maildir` | `PARSEDMARC_MAILDIR_` |
+| `log_analytics` | `PARSEDMARC_LOG_ANALYTICS_` |
+| `gelf` | `PARSEDMARC_GELF_` |
+| `webhook` | `PARSEDMARC_WEBHOOK_` |
 
 ## Performance tuning
 


### PR DESCRIPTION
## Summary

Brings the Features list (in `README.md` and `docs/source/index.md`) up to date with what parsedmarc actually supports:

- **Report standards** — aggregate/rua: draft and 1.0 schemas (RFC 7489) plus the new RFC 9990 schema for the final DMARC standard (RFC 9989); failure/ruf: RFC 6591 and RFC 9991; SMTP TLS Reporting: TLS-RPT (RFC 8460)
- **Output destinations** — now lists every sink: Elasticsearch, OpenSearch, Splunk, and PostgreSQL (premade dashboards), plus Apache Kafka, Amazon S3, Azure Log Analytics (Microsoft Sentinel), Graylog (GELF), syslog, and HTTP webhooks

Also re-aligns the Python compatibility table so the status-emoji rows satisfy markdownlint MD060 (the rule measures display width; the emoji render two columns wide).

Docs-only; both files kept in sync.

> [!NOTE]
> The features list mentions **PostgreSQL**, which lands via #667. Both are targeted at 10.0.0 — merge #667 first (or accept that this doc briefly leads master until it does).

## Test plan

- [x] `cd docs && make html` builds cleanly
- [x] `markdownlint-cli2` reports 0 MD060 errors on both files