### PR TITLE
CI: update all GitHub Actions to their latest major versions

### DIFF
--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -53,7 +53,7 @@ jobs:
           --health-retries 30
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Wait for Kibana to report ready
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,17 +40,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -68,14 +68,14 @@ jobs:
         # workflow_dispatch runs build for validation only and must never
         # touch the registry, so they skip the login entirely.
         if: github.event_name == 'release' || inputs.push_image == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,10 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -44,13 +44,17 @@ jobs:
         run: make -C docs html
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build/html
+          # v4 stopped including dotfiles by default; keep the artifact
+          # identical to what v3 shipped (sphinx.ext.githubpages emits a
+          # .nojekyll file into the build output).
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.13"
     - name: Install Python dependencies
@@ -65,9 +65,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install system dependencies
@@ -90,7 +90,7 @@ jobs:
       run: |
         hatch build
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -101,7 +101,7 @@ jobs:
       # codecov/test-results-action is deprecated in favor of running
       # codecov-action a second time with report_type: test_results.
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         report_type: test_results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -47,7 +47,7 @@ jobs:
           hatch build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -63,7 +63,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -78,10 +78,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/update-ipinfo-mmdb.yml
+++ b/.github/workflows/update-ipinfo-mmdb.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -61,7 +61,7 @@ jobs:
           mv "$tmp" "$dest"
 
       - name: Open pull request if changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: update IPinfo Lite MMDB"
           title: "chore: update IPinfo Lite MMDB"


### PR DESCRIPTION
## Summary

Brings every action across the six workflows up to its current major version. All actions are now on the Node 24 runtime, which clears the remaining Node 20 deprecation warnings.

| Action | Before | After |
|---|---|---|
| actions/checkout | v5 | v7 |
| actions/setup-python | v6 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/configure-pages | v5 | v6 |
| actions/deploy-pages | v4 | v5 |
| codecov/codecov-action | v5 | v7 |
| docker/build-push-action | v6 | v7 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/setup-qemu-action | v3 | v4 |
| peter-evans/create-pull-request | v7 | v8 |

`pypa/gh-action-pypi-publish` stays on `release/v1` — that's a moving branch ref already tracking the latest v1.x (currently v1.14.2).

## Breaking changes checked against our usage

I read the release notes for every intermediate major. Most are Node 24 / ESM-only bumps; the ones with real behavioral changes:

- **download-artifact v5** changed the extraction path for single-artifact downloads **by ID** — release.yml downloads by `name: dist`, unaffected. **v8** defaults `digest-mismatch` to `error` (a safety improvement; our artifact is uploaded in the same run) and skips unzipping only for `archive: false` direct uploads, which we don't use.
- **upload-pages-artifact v4** stopped including dotfiles by default. Our Sphinx build emits `.nojekyll` (via `sphinx.ext.githubpages`) and `.buildinfo`, so the step now passes `include-hidden-files: true` (input added in v5) to keep the Pages artifact byte-identical to what v3 shipped.
- **setup-python v7** removed the `pip-install` input — not used here.
- **checkout v7** blocks checking out fork PRs in `pull_request_target` / `workflow_run` events — neither trigger is used in this repo.
- **metadata-action v6** changed `#` handling inside list input values (inline `#` now preserved) — our only `#` in a list input is a full-line comment, still supported.
- **setup-buildx-action v4** removed deprecated inputs/outputs — we pass none.
- **codecov-action v6/v7** — no input changes (v7 is a GPG signing-key account rotation), so the `report_type: test_results` upload from #877 carries over unchanged.

## Test plan

- Push/PR CI exercises checkout, setup-python, and both codecov-action uploads directly on this PR.
- The Docker build workflow runs on merge to master (build-only validation path).
- Pages/docs, release-artifact, and create-pull-request steps run in maintainer-triggered workflows (Docs dispatch, next release tag, weekly MMDB cron); their changed inputs were verified against the release notes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)