### PR TITLE
Give a clear error when mail-parser's strict= kwarg is unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Migrated the Elasticsearch output to the elasticsearch-py 8.x client** ([#806](https://github.com/domainaware/parsedmarc/issues/806)): the `elasticsearch-dsl` dependency is gone (the DSL is bundled in the client as `elasticsearch.dsl` since 8.18), and the new pin `elasticsearch>=8.18,<9` no longer forces `urllib3<2` — installs can now resolve urllib3 2.x. **Elasticsearch 7.x servers are no longer supported** (the 8.x client supports ES 8.x and 9.x servers). **OpenSearch users who were pointing the `[elasticsearch]` config section at an OpenSearch cluster must switch to the `[opensearch]` section** (the 8.x client's product check rejects OpenSearch). Also removed the dead ES 6-era `published_policy.fo` index migration in `migrate_indexes()` (unreachable via the 8.x client; the function remains as a no-op for API compatibility).
 
+### Bug fixes
+
+- **An outdated Python patch release no longer masquerades as an invalid report** ([#808](https://github.com/domainaware/parsedmarc/issues/808)). The third-party `mail-parser` package unconditionally calls `email.utils.getaddresses([...], strict=True)`, a keyword only supported on Python patch releases `>=3.10.15`, `>=3.11.10`, `>=3.12.6` (the CVE-2023-27043 hardening). On an older patch release within an otherwise-supported minor version, `mailparser.parse_from_string()` raised `TypeError: getaddresses() got an unexpected keyword argument 'strict'`, which parsedmarc's existing broad exception handlers silently turned into a generic "invalid report" error — giving no indication that the report itself was fine and the real cause was an outdated Python patch release. The `TypeError` is now caught right at the `mailparser.parse_from_string()` call sites and re-raised as an `EmailParserError` naming the Python versions required to fix it, guarded on `email.utils.supports_strict_parsing` so unrelated `TypeError`s are untouched and still propagate as before. The real fix belongs upstream in `mail-parser` ([SpamScope/mail-parser#162](https://github.com/SpamScope/mail-parser/pull/162)); this only makes the failure mode legible until that lands.
+
 ## 10.2.2
 
 ### Changes

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -30,7 +30,6 @@ from typing import (
 )
 
 import lxml.etree as etree
-import mailparser
 import xmltodict
 from expiringdict import ExpiringDict
 from mailsuite.smtp import send_email
@@ -57,6 +56,7 @@ from parsedmarc.types import (
     SMTPTLSReport,
 )
 from parsedmarc.utils import (
+    _mailparser_parse_from_string,
     convert_outlook_msg,
     get_base_domain,
     get_ip_address_info,
@@ -1742,7 +1742,7 @@ def parse_report_email(
         else:
             input_str = input_data
 
-        msg = mailparser.parse_from_string(input_str)
+        msg = _mailparser_parse_from_string(input_str)
         msg_headers = json.loads(msg.headers_json)
         if "Date" in msg_headers:
             msg_date = human_timestamp_to_datetime(msg_headers["Date"])

--- a/parsedmarc/utils.py
+++ b/parsedmarc/utils.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 import base64
 import csv
+import email.utils
 import hashlib
 import io
 import json
 import logging
 import mailbox
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -1123,6 +1125,34 @@ def convert_outlook_msg(msg_bytes: bytes) -> bytes:
     return rfc822
 
 
+def _mailparser_parse_from_string(data: str):
+    """Wraps mailparser.parse_from_string(), turning the TypeError caused
+    by mail-parser unconditionally passing strict=True to
+    email.utils.getaddresses() into an actionable EmailParserError on
+    Python patch releases that don't support it yet (see
+    email.utils.supports_strict_parsing, added for CVE-2023-27043).
+    This is a mail-parser bug, not a parsedmarc one — see #808 and
+    SpamScope/mail-parser#162 — and this helper can be removed once
+    mail-parser guards the call itself."""
+    try:
+        return mailparser.parse_from_string(data)
+    except TypeError as error:
+        if "strict" in str(error) and not getattr(
+            email.utils, "supports_strict_parsing", False
+        ):
+            raise EmailParserError(
+                "Cannot parse this email because the mail-parser package "
+                "requires email.utils.getaddresses(strict=), which Python "
+                f"{platform.python_version()} does not support. Upgrade "
+                "Python to a patch release that includes the CVE-2023-27043 "
+                "email parsing fixes (>=3.10.15, >=3.11.10, or >=3.12.6). "
+                "This is an incompatibility between the mail-parser "
+                "dependency and an outdated Python patch release, not an "
+                f"invalid report or a parsedmarc bug. Original error: {error}"
+            ) from error
+        raise
+
+
 def parse_email(data: bytes | str, *, strip_attachment_payloads: bool = False) -> dict:
     """
     A simplified email parser
@@ -1139,7 +1169,7 @@ def parse_email(data: bytes | str, *, strip_attachment_payloads: bool = False) -
         if is_outlook_msg(data):
             data = convert_outlook_msg(data)
         data = data.decode("utf-8", errors="replace")
-    parsed_email = mailparser.parse_from_string(data)
+    parsed_email = _mailparser_parse_from_string(data)
     headers = json.loads(parsed_email.headers_json).copy()
     parsed_email = json.loads(parsed_email.mail_json).copy()
     parsed_email["headers"] = headers

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
 from typing import BinaryIO, cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from lxml import etree  # type: ignore[import-untyped]
 
@@ -2208,6 +2208,29 @@ This is not a DMARC report."""
         with self.assertRaises(parsedmarc.ParserError) as ctx:
             parsedmarc.parse_report_email(email_str, offline=True)
         self.assertIn("not-a-real-date", str(ctx.exception))
+
+    def testStrictKwargMessageReachesParserError(self):
+        """mail-parser's getaddresses(strict=True) TypeError on an
+        unpatched Python interpreter surfaces through parse_report_email's
+        own catch-all as a ParserError naming the required Python patch
+        releases, not a confusing generic error.
+
+        See #808.
+        """
+        with (
+            patch("email.utils.supports_strict_parsing", False),
+            patch(
+                "parsedmarc.utils.mailparser.parse_from_string",
+                side_effect=TypeError(
+                    "getaddresses() got an unexpected keyword argument 'strict'"
+                ),
+            ),
+        ):
+            with self.assertRaises(parsedmarc.ParserError) as ctx:
+                parsedmarc.parse_report_email(
+                    "From: a@b.c\nSubject: x\n\nbody", offline=True
+                )
+        self.assertIn("3.12.6", str(ctx.exception))
 
     def testFailureTextReportParses(self):
         """A valid legacy text/plain failure report parses to a failure

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -949,6 +949,65 @@ Body"""
         self.assertNotIn("sha256", attachments[0])
         self.assertEqual(attachments[0]["payload"], "!!!notb64!!!")
 
+    def testStrictKwargTypeErrorGetsClearMessage(self):
+        """mail-parser's getaddresses(strict=True) TypeError on an
+        unpatched Python interpreter is re-raised as an actionable
+        EmailParserError naming the required Python patch releases,
+        instead of surfacing as a bare TypeError.
+
+        See #808: mail-parser unconditionally calls
+        email.utils.getaddresses(strict=True), a keyword only supported
+        on Python patch releases >=3.10.15, >=3.11.10, >=3.12.6 (the
+        CVE-2023-27043 hardening). email.utils.supports_strict_parsing
+        is the stdlib's own feature-detection flag for this.
+        """
+        with (
+            patch("email.utils.supports_strict_parsing", False),
+            patch(
+                "parsedmarc.utils.mailparser.parse_from_string",
+                side_effect=TypeError(
+                    "getaddresses() got an unexpected keyword argument 'strict'"
+                ),
+            ),
+        ):
+            with self.assertRaises(parsedmarc.utils.EmailParserError) as ctx:
+                parsedmarc.utils.parse_email("From: a@b.com\r\n\r\nBody\r\n")
+        message = str(ctx.exception)
+        self.assertIn("3.10.15", message)
+        self.assertIn("3.11.10", message)
+        self.assertIn("3.12.6", message)
+        self.assertIn("mail-parser", message)
+        self.assertIsInstance(ctx.exception.__cause__, TypeError)
+
+    def testUnrelatedTypeErrorNotMisclassified(self):
+        """The strict= guard only fires for the specific mail-parser
+        TypeError on an unpatched interpreter - any other TypeError, or
+        the same message on a patched interpreter, propagates unchanged.
+        """
+        with (
+            patch("email.utils.supports_strict_parsing", False),
+            patch(
+                "parsedmarc.utils.mailparser.parse_from_string",
+                side_effect=TypeError("unrelated failure"),
+            ),
+        ):
+            with self.assertRaises(TypeError) as ctx:
+                parsedmarc.utils.parse_email("From: a@b.com\r\n\r\nBody\r\n")
+        self.assertNotIsInstance(ctx.exception, parsedmarc.utils.EmailParserError)
+
+        with (
+            patch("email.utils.supports_strict_parsing", True),
+            patch(
+                "parsedmarc.utils.mailparser.parse_from_string",
+                side_effect=TypeError(
+                    "getaddresses() got an unexpected keyword argument 'strict'"
+                ),
+            ),
+        ):
+            with self.assertRaises(TypeError) as ctx:
+                parsedmarc.utils.parse_email("From: a@b.com\r\n\r\nBody\r\n")
+        self.assertNotIsInstance(ctx.exception, parsedmarc.utils.EmailParserError)
+
 
 class TestUtilsOutlookMsg(unittest.TestCase):
     """Tests for Outlook MSG detection and conversion"""


### PR DESCRIPTION
## Summary

`mailparser.parse_from_string()` unconditionally passes `strict=True` to `email.utils.getaddresses()`, which only exists on Python patch releases `>=3.10.15`, `>=3.11.10`, `>=3.12.6` (the CVE-2023-27043 hardening). On an older patch release within an otherwise-supported minor version, this raises `TypeError: getaddresses() got an unexpected keyword argument 'strict'` -- and parsedmarc's existing broad exception handlers silently turn that into a generic "invalid report" error, giving no indication the report itself was fine and the real cause was an outdated Python patch release. Reported in #808.

## Fix

`_mailparser_parse_from_string()` now catches this specific `TypeError`, gated on `email.utils.supports_strict_parsing` so unrelated `TypeError`s still pass through untouched, and re-raises as `EmailParserError` naming the Python versions required to fix it. The existing catch-alls in `parse_report_email()` and `parse_failure_report()` already embed the inner exception's message into their own, so the clearer text reaches operators with no other control-flow changes -- same exception types, same logging, same Invalid-folder mailbox behavior as today.

The real fix belongs upstream in `mail-parser` itself (it should feature-detect `supports_strict_parsing` before passing `strict=True`): filed as [SpamScope/mail-parser#162](https://github.com/SpamScope/mail-parser/pull/162), open at the time of this PR. This change is a workaround for parsedmarc users in the meantime, not a substitute for that fix.

## Test plan

- [x] New tests in `tests/test_utils.py` (`testStrictKwargTypeErrorGetsClearMessage`, `testUnrelatedTypeErrorNotMisclassified`) verifying the clear-message path and that unrelated `TypeError`s aren't misclassified.
- [x] New test in `tests/test_init.py` (`testStrictKwargMessageReachesParserError`) proving the message survives `parse_report_email()`'s catch-all end-to-end, not just the helper in isolation.
- [x] `pytest --cov tests/` — 721 passed.
- [x] `ruff check .` / `ruff format --check .` — clean.
- [x] `pyright` — 0 errors, 0 warnings.

Fixes #808.
