### PR TITLE
Prune obsolete permission allowlist entries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,14 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(git fetch:*)",
-      "Bash(python -c \"import py_compile; py_compile.compile\\(''parsedmarc/cli.py'', doraise=True\\)\")",
       "Bash(ruff check:*)",
       "Bash(ruff format:*)",
-      "Bash(GITHUB_ACTIONS=true pytest --cov tests.py)",
       "Bash(ls tests*)",
-      "Bash(GITHUB_ACTIONS=true python -m pytest --cov tests.py -x)",
-      "Bash(GITHUB_ACTIONS=true python -m pytest tests.py -x -v)",
-      "Bash(python -m pytest tests.py --no-header -q)",
       "Bash(pytest *)",
       "Bash(.venv/bin/pytest *)",
       "Bash(GITHUB_ACTIONS=true pytest *)",


### PR DESCRIPTION
Follow-up to Copilot's review feedback on #861 (left after merge).

Removes five dead exact-match rules from `.claude/settings.json`:

- The four `pytest` rules referencing the retired `tests.py` monolith — tests now live under `tests/`, so these entries can never match.
- The one-off `py_compile` rule, an equally obsolete exact-match relic.

The `pytest *` / `GITHUB_ACTIONS=true pytest *` and ruff prefix rules added in #861 cover all current invocation forms.

Copilot's second comment on #861 (broad patterns auto-approving chained commands) needs no action: Claude Code's permission matching is shell-operator-aware and splits compound commands, so a prefix rule never extends across `&&`/`;`/`|`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)