### PR TITLE
10.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 10.5.0
 
 ### New features
 

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.4.3"
+__version__ = "10.5.0"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 


### PR DESCRIPTION
Release PR for **10.5.0**: bumps `parsedmarc/constants.py` to 10.5.0 and renames `## Unreleased` to `## 10.5.0` in the changelog — the two edits that land together only in a release PR.

## In this release (since 10.4.3)

### New features
- DNS over HTTPS and DNS over TLS support via the existing `nameservers` option (#880, #886)

### Bug fixes
- Failure report MIME parts decoded per their `Content-Transfer-Encoding`, CRLF handling, and clean rejection of failure reports with no usable domain (#882, #885)

### Internal / unlisted
- `parsedmarc.mail` imports the optional Gmail/Microsoft Graph connections lazily (#884 — groundwork for #883, deliberately unlisted in the changelog)
- CI and MMDB maintenance (#877, #879, #881)

## Pre-release verification (all green)
- Full suite twice: 957 passed with `GITHUB_ACTIONS=true` + coverage, and 957 passed with real DNS enrichment (no skip)
- `ruff check` / `ruff format --check` and `pyright` (0 errors/warnings) repo-wide
- `docs make html` clean; `hatch build` produces sdist + wheel
- CLI parse of all bundled aggregate/failure/SMTP-TLS samples clean; live DoH/DoT queries verified against Cloudflare and Quad9

After merge: push the annotated `10.5.0` tag, which runs the full CI suite and then publishes to PyPI, creates the GitHub Release, pushes the Docker image, and deploys docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)