### PR TITLE
10.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 10.4.2
 
 ### Changes
 

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.4.1"
+__version__ = "10.4.2"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 


### PR DESCRIPTION
Release PR for 10.4.2.

- Bumps `__version__` in `parsedmarc/constants.py` from 10.4.1 to 10.4.2
- Renames the `## Unreleased` heading in `CHANGELOG.md` to `## 10.4.2`

The changelog section covers the two changes already on master:

- The `mailsuite` floor bump to `>=2.3.0` — the latest mailsuite release, published to PyPI today (raises the transitive `mail-parser` floor to `>=4.6.2` and `cryptography` to `>=50.0.0`)
- The automated release and docs deployment pipeline (#874)

No tag will be pushed until this PR merges and the maintainer gives the go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)