### PR TITLE
chore: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -53,7 +53,7 @@ jobs:
           --health-retries 30
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Wait for Kibana to report ready
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,17 +40,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -68,14 +68,14 @@ jobs:
         # workflow_dispatch runs build for validation only and must never
         # touch the registry, so they skip the login entirely.
         if: github.event_name == 'release' || inputs.push_image == true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,10 +27,10 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -44,13 +44,13 @@ jobs:
         run: make -C docs html
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/build/html
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.13"
     - name: Install Python dependencies
@@ -65,9 +65,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install system dependencies
@@ -90,7 +90,7 @@ jobs:
       run: |
         hatch build
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -101,7 +101,7 @@ jobs:
       # codecov/test-results-action is deprecated in favor of running
       # codecov-action a second time with report_type: test_results.
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         report_type: test_results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -47,7 +47,7 @@ jobs:
           hatch build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -63,7 +63,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -78,10 +78,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/update-ipinfo-mmdb.yml
+++ b/.github/workflows/update-ipinfo-mmdb.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
@@ -61,7 +61,7 @@ jobs:
           mv "$tmp" "$dest"
 
       - name: Open pull request if changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: update IPinfo Lite MMDB"
           title: "chore: update IPinfo Lite MMDB"


### PR DESCRIPTION
Updates every third-party action in `.github/workflows/` to its latest major version:

| Action | From | To |
|---|---|---|
| actions/checkout | v5 | v7 |
| actions/setup-python | v6 | v7 |
| actions/configure-pages | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/login-action | v3 | v4 |
| docker/build-push-action | v6 | v7 |
| codecov/codecov-action | v5 | v7 |
| peter-evans/create-pull-request | v7 | v8 |

**Unchanged (already current):** `pypa/gh-action-pypi-publish@release/v1` is a moving branch and v1 is still the latest major (v1.14.2).

I read the release notes for each major-version boundary before bumping. Nearly all of them are Node 24 runtime + ESM migrations, which only affect self-hosted runners older than Actions Runner 2.327.1 — all of these workflows run on `ubuntu-latest`. The remaining behavioral changes and why they don't bite here:

- **actions/setup-python v7** removed the `pip-install` input — not used here.
- **actions/checkout v7** blocks checking out fork PRs on `pull_request_target`/`workflow_run` — no workflow uses those events.
- **actions/upload-pages-artifact v4+** excludes hidden files by default. The Sphinx build output contains only `.buildinfo` and `.nojekyll` as dotfiles; neither matters for Actions-based Pages deployment (`.nojekyll` only suppresses Jekyll on legacy branch-based deploys, and `.buildinfo` is a Sphinx incremental-build cache, not served content).
- **actions/download-artifact v8** now fails on digest mismatch instead of warning (security improvement), and skips unzipping non-zipped direct uploads — `release.yml` uploads a normal zipped `dist` artifact with plain `name`/`path` inputs, so both are no-ops here.
- **codecov/codecov-action v7**: verified the `report_type` input used by the test-results upload step still exists in v7's `action.yml` (it does, line 121).
- **docker/setup-buildx-action v4** removed deprecated inputs/outputs — none are used here (the step passes no inputs).
- **docker/metadata-action v6** changed `#`-handling in list inputs — the `tags`/`images` lists here contain no `#`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)