### PR TITLE
11.0.0 release: bump version and finalize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 11.0.0
 
 ### Changes
 

--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "10.5.0"
+__version__ = "11.0.0"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 


### PR DESCRIPTION
Release PR for **11.0.0**: bumps `__version__` in `parsedmarc/constants.py` from 10.5.0 to 11.0.0 and renames the `## Unreleased` CHANGELOG heading to `## 11.0.0` — the two edits that land together only in a release PR.

The major bump is warranted by the breaking change in this cycle: the output and mailbox integrations moved behind optional extras (#883/#888), so `pip install parsedmarc` no longer includes every SDK and 10.x CLI users must switch to `parsedmarc[all]`. The section also includes the per-report Kafka sends for failure/SMTP TLS reports (consumer-visible), `--dns-timeout`, the `number_of_replicas` and unmatched-CLI-path fixes, and the Podman-capable dashboard bootstrap (#891).

Pre-flight checks done: 10.5.0 (the current `constants.py` version) is tagged on origin, so no version gap; `ruff check`/`format` pass.

After merge (maintainer action, not done here): push the annotated tag `11.0.0` on the merge commit to trigger `release.yml` (CI → PyPI → GitHub Release → Docker image → docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)