### PR TITLE
Bump mailsuite to >=2.2.1 (release 10.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Changes
 
-- Bump the `mailsuite` requirement to `>=2.2.1`, which raises the transitive `mail-parser` floor to `>=4.2.1`. `mail-parser` 4.2.1 stops returning a phantom `('', '')` entry for absent address headers, so parsedmarc no longer indexes an empty `Cc`/`Bcc` address (`{address: ""}`) for every DMARC failure-report sample in Elasticsearch/OpenSearch — and no longer emits it in JSON, S3, or Kafka output. (The `Reply-To` parsing for failure samples and the failure dashboards are tracked separately.)
+- Bump the `mailsuite` requirement to `>=2.2.1`, which raises the transitive `mail-parser` floor to `>=4.2.1`. This pulls in two upstream fixes:
+  - `mail-parser` 4.2.1 stops returning a phantom `('', '')` entry for absent address headers, so parsedmarc no longer indexes an empty `Cc`/`Bcc` address (`{address: ""}`) for every DMARC failure-report sample in Elasticsearch/OpenSearch — and no longer emits it in JSON, S3, or Kafka output.
+  - `mail-parser` 4.2.1 also adopts the stricter address parsing that hardens against [CVE-2023-27043](https://nvd.nist.gov/vuln/detail/CVE-2023-27043) — a Python `email`-module flaw where an RFC 2822 header containing a special character has the wrong portion identified as the addr-spec, which can let a crafted address bypass email-domain verification.
+
+  (The `Reply-To` parsing for failure samples and the failure dashboards are tracked separately.)
 
 ## 10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 10.0.2
+
+### Changes
+
+- Bump the `mailsuite` requirement to `>=2.2.1`, which raises the transitive `mail-parser` floor to `>=4.2.1`. `mail-parser` 4.2.1 stops returning a phantom `('', '')` entry for absent address headers, so parsedmarc no longer indexes an empty `Cc`/`Bcc` address (`{address: ""}`) for every DMARC failure-report sample in Elasticsearch/OpenSearch — and no longer emits it in JSON, S3, or Kafka output. (The `Reply-To` parsing for failure samples and the failure dashboards are tracked separately.)
+
 ## 10.0.1
 
 ### Changes

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.0.1"
+__version__ = "10.0.2"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "expiringdict>=1.1.4",
     "kafka-python-ng>=2.2.2",
     "lxml>=4.4.0",
-    "mailsuite[gmail,msgraph]>=2.2.0",
+    "mailsuite[gmail,msgraph]>=2.2.1",
     "maxminddb>=2.0.0",
     "opensearch-py>=2.4.2,<=4.0.0",
     "publicsuffixlist>=0.10.0",


### PR DESCRIPTION
## Summary

Patch release `10.0.2` bumping the `mailsuite` requirement from `>=2.2.0` to `>=2.2.1`.

mailsuite 2.2.1 raises the transitive `mail-parser` floor to `>=4.2.1`, which pulls in two upstream fixes:

1. **Phantom empty-address fix.** mail-parser 4.2.1 stops returning a phantom `('', '')` entry for **absent** address headers (`Cc`, `Bcc`, `Reply-To`, etc.) instead of an empty list. parsedmarc reads the `mail-parser` object directly through its own `parse_email()`, so this phantom flowed straight into output: an empty `{address: ""}` `Cc`/`Bcc` entry was indexed for **every** DMARC failure-report sample in Elasticsearch/OpenSearch, and emitted in JSON/S3/Kafka output.
2. **CVE-2023-27043 hardening.** mail-parser 4.2.1 also adopts the stricter address parsing that hardens against [CVE-2023-27043](https://nvd.nist.gov/vuln/detail/CVE-2023-27043) (CVSS 5.3) — a Python `email`-module flaw where an RFC 2822 header containing a special character has the wrong portion identified as the addr-spec, which can let a crafted address bypass email-domain verification.

## Verification

Upgraded the venv to `mailsuite 2.2.1` / `mail-parser 4.2.1` and re-parsed every sample in `samples/failure/`:

| field | before (mail-parser 4.1.4) | after (4.2.1) |
|-------|----------------------------|---------------|
| `cc`  | `[{"address": "", ...}]`   | `[]`          |
| `bcc` | `[{"address": "", ...}]`   | `[]`          |

Full test suite passes against the upgraded dependency (`313 passed`).

## Out of scope (tracked separately)

- **`Reply-To` always empty for failure samples** — a hyphen-vs-underscore key mismatch in parsedmarc's *own* `parse_email()` (`reply_to` vs mail-parser's `reply-to`), not an upstream issue. The mail-parser bump does not address it.
- **Failure dashboards** — Splunk RUF dashboard renames the wrong field paths; the OpenSearch RUF "reply_to" column aggregates the `In-Reply-To` threading header instead of the Reply-To address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)