### PR TITLE
Declare backward-compatible method aliases inside class bodies

### DIFF
--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.0.4"
+__version__ = "10.1.0"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 

--- a/parsedmarc/gelf.py
+++ b/parsedmarc/gelf.py
@@ -76,6 +76,5 @@ class GelfClient(object):
         self.logger.removeHandler(self.handler)
         self.handler.close()
 
-
-# Backward-compatible aliases
-GelfClient.save_forensic_report_to_gelf = GelfClient.save_failure_report_to_gelf
+    # Backward-compatible alias
+    save_forensic_report_to_gelf = save_failure_report_to_gelf

--- a/parsedmarc/kafkaclient.py
+++ b/parsedmarc/kafkaclient.py
@@ -11,7 +11,7 @@ from kafka.errors import UnknownTopicOrPartitionError
 
 try:
     # kafka-python < 3.0 raises this when the producer cannot bootstrap
-    from kafka.errors import NoBrokersAvailable as _BootstrapError
+    from kafka.errors import NoBrokersAvailable as _BootstrapError  # pyright: ignore[reportAttributeAccessIssue]
 except ImportError:
     # kafka-python >= 3.0 removed NoBrokersAvailable; a failed bootstrap
     # raises KafkaTimeoutError instead
@@ -219,6 +219,5 @@ class KafkaClient(object):
         except Exception as e:
             raise KafkaError("Kafka error: {0}".format(e.__str__()))
 
-
-# Backward-compatible aliases
-KafkaClient.save_forensic_reports_to_kafka = KafkaClient.save_failure_reports_to_kafka
+    # Backward-compatible alias
+    save_forensic_reports_to_kafka = save_failure_reports_to_kafka

--- a/parsedmarc/s3.py
+++ b/parsedmarc/s3.py
@@ -115,6 +115,5 @@ class S3Client(object):
         except Exception:
             pass
 
-
-# Backward-compatible aliases
-S3Client.save_forensic_report_to_s3 = S3Client.save_failure_report_to_s3
+    # Backward-compatible alias
+    save_forensic_report_to_s3 = save_failure_report_to_s3

--- a/parsedmarc/splunk.py
+++ b/parsedmarc/splunk.py
@@ -221,6 +221,5 @@ class HECClient(object):
         """Close the underlying HTTP session."""
         self.session.close()
 
-
-# Backward-compatible aliases
-HECClient.save_forensic_reports_to_splunk = HECClient.save_failure_reports_to_splunk
+    # Backward-compatible alias
+    save_forensic_reports_to_splunk = save_failure_reports_to_splunk

--- a/parsedmarc/syslog.py
+++ b/parsedmarc/syslog.py
@@ -185,6 +185,5 @@ class SyslogClient(object):
         self.logger.removeHandler(self.log_handler)
         self.log_handler.close()
 
-
-# Backward-compatible aliases
-SyslogClient.save_forensic_report_to_syslog = SyslogClient.save_failure_report_to_syslog
+    # Backward-compatible alias
+    save_forensic_report_to_syslog = save_failure_report_to_syslog

--- a/parsedmarc/webhook.py
+++ b/parsedmarc/webhook.py
@@ -64,8 +64,5 @@ class WebhookClient(object):
         """Close the underlying HTTP session."""
         self.session.close()
 
-
-# Backward-compatible aliases
-WebhookClient.save_forensic_report_to_webhook = (
-    WebhookClient.save_failure_report_to_webhook
-)
+    # Backward-compatible alias
+    save_forensic_report_to_webhook = save_failure_report_to_webhook

--- a/tests/test_gelf.py
+++ b/tests/test_gelf.py
@@ -325,7 +325,7 @@ class TestGelfClientClose(unittest.TestCase):
 class TestGelfClientBackwardCompatAlias(unittest.TestCase):
     def test_forensic_alias_points_to_failure_method(self):
         self.assertIs(
-            GelfClient.save_forensic_report_to_gelf,  # type: ignore[attr-defined]
+            GelfClient.save_forensic_report_to_gelf,
             GelfClient.save_failure_report_to_gelf,
         )
 

