### PR TITLE
CI: replace deprecated codecov/test-results-action with codecov-action@v5

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -95,11 +95,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
     - name: Upload test results to Codecov
-       # Feeds Codecov Test Analytics (flaky-test detection, per-test
-       # history). Runs even on test failure so failed cases still get
+      # Feeds Codecov Test Analytics (flaky-test detection, per-test
+      # history). Runs even on test failure so failed cases still get
       # reported. Uses the same CODECOV_TOKEN as the coverage upload.
+      # codecov/test-results-action is deprecated in favor of running
+      # codecov-action a second time with report_type: test_results.
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        report_type: test_results
         files: ./junit.xml


### PR DESCRIPTION
## Summary

The Python tests workflow emits two warnings on every run, both traced to `codecov/test-results-action@v1`:

1. **Node.js 20 deprecation** — the action's internally pinned `actions/github-script` targets Node 20, which GitHub Actions runners are force-upgrading to Node 24 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).
2. **Action deprecation** — Codecov deprecated `test-results-action` in favor of running `codecov-action@v5` with `report_type: test_results`.

This swaps the test-results upload step to `codecov/codecov-action@v5` with `report_type: test_results`, per the [codecov-action README](https://github.com/codecov/codecov-action) ("The type of file to upload, coverage by default. Possible values are 'test_results', 'coverage'."). Everything else about the step is unchanged: same `CODECOV_TOKEN`, same `./junit.xml` file, same `if: ${{ !cancelled() }}` so failed test runs still feed Test Analytics.

Also normalizes the mis-indented comment lines on that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)