### PR TITLE
Release 10.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 10.3.0
 
 ### New features
 

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.2.4"
+__version__ = "10.3.0"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 


### PR DESCRIPTION
Bumps the version to 10.3.0 and dates the changelog section.

Highlights since 10.2.4:

**New features**
- Per-domain DMARC compliance percentage on the aggregate dashboards of every provider (#112)
- Directory paths accepted as `file_path` CLI arguments, with a new `-r`/`--recursive` flag (#397)

**Bug fixes**
- DKIM/SPF and SMTP TLS detail-table cross-products fixed across the Kibana/OpenSearch Dashboards, Grafana, and Splunk dashboards, with automatic backfill of older documents (#169)
- Over-time charts no longer double-count on the multi-valued `date_range` field
- Aggregate result words normalized to lowercase (#288)
- Results email skipped when no reports were parsed (#200)
- mbox-only runs get a real progress bar instead of a stuck `0it` bar, and `n_procs` scope is documented (#147)
- Grafana source-country map markers scale with volume; dead `_SPFResult.results` field corrected

**Changes**
- Dev tooling upgraded to ruff 0.16.0 / pyright 1.1.411; codebase converted to f-strings (#847)

🤖 Generated with [Claude Code](https://claude.com/claude-code)