--- a/tests/test_kafkaclient.py
+++ b/tests/test_kafkaclient.py
@@ -271,7 +271,7 @@ class TestKafkaClientClose(unittest.TestCase):
 class TestKafkaBackwardCompatAlias(unittest.TestCase):
     def test_forensic_alias_points_to_failure_method(self):
         self.assertIs(
-            KafkaClient.save_forensic_reports_to_kafka,  # type: ignore[attr-defined]
+            KafkaClient.save_forensic_reports_to_kafka,
             KafkaClient.save_failure_reports_to_kafka,
         )
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -211,7 +211,7 @@ class TestS3ClientClose(unittest.TestCase):
 class TestS3ClientBackwardCompatAlias(unittest.TestCase):
     def test_forensic_alias_points_to_failure_method(self):
         self.assertIs(
-            S3Client.save_forensic_report_to_s3,  # type: ignore[attr-defined]
+            S3Client.save_forensic_report_to_s3,
             S3Client.save_failure_report_to_s3,
         )
 

--- a/tests/test_splunk.py
+++ b/tests/test_splunk.py
@@ -420,7 +420,7 @@ class TestHECClientClose(unittest.TestCase):
 class TestSplunkBackwardCompatAlias(unittest.TestCase):
     def test_forensic_alias_points_to_failure_method(self):
         self.assertIs(
-            HECClient.save_forensic_reports_to_splunk,  # type: ignore[attr-defined]
+            HECClient.save_forensic_reports_to_splunk,
             HECClient.save_failure_reports_to_splunk,
         )
 

--- a/tests/test_syslog.py
+++ b/tests/test_syslog.py
@@ -356,7 +356,7 @@ class TestSyslogClientClose(unittest.TestCase):
 class TestSyslogBackwardCompatAlias(unittest.TestCase):
     def test_forensic_alias_points_to_failure_method(self):
         self.assertIs(
-            SyslogClient.save_forensic_report_to_syslog,  # type: ignore[attr-defined]
+            SyslogClient.save_forensic_report_to_syslog,
             SyslogClient.save_failure_report_to_syslog,
         )
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -112,7 +112,7 @@ class TestWebhookClientClose(unittest.TestCase):
 class TestWebhookBackwardCompatAlias(unittest.TestCase):
     def test_forensic_alias_points_to_failure_method(self):
         self.assertIs(
-            WebhookClient.save_forensic_report_to_webhook,  # type: ignore[attr-defined]
+            WebhookClient.save_forensic_report_to_webhook,
             WebhookClient.save_failure_report_to_webhook,
         )
 


### PR DESCRIPTION
## Problem

The legacy `save_forensic_*` aliases were assigned onto the output client classes *after* the class body:

```python
KafkaClient.save_forensic_reports_to_kafka = KafkaClient.save_failure_reports_to_kafka
```

That assignment is invisible to static type checkers, so Pylance/Pyright flagged both the assignment and every use of the alias with `reportAttributeAccessIssue`, and the alias tests needed `# type: ignore[attr-defined]` comments to stay quiet.

## Fix

Declare each alias inside the class body, where it is statically visible:

```python
    # Backward-compatible alias
    save_forensic_reports_to_kafka = save_failure_reports_to_kafka
```

Runtime behavior is identical — it's the same function object bound as a method, guarded by the existing `assertIs` alias tests in each module's test file. The IDE errors disappear, the aliases get autocomplete and proper typing for downstream users, and the six now-unnecessary `type: ignore[attr-defined]` comments are removed.

Applies to `kafkaclient`, `splunk`, `gelf`, `syslog`, `s3`, and `webhook`. The module-level function aliases in `elastic`, `opensearch`, `types`, and `__init__` are already statically visible and unchanged.

Also adds a `# pyright: ignore[reportAttributeAccessIssue]` on the `NoBrokersAvailable` import in `kafkaclient.py`: the import is guarded by `try/except ImportError` for kafka-python 2.x, but Pyright resolves it against the installed 3.x environment where the name no longer exists.

## Version bump

Bumps `__version__` to 10.1.0: 10.0.4 is tagged and released, and `CHANGELOG.md` on master already documents the in-progress 10.1.0 section this release will ship.

## Verification

- Full test suite passes (639 tests).
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)