### PR TITLE
10.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 10.4.3
+
+### Changes
+
+- **Bumped the `mailsuite` floor to `>=2.3.1`**, picking up the fix for `mailsuite.utils.parse_email()` raising `TypeError` instead of `ValueError("Not an email")` on unparseable (non-email) input under mail-parser 4.6.2 and later ([seanthegeek/mailsuite#61](https://github.com/seanthegeek/mailsuite/issues/61)) — a potential crash for anything reading non-email files through that API. mail-parser 4.6.2 changed its contract for unparseable input (it now returns a header-less parse result instead of the input string), so mailsuite's not-an-email detection never fired and parsing crashed on the missing `From` header. Every install of the previous parsedmarc release shipped the affected combination, because mailsuite 2.3.0 — the floor since parsedmarc 10.4.2 — itself requires mail-parser `>=4.6.2`. parsedmarc's own CLI and library report parsing never call that mailsuite API; they use parsedmarc's separate `parse_email` implementation, which rejects non-email input gracefully and behaves identically under both mailsuite versions, so this bump removes the affected combination from installs rather than fixing a parsedmarc crash.
+
 ## 10.4.2
 
 ### Changes

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.4.2"
+__version__ = "10.4.3"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "httpx>=0.25",
     "kafka-python>=2.3.2",
     "lxml>=4.4.0",
-    "mailsuite[gmail,msgraph]>=2.3.0",
+    "mailsuite[gmail,msgraph]>=2.3.1",
     "maxminddb>=2.0.0",
     # Imported directly in cli.py for Graph error handling; otherwise
     # only a transitive dep of mailsuite[msgraph] -> msgraph-sdk.


### PR DESCRIPTION
## Summary

Patch release bumping the `mailsuite` floor from `>=2.3.0` to `>=2.3.1`.

mailsuite 2.3.1 ([release notes](https://github.com/seanthegeek/mailsuite/releases/tag/2.3.1), [seanthegeek/mailsuite#61](https://github.com/seanthegeek/mailsuite/issues/61)) fixes `mailsuite.utils.parse_email()` raising `TypeError: argument of type 'NoneType' is not a container or iterable` instead of `ValueError("Not an email")` on unparseable (non-email) input under mail-parser 4.6.2. mail-parser 4.6.2 changed its contract for unparseable input — it returns a header-less parse result instead of the input string — so mailsuite's not-an-email detection never fired and parsing crashed on the missing `From` header. parsedmarc has required mail-parser `>=4.6.2` (via `mailsuite>=2.3.0`) since 10.4.2, so every install of the previous release carries the susceptible combination.

## Verification notes

Checked parsedmarc's own exposure empirically before writing the changelog entry, in a fresh venv with the working tree plus mailsuite 2.3.0 / mail-parser 4.6.2, then again with mailsuite 2.3.1:

- parsedmarc's CLI/library report parsing never calls mailsuite's `parse_email` at runtime: `parse_report_email()` and the failure-report sample parser use parsedmarc's own `parsedmarc.utils.parse_email`, and the mailsuite 2.3.x mailbox backends fetch with `parse=False`.
- Feeding the CLI binary garbage, an email-shaped non-report, a message with an unparseable `From` header, and a failure report with a garbage `message/rfc822` sample produced identical, non-crashing behavior under both mailsuite versions (each input logged and skipped, exit 0).

So for parsedmarc itself this is a dependency-hygiene bump that removes the susceptible combination from installs; the direct crash fix benefits anything else in the same environment (or downstream code) calling `mailsuite.utils.parse_email()` on non-email files.

Release mechanics per `AGENTS.md`: version bumped to 10.4.3 in `parsedmarc/constants.py` together with the new `CHANGELOG.md` section. `ruff check`, `ruff format --check`, and `pyright` all pass from the repo root. No tag will be pushed until you say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)