### PR TITLE
Build multi-arch (amd64+arm64) Docker images with PostgreSQL support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,16 +10,8 @@ on:
   push:
     branches:
       - master
-  # Validate the multi-arch image build on PRs that touch the build inputs.
-  # The build runs for every listed platform but does not push (push is gated
-  # on the release event below), so this only exercises the build.
-  pull_request:
-    paths:
-      - "Dockerfile"
-      - ".dockerignore"
-      - ".github/workflows/docker.yml"
-      - "pyproject.toml"
-  # Allow maintainers to rebuild the images on demand.
+  # Allow maintainers to build/validate the multi-arch image on demand
+  # (e.g. from a feature branch) without pushing anything to the registry.
   workflow_dispatch:
 
 env:
@@ -57,6 +49,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Log in to the Container registry
+        # Only authenticate when we will actually push (release). The master
+        # push and workflow_dispatch runs build for validation only and must
+        # never touch the registry, so they skip the login entirely.
+        if: github.event_name == 'release'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -68,6 +64,9 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          # Push only on a published release. Every other trigger (push to
+          # master, workflow_dispatch) builds both architectures for
+          # validation but never pushes.
           push: ${{ github.event_name == 'release' }}
           tags:  ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,17 @@ on:
   push:
     branches:
       - master
+  # Validate the multi-arch image build on PRs that touch the build inputs.
+  # The build runs for every listed platform but does not push (push is gated
+  # on the release event below), so this only exercises the build.
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker.yml"
+      - "pyproject.toml"
+  # Allow maintainers to rebuild the images on demand.
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -25,6 +36,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
@@ -50,6 +67,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'release' }}
           tags:  ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 10.0.4
+
+### Docker
+
+- **PostgreSQL backend in the prebuilt image** ([#792](https://github.com/domainaware/parsedmarc/issues/792)): the image now installs `parsedmarc[postgresql]`, so the optional PostgreSQL output backend (`psycopg`) works out of the box in the container without a separate `pip install`.
+- **`arm64` images** ([#789](https://github.com/domainaware/parsedmarc/issues/789)): the release workflow now builds and publishes a multi-arch manifest for `linux/amd64` and `linux/arm64`, so `ghcr.io/domainaware/parsedmarc` runs natively on 64-bit ARM hosts such as a Raspberry Pi. All compiled dependencies (`psycopg[binary]`, `lxml`, `maxminddb`, `cryptography`) ship prebuilt `aarch64` wheels, so the build adds no source-compilation step.
+
 ## 10.0.3
 
 ### Bug fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,14 @@ COPY --from=build /app/dist/*.whl /tmp/dist/
 RUN set -ex; \
     groupadd --gid ${USER_GID} ${USERNAME}; \
     useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}; \
-    pip install /tmp/dist/*.whl; \
+    # Install the wheel with the [postgresql] extra so the prebuilt image
+    # ships the PostgreSQL output backend (psycopg). Resolve the globbed wheel
+    # path into a variable first: `*.whl[postgresql]` would otherwise be parsed
+    # as a shell bracket glob rather than a pip extras spec. psycopg[binary]
+    # has prebuilt manylinux wheels for both amd64 and arm64, so this adds no
+    # source-build step on either platform.
+    whl="$(ls /tmp/dist/*.whl)"; \
+    pip install "${whl}[postgresql]"; \
     rm -rf /tmp/dist
 
 USER $USERNAME

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -381,7 +381,11 @@ The full set of configuration options are:
   The PostgreSQL backend is an optional extra. Install it with
   `pip install parsedmarc[postgresql]` (it pulls in `psycopg`); the
   prebuilt binary wheels are not available for every platform, which is
-  why it is not a mandatory dependency.
+  why it is not a mandatory dependency. The prebuilt Docker image
+  (`ghcr.io/domainaware/parsedmarc`) already bundles this extra, so the
+  PostgreSQL backend works out of the box in the container — `psycopg`
+  ships `amd64` and `arm64` binary wheels, both of which the image
+  supports.
 
   Tables are created automatically on first run using
   `CREATE TABLE IF NOT EXISTS`, so no manual schema migration is needed

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.0.3"
+__version__ = "10.0.4"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 


### PR DESCRIPTION
Addresses two Docker feature requests.

### #792 — PostgreSQL support in the prebuilt image
The image now installs `parsedmarc[postgresql]`, so the optional PostgreSQL output backend (`psycopg`) works out of the box in the container with no separate `pip install`. The globbed wheel path is resolved into a variable before the extra is appended, so the shell doesn't parse `*.whl[postgresql]` as a bracket glob.

### #789 — arm64 images
The workflow sets up QEMU + Buildx and builds a multi-arch manifest for `linux/amd64` and `linux/arm64`, so `ghcr.io/domainaware/parsedmarc` runs natively on 64-bit ARM hosts (e.g. a Raspberry Pi). Every compiled dependency (`psycopg[binary]`, `lxml`, `maxminddb`, `cryptography`) ships prebuilt `aarch64` manylinux wheels, so the arm64 build adds no source-compilation step.

### Registry pushes stay release-only
The push to the registry remains gated on the `release` event, so neither a `push` to master nor a manual `workflow_dispatch` run ever publishes an image — they build both architectures for validation only. As defense-in-depth, the `docker/login-action` step is now also gated on the `release` event, so non-release runs never even authenticate to ghcr. A `workflow_dispatch` trigger is added so maintainers can build/validate the multi-arch image on demand from a branch without pushing.

### Version bump
Because the registry push is gated on the `release` event, publishing the new image requires cutting a release — so this bumps the version to **10.0.4** (10.0.3 is already tagged) and documents the change in `CHANGELOG.md`. No library code changes.

### Validation
- Confirmed `psycopg[binary]` and the other C-extension deps publish `aarch64` manylinux + musllinux wheels for cp310–cp314, so the glibc `python:3.13-slim` arm64 build pulls prebuilt wheels (no toolchain needed).
- Confirmed `pip install "<wheel>[postgresql]"` resolves the extra: the install set gains `psycopg` + `psycopg-binary` with the extra and omits them without it.
- The full `linux/amd64,linux/arm64` build was validated two ways: a GitHub Actions run (`push: false`, succeeded in ~10 min) and a local `docker buildx --platform linux/amd64,linux/arm64` build (`EXIT=0`), the latter confirming `psycopg`/`psycopg-binary` install on arm64 from prebuilt wheels with no compilation.

Closes #789
Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)