### PR TITLE
Close the file handle parse_report_file() opens when reading it raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **The prebuilt Docker image (`ghcr.io/domainaware/parsedmarc`) is roughly 40% smaller to pull** ([#893](https://github.com/domainaware/parsedmarc/pull/893)). The runtime stage copied the built wheel out of the build stage and deleted it again at the end of the next `RUN`, but a `RUN` can only write a whiteout over a layer an earlier instruction already committed: the wheel shipped in every published image and every `docker pull` downloaded it (10,713,473 bytes of the 11.0.0 image, on both architectures). The wheel is now bind-mounted from the build stage instead, and a bind mount is never committed to a layer. `pip install` also runs with `--no-cache-dir`, which drops a further ~99 MB of pip's download cache that the image had been carrying in the same layer as `site-packages`. Measured on linux/amd64: 272,138,724 compressed bytes across six layers before, 163,757,439 across five after.
 
+### Bug fixes
+
+- **`parse_report_file()` now closes the file handle it opens itself for a path input if reading it raises.** When `input_` is a path, the function opened the file, read it, and closed it with no exception handling in between; an exception raised by `read()` (e.g. an `OSError` from the underlying storage) skipped the close, so the descriptor was left to be released only when Python's garbage collector eventually finalized the object — CPython's `io.IOBase.__del__` closes an unclosed file on finalization (<https://docs.python.org/3/library/io.html>) — rather than being closed deterministically. This is the pattern CodeQL's `py/file-not-closed` query flags, found in a local code-quality scan. The path branch now opens the file with a `with` block, so the handle is closed on both the success and exception paths. A file-like object or bytes buffer supplied by the caller is unaffected: as before, it is closed only after a successful read, and left open if `read()` raises.
+
 ## 11.0.1
 
 ### Security

--- a/parsedmarc/__init__.py
+++ b/parsedmarc/__init__.py
@@ -2319,14 +2319,20 @@ def parse_report_file(
     if isinstance(input_, (str, os.PathLike)):
         file_path = os.fspath(input_)
         logger.debug(f"Parsing {file_path}")
-        file_object = open(file_path, "rb")
-    elif isinstance(input_, (bytes, bytearray, memoryview)):
-        file_object = BytesIO(bytes(input_))
+        # A path is a handle we opened ourselves, so it must be closed on
+        # both the success and exception paths.
+        with open(file_path, "rb") as file_object:
+            content = file_object.read()
     else:
-        file_object = input_
-
-    content = file_object.read()
-    file_object.close()
+        if isinstance(input_, (bytes, bytearray, memoryview)):
+            file_object = BytesIO(bytes(input_))
+        else:
+            # A caller-supplied file-like object is only closed on success,
+            # matching long-standing behavior; it is left open if read()
+            # raises.
+            file_object = input_
+        content = file_object.read()
+        file_object.close()
     if content.startswith(MAGIC_ZIP) or content.startswith(MAGIC_GZIP):
         content = extract_report(content)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2754,6 +2754,83 @@ class TestParseReportFile(unittest.TestCase):
         finally:
             logger.setLevel(previous)
 
+    def testParseReportFileClosesHandleOnReadError(self):
+        """A file opened internally by parse_report_file is closed even
+        when reading it raises (the pattern CodeQL's py/file-not-closed
+        query flags, found in a local code-quality scan).
+
+        parse_report_file's path branch does `open(file_path, "rb")` and
+        then `.read()`; before the fix, `.close()` sat on the line after
+        `.read()` with no try/finally (and no `with`), so a read()-time
+        exception skipped close() and leaked the descriptor. Patch
+        builtins.open (the SDK boundary) to return a handle whose read()
+        raises, and assert the handle was still closed. The fake handle
+        implements the context-manager protocol itself (mirroring a real
+        file object's __exit__ calling close()), rather than relying on
+        MagicMock's default __enter__/__exit__, which would return a
+        different mock object from __enter__ and never call close().
+        """
+
+        class _RaisingHandle:
+            def __init__(self):
+                self.closed = False
+
+            def read(self):
+                raise OSError("boom")
+
+            def close(self):
+                self.closed = True
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.close()
+                return False
+
+        fake_handle = _RaisingHandle()
+
+        with patch("builtins.open", return_value=fake_handle) as mock_open:
+            with self.assertRaises(OSError):
+                parsedmarc.parse_report_file("some/path.xml", offline=True)
+
+        mock_open.assert_called_once_with("some/path.xml", "rb")
+        self.assertTrue(fake_handle.closed)
+
+    def testParseReportFileLeavesCallerHandleOpenOnReadError(self):
+        """A caller-supplied file-like object is left open (not closed)
+        when reading it raises, preserving parse_report_file's
+        long-standing contract for handles it did not open itself.
+
+        Only a path input (opened internally by parse_report_file) is
+        closed on the exception path; a handle the caller passed in is
+        closed on success only, exactly as before the fix for the
+        internally-opened-path leak.
+
+        A plain class is used instead of MagicMock because MagicMock
+        auto-implements ``__fspath__`` (supported since Python 3.8's
+        unittest.mock), which would make ``isinstance(fake, os.PathLike)``
+        true and route the object through the path branch instead of the
+        caller-supplied-object branch this test targets.
+        """
+
+        class _RaisingCallerHandle:
+            def __init__(self):
+                self.close_called = False
+
+            def read(self):
+                raise OSError("boom")
+
+            def close(self):
+                self.close_called = True
+
+        fake_handle = _RaisingCallerHandle()
+
+        with self.assertRaises(OSError):
+            parsedmarc.parse_report_file(cast(BinaryIO, fake_handle), offline=True)
+
+        self.assertFalse(fake_handle.close_called)
+
 
 class TestParseReportEmail(unittest.TestCase):
     """Tests for parse_report_email edge cases"""
@@ -3699,7 +3776,11 @@ class TestGetDmarcReportsFromMailboxMaildir(unittest.TestCase):
         self._inbox = mailbox.Maildir(self._maildir, create=True)
 
     def _deliver(self, source):
-        raw = open(source, "rb").read() if isinstance(source, str) else source
+        if isinstance(source, str):
+            with open(source, "rb") as f:
+                raw = f.read()
+        else:
+            raw = source
         self._inbox.add(mailbox.MaildirMessage(raw))
         self._inbox.flush()
 


### PR DESCRIPTION
Fixes a file-descriptor leak in `parse_report_file()`. Found by a local CodeQL `python-code-quality.qls` scan (`py/file-not-closed`) — the repo's CodeQL default setup does not run the code-quality suite, so it never appeared as an alert.

## The bug

When `input_` is a path, the function opened the file, read it, and closed it with nothing in between guarding the close:

```python
file_object = open(file_path, "rb")
...
content = file_object.read()
file_object.close()
```

An exception from `read()` — an `OSError` from the underlying storage, say — skipped the close. The descriptor was then released only when CPython finalized the object (`io.IOBase.__del__` closes an unclosed file, per <https://docs.python.org/3/library/io.html>), rather than deterministically. The path branch now uses `with open(...)`.

## Scope: the caller's contract is deliberately unchanged

| `input_` | success | `read()` raises |
|---|---|---|
| path (opened internally) | closed | **closed** ← the fix |
| bytes → internal `BytesIO` | closed | left open (unchanged) |
| caller-supplied file object | closed | **left open** (unchanged) |

An earlier revision of this branch wrapped all three branches in one `try/finally`, which also started closing caller-supplied handles on the exception path. That widening was caught in review and reverted: it changes the library's contract for callers, which deserves its own decision rather than riding along inside a leak fix.

**Open question for a follow-up:** the function closes a caller-supplied file object at all — on the success path, and that predates this PR. A caller who passes their own open handle arguably should get it back open. Worth deciding separately; this PR preserves whatever the status quo was on every branch.

## Tests

Two regression tests, both proven to fail against the code they guard:

- `testParseReportFileClosesHandleOnReadError` — against `origin/master`'s unfixed version: **fails** (`close()` never called).
- `testParseReportFileLeavesCallerHandleOpenOnReadError` — against the naive whole-block `try/finally`: **fails** (`close()` called on the caller's handle).

One trap worth recording: the second test needed a plain fake class rather than `MagicMock`, because `MagicMock` auto-implements `__fspath__`, making `isinstance(fake, os.PathLike)` true and silently routing the object through the path branch instead of the branch under test.

## Verification

`ruff check .`, `ruff format --check .`, `pyright` (0 errors, 0 warnings), `GITHUB_ACTIONS=true pytest tests/` (991 passed) all clean from the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
