### PR TITLE
Bump version to 11.0.2

### DIFF
--- a/parsedmarc/constants.py
+++ b/parsedmarc/constants.py
@@ -1,4 +1,4 @@
-__version__ = "11.0.1"
+__version__ = "11.0.2"
 
 USER_AGENT = f"parsedmarc/{__version__}"
 


### PR DESCRIPTION
Completes the 11.0.2 release commit (f7c94ae), which renamed the `CHANGELOG.md` heading to `## 11.0.2` but left `parsedmarc/constants.py` at `11.0.1`. `release.yml` refuses to build when the pushed tag does not match `hatch version`, so the tag has to wait for this one-line bump.

`hatch version` on this branch prints `11.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
