### PR TITLE
Fix grammatical error in project maintenance note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ProofPoint Email Fraud Defense, and Valimail.
 
 ## Sponsors
 
-This is a project is maintained by one developer.
+This project is maintained by one developer.
 Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if you or your organization benefit from it.
 
 ## Features

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -10,7 +10,7 @@ Package](https://img.shields.io/pypi/v/parsedmarc.svg)](https://pypi.org/project
 
 :::{note}
 
-This is a project is maintained by one developer.
+This project is maintained by one developer.
 Please consider [sponsoring my work](https://github.com/sponsors/seanthegeek) if you or your organization benefit from it.
 :::
 


### PR DESCRIPTION
## Summary

- Fix a grammatical error in the single-maintainer sponsorship note: "This **is a** project is maintained by one developer" → "This project is maintained by one developer".
- The note appears in two places; both are fixed: `README.md` and `docs/source/index.md`.

## Why

- The sentence opens the Sponsors section of the README and the docs landing page — a prominent spot for a typo, and it's the line asking readers to sponsor the project.

## Testing

- `grep -rn "This is a project"` over the repo — no occurrences remain.
- Docs build not run locally (no Python env tooling on this machine); the edit is plain text inside the existing `:::{note}` directive, and the `lint-docs-build` CI job runs `make html`.

## Backward Compatibility / Risk

- None — documentation text only.

## Related Issue

- None (typo noticed while reading the docs).

## Checklist

- [x] Tests added or updated if behavior changed — N/A, no behavior change (docs-only)
- [x] Docs updated if config or user-facing behavior changed — this change is itself docs-only
