### PR TITLE
Refresh the Claude Code permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,14 @@
       "Bash(ls tests*)",
       "Bash(GITHUB_ACTIONS=true python -m pytest --cov tests.py -x)",
       "Bash(GITHUB_ACTIONS=true python -m pytest tests.py -x -v)",
-      "Bash(python -m pytest tests.py --no-header -q)"
+      "Bash(python -m pytest tests.py --no-header -q)",
+      "Bash(pytest *)",
+      "Bash(.venv/bin/pytest *)",
+      "Bash(GITHUB_ACTIONS=true pytest *)",
+      "Bash(GITHUB_ACTIONS=true .venv/bin/pytest *)",
+      "Bash(.venv/bin/pyright *)",
+      "Bash(.venv/bin/python -m ruff check .)",
+      "Bash(.venv/bin/python -m ruff format --check .)"
     ],
     "additionalDirectories": [
       "/tmp"


### PR DESCRIPTION
The existing pytest allow rules in `.claude/settings.json` all reference the retired `tests.py` monolith and never match anymore, so every test run prompts for approval. This adds the command forms actually in use — `pytest`/`.venv/bin/pytest` with and without the `GITHUB_ACTIONS=true` offline prefix, the venv-path `pyright` that built-in auto-allow doesn't recognize, and the two exact pinned `python -m ruff` check forms.

Derived from a 50-session transcript scan; read-only or test-scoped commands only (interpreters, package runners, and mutating git/network commands deliberately excluded). Existing entries kept untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)