### PR TITLE
test: cover no-display-name Reply-To flattening branch

### DIFF
--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -781,6 +781,23 @@ class TestSaveFailureReport(unittest.TestCase):
             [a.address for a in doc.sample.reply_to], ["real@phish.example"]
         )
 
+    def test_reply_to_header_without_display_name_flattens_to_address(self):
+        """A Reply-To header with no display name flattens to the bare
+        address — the empty-display branch of the header flattening,
+        matching the From/To handling."""
+        report = _failure_report()
+        report["parsed_sample"]["headers"]["Reply-To"] = [["", "noname@phish.example"]]
+        with (
+            patch("parsedmarc.elastic.Search", return_value=_empty_search()),
+            patch("parsedmarc.elastic.Index"),
+            patch.object(
+                elastic_module._FailureReportDoc, "save", autospec=True
+            ) as mock_save,
+        ):
+            save_failure_report_to_elasticsearch(report)
+        doc = mock_save.call_args.args[0]
+        self.assertEqual(doc.sample.headers["reply-to"], "noname@phish.example")
+
 
 # ---------------------------------------------------------------------------
 # save_smtp_tls_report_to_elasticsearch

--- a/tests/test_opensearch.py
+++ b/tests/test_opensearch.py
@@ -779,6 +779,23 @@ class TestSaveFailureReport(unittest.TestCase):
             [a.address for a in doc.sample.reply_to], ["real@phish.example"]
         )
 
+    def test_reply_to_header_without_display_name_flattens_to_address(self):
+        """A Reply-To header with no display name flattens to the bare
+        address — the empty-display branch of the header flattening,
+        matching the From/To handling."""
+        report = _failure_report()
+        report["parsed_sample"]["headers"]["Reply-To"] = [["", "noname@phish.example"]]
+        with (
+            patch("parsedmarc.opensearch.Search", return_value=_empty_search()),
+            patch("parsedmarc.opensearch.Index"),
+            patch.object(
+                opensearch_module._FailureReportDoc, "save", autospec=True
+            ) as mock_save,
+        ):
+            save_failure_report_to_opensearch(report)
+        doc = mock_save.call_args.args[0]
+        self.assertEqual(doc.sample.headers["reply-to"], "noname@phish.example")
+
 
 # ---------------------------------------------------------------------------
 # save_smtp_tls_report_to_opensearch


### PR DESCRIPTION
Fixes the Codecov patch-coverage failure on the 10.0.3 changes.

The Reply-To header flattening added in 10.0.3 (`parsedmarc/elastic.py` and `parsedmarc/opensearch.py`, line 711) has two branches:

```python
if headers["reply-to"][0] == "":
    headers["reply-to"] = headers["reply-to"][1]   # no display name -> bare address
else:
    headers["reply-to"] = " <".join(headers["reply-to"]) + ">"   # "Name <addr>"
```

The existing `test_reply_to_header_flattened_and_indexed` only exercised the `else` branch, leaving the empty-display-name line uncovered — the two lines (one per module) Codecov flagged.

This adds `test_reply_to_header_without_display_name_flattens_to_address` to both `tests/test_elastic.py` and `tests/test_opensearch.py`: a failure report whose `Reply-To` has no display name, asserting `sample.headers["reply-to"]` flattens to the bare address on the document handed to `.save()`.

Test-only change — no library code, no version bump, no changelog entry. Full suite `635 passed`; `ruff` clean. Confirmed line 711 is no longer in the coverage `Missing` set for either module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)