### PR TITLE
Clear shared IP cache in parallel test setUp for isolation

### DIFF
--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -47,7 +47,8 @@ class _CountingIterable:
 
 
 class _ParallelTestCase(unittest.TestCase):
-    """Common env setup shared by parallel.py tests: offline mode, no DNS."""
+    """Common env setup shared by parallel.py tests: offline mode, no DNS,
+    and a cold IP address cache."""
 
     def setUp(self):
         self._env_patcher = patch.dict(
@@ -55,6 +56,13 @@ class _ParallelTestCase(unittest.TestCase):
         )
         self._env_patcher.start()
         self.addCleanup(self._env_patcher.stop)
+        # Earlier test modules (e.g. tests/test_init.py) may run with DNS
+        # enabled locally and warm the shared module-level
+        # parsedmarc.IP_ADDRESS_CACHE. get_ip_address_info consults the
+        # cache before the offline check, so a warm cache would leak
+        # DNS-enriched entries into offline parses run in this process
+        # while spawned workers start cold, breaking parity.
+        parsedmarc.IP_ADDRESS_CACHE.clear()
 
 
 class TestParallelMapParseReportFile(_ParallelTestCase):


### PR DESCRIPTION
## Summary

`tests/test_parallel.py::TestParallelMapParseReportFile::test_results_match_sequential_parsing_in_order` fails when the full suite runs locally, but passes on CI.

**Cause:** `parsedmarc.IP_ADDRESS_CACHE` is a module-level singleton shared across the pytest process. Locally (`GITHUB_ACTIONS` unset), `tests/test_init.py` runs first (alphabetical collection) with real DNS lookups and warms that cache. `get_ip_address_info` consults the cache **before** honoring `offline` (parsedmarc/utils.py), so the parity test's sequential baseline — `parse_report_file(path, offline=True)` in the parent process — returned cached DNS-enriched entries (e.g. `reverse_dns='smtp7.cardinal.com'` for `199.230.200.36`), while the spawned workers started with a cold cache and correctly returned `None`. On CI everything runs offline from the start, so the mismatch never appears.

**Fix:** clear the shared cache in `_ParallelTestCase.setUp` so the sequential baselines and the workers both start cold. Test-only change — the cache-before-offline ordering in `utils.py` is intentional and benign in production (a cache hit makes no network queries; a one-shot CLI run can never hold online-derived entries while offline).

## Verification

- Reproduced pre-fix by seeding `IP_ADDRESS_CACHE` with a DNS-enriched entry for a sample IP in the parent process, then running the parity test in-process: exact `AssertionError` from the local suite run. Same seed against the fixed test: passes.
- A fresh-context review independently re-verified the failure mechanism against `utils.py`/`config.py`, confirmed the non-`_ParallelTestCase` classes in the file have no IP-enrichment exposure, and confirmed no reverse-direction state leak (later modules use private caches or `cache=None`).
- `pytest tests/test_parallel.py` — 10 passed; `ruff check .`, `ruff format --check .`, and `pyright` all clean.

No CHANGELOG entry: test-infrastructure fix only, no library behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)